### PR TITLE
test: establish API contract baseline

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,15 +1,107 @@
-use actix_web::{FromRequest, HttpRequest, dev::Payload, web};
-use futures_util::future::LocalBoxFuture;
+use std::{
+    rc::Rc,
+    task::{Context, Poll},
+};
+
+use actix_web::{
+    Error, FromRequest, HttpMessage, HttpRequest, ResponseError,
+    body::{EitherBody, MessageBody},
+    dev::{Payload, Service, ServiceRequest, ServiceResponse, Transform},
+    http::header,
+    web,
+};
+use futures_util::future::{LocalBoxFuture, Ready, ready};
 
 use crate::{
     app_state::AppState, error::ApiError, models::AuthenticatedUser, services::auth_service,
 };
+
+/// 在 JSON 等 payload extractor 之前验证 API 会话，确保所有受保护端点对缺失或失效 token
+/// 均返回统一的 401，而不会因请求 body 不完整先泄露 400。
+#[derive(Clone, Copy)]
+pub struct ApiSessionAuthentication;
+
+pub struct ApiSessionAuthenticationMiddleware<S> {
+    service: Rc<S>,
+}
+
+impl<S, B> Transform<S, ServiceRequest> for ApiSessionAuthentication
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    S::Future: 'static,
+    B: MessageBody + 'static,
+{
+    type Response = ServiceResponse<EitherBody<B>>;
+    type Error = Error;
+    type InitError = ();
+    type Transform = ApiSessionAuthenticationMiddleware<S>;
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        ready(Ok(ApiSessionAuthenticationMiddleware {
+            service: Rc::new(service),
+        }))
+    }
+}
+
+impl<S, B> Service<ServiceRequest> for ApiSessionAuthenticationMiddleware<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error> + 'static,
+    S::Future: 'static,
+    B: MessageBody + 'static,
+{
+    type Response = ServiceResponse<EitherBody<B>>;
+    type Error = Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&self, context: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(context)
+    }
+
+    fn call(&self, request: ServiceRequest) -> Self::Future {
+        let service = self.service.clone();
+        Box::pin(async move {
+            if public_api_path(request.path()) {
+                return service
+                    .call(request)
+                    .await
+                    .map(ServiceResponse::map_into_left_body);
+            }
+
+            let Some(state) = request.app_data::<web::Data<AppState>>().cloned() else {
+                return Ok(request
+                    .into_response(ApiError::Internal.error_response().map_into_right_body()));
+            };
+            let token = match bearer_token_from_service_request(&request) {
+                Ok(token) => token,
+                Err(error) => {
+                    return Ok(request.into_response(error.error_response().map_into_right_body()));
+                }
+            };
+            let authenticated = match auth_service::authenticate(&state.db, &token).await {
+                Ok(authenticated) => authenticated,
+                Err(error) => {
+                    return Ok(request.into_response(error.error_response().map_into_right_body()));
+                }
+            };
+            request.extensions_mut().insert(authenticated);
+
+            service
+                .call(request)
+                .await
+                .map(ServiceResponse::map_into_left_body)
+        })
+    }
+}
 
 impl FromRequest for AuthenticatedUser {
     type Error = ApiError;
     type Future = LocalBoxFuture<'static, Result<Self, Self::Error>>;
 
     fn from_request(request: &HttpRequest, _payload: &mut Payload) -> Self::Future {
+        if let Some(authenticated) = request.extensions().get::<AuthenticatedUser>().cloned() {
+            return Box::pin(async move { Ok(authenticated) });
+        }
         let Some(state) = request.app_data::<web::Data<AppState>>().cloned() else {
             return Box::pin(async { Err(ApiError::Internal) });
         };
@@ -26,6 +118,28 @@ fn bearer_token(request: &HttpRequest) -> Result<String, ApiError> {
     let value = request
         .headers()
         .get(actix_web::http::header::AUTHORIZATION)
+        .ok_or_else(|| ApiError::Unauthorized("authentication required".to_owned()))?
+        .to_str()
+        .map_err(|_| ApiError::Unauthorized("invalid authorization header".to_owned()))?;
+    let mut parts = value.split_whitespace();
+    let scheme = parts.next().unwrap_or_default();
+    let token = parts.next().unwrap_or_default();
+    if !scheme.eq_ignore_ascii_case("bearer") || token.is_empty() || parts.next().is_some() {
+        return Err(ApiError::Unauthorized(
+            "invalid authorization header".to_owned(),
+        ));
+    }
+    Ok(token.to_owned())
+}
+
+fn public_api_path(path: &str) -> bool {
+    matches!(path, "/api/health" | "/api/auth/login")
+}
+
+fn bearer_token_from_service_request(request: &ServiceRequest) -> Result<String, ApiError> {
+    let value = request
+        .headers()
+        .get(header::AUTHORIZATION)
         .ok_or_else(|| ApiError::Unauthorized("authentication required".to_owned()))?
         .to_str()
         .map_err(|_| ApiError::Unauthorized("invalid authorization header".to_owned()))?;

--- a/src/routes/cases.rs
+++ b/src/routes/cases.rs
@@ -31,8 +31,8 @@ async fn list_cases(
 }
 
 async fn create_case(
-    state: web::Data<AppState>,
     auth: AuthenticatedUser,
+    state: web::Data<AppState>,
     request: web::Json<CreateCaseRequest>,
 ) -> Result<HttpResponse, ApiError> {
     let case = case_service::create_case(&state.db, &auth, request.into_inner()).await?;
@@ -49,8 +49,8 @@ async fn get_case(
 }
 
 async fn update_case_status(
-    state: web::Data<AppState>,
     auth: AuthenticatedUser,
+    state: web::Data<AppState>,
     case_id: web::Path<String>,
     request: web::Json<UpdateCaseStatusRequest>,
 ) -> Result<HttpResponse, ApiError> {
@@ -60,8 +60,8 @@ async fn update_case_status(
 }
 
 async fn create_clue(
-    state: web::Data<AppState>,
     auth: AuthenticatedUser,
+    state: web::Data<AppState>,
     case_id: web::Path<String>,
     request: web::Json<CreateClueRequest>,
 ) -> Result<HttpResponse, ApiError> {
@@ -70,8 +70,8 @@ async fn create_clue(
 }
 
 async fn add_case_member(
-    state: web::Data<AppState>,
     auth: AuthenticatedUser,
+    state: web::Data<AppState>,
     case_id: web::Path<String>,
     request: web::Json<AddCaseMemberRequest>,
 ) -> Result<HttpResponse, ApiError> {

--- a/src/routes/clues.rs
+++ b/src/routes/clues.rs
@@ -12,8 +12,8 @@ pub fn configure(config: &mut web::ServiceConfig) {
 }
 
 async fn review_clue(
-    state: web::Data<AppState>,
     auth: AuthenticatedUser,
+    state: web::Data<AppState>,
     clue_id: web::Path<String>,
     request: web::Json<ReviewClueRequest>,
 ) -> Result<HttpResponse, ApiError> {

--- a/src/routes/health.rs
+++ b/src/routes/health.rs
@@ -16,25 +16,3 @@ pub async fn get_health() -> impl Responder {
         version: env!("CARGO_PKG_VERSION").to_owned(),
     })
 }
-
-#[cfg(test)]
-mod tests {
-    use actix_web::{App, http::StatusCode, test};
-
-    use super::HealthResponse;
-    use crate::routes;
-
-    #[actix_web::test]
-    async fn health_endpoint_returns_service_metadata() {
-        let app = test::init_service(App::new().configure(routes::configure)).await;
-        let request = test::TestRequest::get().uri("/api/health").to_request();
-
-        let response = test::call_service(&app, request).await;
-
-        assert_eq!(response.status(), StatusCode::OK);
-        let body: HealthResponse = test::read_body_json(response).await;
-        assert_eq!(body.status, "ok");
-        assert_eq!(body.service, "angui-api");
-        assert_eq!(body.version, env!("CARGO_PKG_VERSION"));
-    }
-}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -5,9 +5,12 @@ mod health;
 
 use actix_web::web;
 
+use crate::auth::ApiSessionAuthentication;
+
 pub fn configure(config: &mut web::ServiceConfig) {
     config.service(
         web::scope("/api")
+            .wrap(ApiSessionAuthentication)
             .service(health::get_health)
             .configure(auth::configure)
             .configure(cases::configure)

--- a/tests/api/auth_login_post.rs
+++ b/tests/api/auth_login_post.rs
@@ -1,0 +1,76 @@
+use actix_web::{http::StatusCode, test};
+use serde_json::{Value, json};
+
+use crate::support::{FAMILY, PASSWORD, TestContext, assert_error};
+
+#[actix_web::test]
+async fn login_returns_a_session_for_valid_demo_credentials() {
+    let context = TestContext::new().await;
+    let app = crate::init_api_app!(&context);
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/auth/login")
+            .set_json(json!({ "email": FAMILY, "password": PASSWORD }))
+            .to_request(),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = test::read_body_json(response).await;
+    assert!(
+        body["token"]
+            .as_str()
+            .is_some_and(|token| token.starts_with("angui_"))
+    );
+    assert_eq!(body["user"]["email"], FAMILY);
+    assert_eq!(body["user"]["role"], "family");
+}
+
+#[actix_web::test]
+async fn login_hides_account_existence_and_rate_limits_repeated_failures() {
+    let context = TestContext::new().await;
+    let app = crate::init_api_app!(&context);
+    let wrong_password = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/auth/login")
+            .set_json(json!({ "email": FAMILY, "password": "wrong-password" }))
+            .to_request(),
+    )
+    .await;
+    let unknown_account = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/auth/login")
+            .set_json(json!({ "email": "unknown@demo.invalid", "password": "wrong-password" }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(wrong_password.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(unknown_account.status(), StatusCode::UNAUTHORIZED);
+    let wrong_body: Value = test::read_body_json(wrong_password).await;
+    let unknown_body: Value = test::read_body_json(unknown_account).await;
+    assert_eq!(wrong_body, unknown_body);
+
+    for _ in 0..3 {
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/api/auth/login")
+                .set_json(json!({ "email": FAMILY, "password": "wrong-password" }))
+                .to_request(),
+        )
+        .await;
+        assert_error(response, StatusCode::UNAUTHORIZED, "unauthorized").await;
+    }
+    let limited = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/auth/login")
+            .set_json(json!({ "email": FAMILY, "password": "wrong-password" }))
+            .to_request(),
+    )
+    .await;
+    assert_error(limited, StatusCode::TOO_MANY_REQUESTS, "rate_limited").await;
+}

--- a/tests/api/auth_logout_post.rs
+++ b/tests/api/auth_logout_post.rs
@@ -1,0 +1,32 @@
+use actix_web::{
+    http::{StatusCode, header},
+    test,
+};
+
+use crate::support::{FAMILY, TestContext, assert_error};
+
+#[actix_web::test]
+async fn logout_revokes_the_current_bearer_session() {
+    let context = TestContext::new().await;
+    let token = context.token(FAMILY).await;
+    let app = crate::init_api_app!(&context);
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/auth/logout")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    let revoked = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/api/auth/me")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .to_request(),
+    )
+    .await;
+    assert_error(revoked, StatusCode::UNAUTHORIZED, "unauthorized").await;
+}

--- a/tests/api/auth_me_get.rs
+++ b/tests/api/auth_me_get.rs
@@ -1,0 +1,41 @@
+use actix_web::{
+    http::{StatusCode, header},
+    test,
+};
+use serde_json::Value;
+
+use crate::support::{FAMILY, TestContext, assert_error};
+
+#[actix_web::test]
+async fn get_auth_me_returns_the_authenticated_identity_and_rejects_bad_tokens() {
+    let context = TestContext::new().await;
+    let token = context.token(FAMILY).await;
+    let app = crate::init_api_app!(&context);
+    let authorized = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/api/auth/me")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(authorized.status(), StatusCode::OK);
+    let body: Value = test::read_body_json(authorized).await;
+    assert_eq!(body["email"], FAMILY);
+
+    let missing = test::call_service(
+        &app,
+        test::TestRequest::get().uri("/api/auth/me").to_request(),
+    )
+    .await;
+    assert_error(missing, StatusCode::UNAUTHORIZED, "unauthorized").await;
+    let invalid = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/api/auth/me")
+            .insert_header((header::AUTHORIZATION, "Bearer invalid-token"))
+            .to_request(),
+    )
+    .await;
+    assert_error(invalid, StatusCode::UNAUTHORIZED, "unauthorized").await;
+}

--- a/tests/api/authentication_guards.rs
+++ b/tests/api/authentication_guards.rs
@@ -1,0 +1,48 @@
+use actix_web::{http::StatusCode, test};
+
+use crate::support::{TestContext, assert_error};
+
+macro_rules! assert_unauthorized {
+    ($app:expr, $method:ident, $uri:expr) => {{
+        let missing =
+            test::call_service(&$app, test::TestRequest::$method().uri($uri).to_request()).await;
+        assert_eq!(
+            missing.status(),
+            StatusCode::UNAUTHORIZED,
+            "missing token should be rejected before request parsing for {}",
+            $uri
+        );
+        assert_error(missing, StatusCode::UNAUTHORIZED, "unauthorized").await;
+        let invalid = test::call_service(
+            &$app,
+            test::TestRequest::$method()
+                .uri($uri)
+                .insert_header(("authorization", "Bearer invalid-token"))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(
+            invalid.status(),
+            StatusCode::UNAUTHORIZED,
+            "invalid token should be rejected before request parsing for {}",
+            $uri
+        );
+        assert_error(invalid, StatusCode::UNAUTHORIZED, "unauthorized").await;
+    }};
+}
+
+#[actix_web::test]
+async fn every_protected_endpoint_rejects_missing_and_invalid_bearer_tokens() {
+    let context = TestContext::new().await;
+    let app = crate::init_api_app!(&context);
+
+    assert_unauthorized!(app, get, "/api/auth/me");
+    assert_unauthorized!(app, post, "/api/auth/logout");
+    assert_unauthorized!(app, get, "/api/cases");
+    assert_unauthorized!(app, post, "/api/cases");
+    assert_unauthorized!(app, get, "/api/cases/not-used");
+    assert_unauthorized!(app, patch, "/api/cases/not-used/status");
+    assert_unauthorized!(app, post, "/api/cases/not-used/members");
+    assert_unauthorized!(app, post, "/api/cases/not-used/clues");
+    assert_unauthorized!(app, patch, "/api/clues/not-used/review");
+}

--- a/tests/api/case_clues_post.rs
+++ b/tests/api/case_clues_post.rs
@@ -1,0 +1,62 @@
+use actix_web::{
+    http::{StatusCode, header},
+    test,
+};
+use serde_json::Value;
+
+use crate::support::{COMMANDER, FAMILY, TestContext, VOLUNTEER, assert_error, create_clue_json};
+
+#[actix_web::test]
+async fn post_case_clues_creates_pending_review_clues_for_case_members() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    let family_token = context.token(FAMILY).await;
+    let app = crate::init_api_app!(&context);
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/clues"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {family_token}")))
+            .set_json(create_clue_json())
+            .to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body: Value = test::read_body_json(response).await;
+    assert_eq!(body["case_id"], case_id);
+    assert_eq!(body["status"], "pending_review");
+    assert_eq!(body["is_own_submission"], true);
+}
+
+#[actix_web::test]
+async fn post_case_clues_hides_non_member_cases_and_rejects_closed_cases() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    let volunteer_token = context.token(VOLUNTEER).await;
+    let family_token = context.token(FAMILY).await;
+    let app = crate::init_api_app!(&context);
+    let non_member = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/clues"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {volunteer_token}")))
+            .set_json(create_clue_json())
+            .to_request(),
+    )
+    .await;
+    assert_error(non_member, StatusCode::NOT_FOUND, "not_found").await;
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    context.close_case(&case_id).await;
+    let closed = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/clues"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {family_token}")))
+            .set_json(create_clue_json())
+            .to_request(),
+    )
+    .await;
+    assert_error(closed, StatusCode::CONFLICT, "conflict").await;
+}

--- a/tests/api/case_detail_get.rs
+++ b/tests/api/case_detail_get.rs
@@ -1,0 +1,59 @@
+use actix_web::{
+    http::{StatusCode, header},
+    test,
+};
+use serde_json::Value;
+
+use crate::support::{COMMANDER, FAMILY, TestContext, VOLUNTEER, assert_error};
+
+#[actix_web::test]
+async fn get_case_applies_membership_and_role_based_field_and_clue_cuts() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    let family_token = context.token(FAMILY).await;
+    let volunteer_token = context.token(VOLUNTEER).await;
+    let app = crate::init_api_app!(&context);
+
+    let non_member = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/cases/{case_id}"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {volunteer_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_error(non_member, StatusCode::NOT_FOUND, "not_found").await;
+
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    context
+        .add_member(&case_id, COMMANDER, VOLUNTEER, "volunteer")
+        .await;
+    context.create_clue(&case_id, FAMILY).await;
+
+    let family = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/cases/{case_id}"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {family_token}")))
+            .to_request(),
+    )
+    .await;
+    let family_body: Value = test::read_body_json(family).await;
+    assert_eq!(family_body["access_role"], "family");
+    assert_eq!(family_body["clues"].as_array().map(Vec::len), Some(1));
+
+    let volunteer = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/cases/{case_id}"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {volunteer_token}")))
+            .to_request(),
+    )
+    .await;
+    let volunteer_body: Value = test::read_body_json(volunteer).await;
+    assert_eq!(volunteer_body["access_role"], "volunteer");
+    assert!(volunteer_body["elder_profile"]["health_notes"].is_null());
+    assert_eq!(volunteer_body["clues"].as_array().map(Vec::len), Some(0));
+}

--- a/tests/api/case_members_post.rs
+++ b/tests/api/case_members_post.rs
@@ -1,0 +1,75 @@
+use actix_web::{
+    http::{StatusCode, header},
+    test,
+};
+use serde_json::Value;
+
+use crate::support::{COMMANDER, FAMILY, TestContext, VOLUNTEER, assert_error};
+
+#[actix_web::test]
+async fn post_case_members_applies_invitation_role_and_duplicate_rules() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    let family_token = context.token(FAMILY).await;
+    let app = crate::init_api_app!(&context);
+    let invite_commander = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/members"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {family_token}")))
+            .set_json(serde_json::json!({ "email": COMMANDER, "role": "commander" }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(invite_commander.status(), StatusCode::CREATED);
+    let body: Value = test::read_body_json(invite_commander).await;
+    assert_eq!(body["email"], COMMANDER);
+    assert_eq!(body["role"], "commander");
+
+    let duplicate = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/members"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {family_token}")))
+            .set_json(serde_json::json!({ "email": COMMANDER, "role": "commander" }))
+            .to_request(),
+    )
+    .await;
+    assert_error(duplicate, StatusCode::CONFLICT, "conflict").await;
+    let family_cannot_invite_volunteer = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/members"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {family_token}")))
+            .set_json(serde_json::json!({ "email": VOLUNTEER, "role": "volunteer" }))
+            .to_request(),
+    )
+    .await;
+    assert_error(
+        family_cannot_invite_volunteer,
+        StatusCode::FORBIDDEN,
+        "forbidden",
+    )
+    .await;
+}
+
+#[actix_web::test]
+async fn post_case_members_allows_a_commander_to_add_a_matching_volunteer() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    let commander_token = context.token(COMMANDER).await;
+    let app = crate::init_api_app!(&context);
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/members"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(serde_json::json!({ "email": VOLUNTEER, "role": "volunteer" }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+}

--- a/tests/api/case_status_patch.rs
+++ b/tests/api/case_status_patch.rs
@@ -1,0 +1,62 @@
+use actix_web::{
+    http::{StatusCode, header},
+    test,
+};
+use serde_json::Value;
+
+use crate::support::{COMMANDER, FAMILY, TestContext, assert_error};
+
+#[actix_web::test]
+async fn patch_case_status_requires_commander_and_enforces_the_state_machine() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    let family_token = context.token(FAMILY).await;
+    let commander_token = context.token(COMMANDER).await;
+    let app = crate::init_api_app!(&context);
+
+    let forbidden = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&format!("/api/cases/{case_id}/status"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {family_token}")))
+            .set_json(serde_json::json!({ "status": "resolved" }))
+            .to_request(),
+    )
+    .await;
+    assert_error(forbidden, StatusCode::FORBIDDEN, "forbidden").await;
+    let resolved = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&format!("/api/cases/{case_id}/status"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(serde_json::json!({ "status": "resolved" }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(resolved.status(), StatusCode::OK);
+    let body: Value = test::read_body_json(resolved).await;
+    assert_eq!(body["status"], "resolved");
+    let closed = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&format!("/api/cases/{case_id}/status"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(serde_json::json!({ "status": "closed" }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(closed.status(), StatusCode::OK);
+    let invalid_transition = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&format!("/api/cases/{case_id}/status"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(serde_json::json!({ "status": "active" }))
+            .to_request(),
+    )
+    .await;
+    assert_error(invalid_transition, StatusCode::CONFLICT, "conflict").await;
+}

--- a/tests/api/cases_create_post.rs
+++ b/tests/api/cases_create_post.rs
@@ -1,0 +1,56 @@
+use actix_web::{
+    http::{StatusCode, header},
+    test,
+};
+use serde_json::Value;
+
+use crate::support::{FAMILY, TestContext, VOLUNTEER, assert_error, create_case_json};
+
+#[actix_web::test]
+async fn post_cases_creates_an_active_case_for_a_family_member() {
+    let context = TestContext::new().await;
+    let token = context.token(FAMILY).await;
+    let app = crate::init_api_app!(&context);
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/cases")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .set_json(create_case_json())
+            .to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body: Value = test::read_body_json(response).await;
+    assert_eq!(body["status"], "active");
+    assert_eq!(body["access_role"], "family");
+    assert_eq!(body["elder_profile"]["display_name"], "测试老人");
+}
+
+#[actix_web::test]
+async fn post_cases_enforces_auth_role_and_request_validation() {
+    let context = TestContext::new().await;
+    let volunteer_token = context.token(VOLUNTEER).await;
+    let family_token = context.token(FAMILY).await;
+    let app = crate::init_api_app!(&context);
+    let forbidden = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/cases")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {volunteer_token}")))
+            .set_json(create_case_json())
+            .to_request(),
+    )
+    .await;
+    assert_error(forbidden, StatusCode::FORBIDDEN, "forbidden").await;
+    let invalid = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/cases")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {family_token}")))
+            .set_json(serde_json::json!({ "display_name": "测试老人" }))
+            .to_request(),
+    )
+    .await;
+    assert_error(invalid, StatusCode::BAD_REQUEST, "validation_error").await;
+}

--- a/tests/api/cases_list_get.rs
+++ b/tests/api/cases_list_get.rs
@@ -1,0 +1,47 @@
+use actix_web::{
+    http::{StatusCode, header},
+    test,
+};
+use serde_json::Value;
+
+use crate::support::{COMMANDER, FAMILY, TestContext, assert_error};
+
+#[actix_web::test]
+async fn get_cases_only_returns_cases_where_the_user_is_a_member() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    let family_token = context.token(FAMILY).await;
+    let commander_token = context.token(COMMANDER).await;
+    let app = crate::init_api_app!(&context);
+
+    let family_response = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/api/cases")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {family_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(family_response.status(), StatusCode::OK);
+    let family_cases: Value = test::read_body_json(family_response).await;
+    assert_eq!(family_cases[0]["id"], case_id);
+    assert_eq!(family_cases[0]["access_role"], "family");
+
+    let absent_member = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/api/cases")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .to_request(),
+    )
+    .await;
+    let absent_cases: Value = test::read_body_json(absent_member).await;
+    assert_eq!(absent_cases, Value::Array(vec![]));
+
+    let missing = test::call_service(
+        &app,
+        test::TestRequest::get().uri("/api/cases").to_request(),
+    )
+    .await;
+    assert_error(missing, StatusCode::UNAUTHORIZED, "unauthorized").await;
+}

--- a/tests/api/clue_review_patch.rs
+++ b/tests/api/clue_review_patch.rs
@@ -1,0 +1,65 @@
+use actix_web::{
+    http::{StatusCode, header},
+    test,
+};
+use serde_json::Value;
+
+use crate::support::{COMMANDER, FAMILY, TestContext, assert_error};
+
+#[actix_web::test]
+async fn patch_clue_review_requires_the_case_commander_and_publishes_review_status() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    let clue_id = context.create_clue(&case_id, FAMILY).await;
+    let family_token = context.token(FAMILY).await;
+    let commander_token = context.token(COMMANDER).await;
+    let app = crate::init_api_app!(&context);
+    let forbidden = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&format!("/api/clues/{clue_id}/review"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {family_token}")))
+            .set_json(serde_json::json!({ "status": "confirmed" }))
+            .to_request(),
+    )
+    .await;
+    assert_error(forbidden, StatusCode::FORBIDDEN, "forbidden").await;
+    let confirmed = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&format!("/api/clues/{clue_id}/review"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(serde_json::json!({ "status": "confirmed" }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(confirmed.status(), StatusCode::OK);
+    let body: Value = test::read_body_json(confirmed).await;
+    assert_eq!(body["status"], "confirmed");
+    assert!(body["reviewed_at"].is_string());
+}
+
+#[actix_web::test]
+async fn patch_clue_review_rejects_pending_review_as_a_review_target() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    let clue_id = context.create_clue(&case_id, FAMILY).await;
+    let token = context.token(COMMANDER).await;
+    let app = crate::init_api_app!(&context);
+    let response = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&format!("/api/clues/{clue_id}/review"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .set_json(serde_json::json!({ "status": "pending_review" }))
+            .to_request(),
+    )
+    .await;
+    assert_error(response, StatusCode::BAD_REQUEST, "validation_error").await;
+}

--- a/tests/api/health_get.rs
+++ b/tests/api/health_get.rs
@@ -1,0 +1,20 @@
+use actix_web::{http::StatusCode, test};
+use serde_json::Value;
+
+#[actix_web::test]
+async fn get_health_returns_documented_service_metadata() {
+    let context = crate::support::TestContext::new().await;
+    let app = crate::init_api_app!(&context);
+
+    let response = test::call_service(
+        &app,
+        test::TestRequest::get().uri("/api/health").to_request(),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = test::read_body_json(response).await;
+    assert_eq!(body["status"], "ok");
+    assert_eq!(body["service"], "angui-api");
+    assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
+}

--- a/tests/api/mod.rs
+++ b/tests/api/mod.rs
@@ -1,0 +1,12 @@
+mod auth_login_post;
+mod auth_logout_post;
+mod auth_me_get;
+mod authentication_guards;
+mod case_clues_post;
+mod case_detail_get;
+mod case_members_post;
+mod case_status_patch;
+mod cases_create_post;
+mod cases_list_get;
+mod clue_review_patch;
+mod health_get;

--- a/tests/api_contract.rs
+++ b/tests/api_contract.rs
@@ -1,0 +1,9 @@
+//! 集中式 HTTP/API 契约测试入口。
+//!
+//! 新增端点测试应作为 `api` 下按 `method_path` 命名的子模块加入，避免每个端点生成一个
+//! 顶层 Cargo integration-test target。
+
+mod support;
+
+#[path = "api/mod.rs"]
+mod api;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,0 +1,176 @@
+use actix_web::{body::MessageBody, dev::ServiceResponse, http::StatusCode, test};
+use angui::{
+    app_state::AppState,
+    models::{
+        AddCaseMemberRequest, AuthenticatedUser, CreateCaseRequest, CreateClueRequest,
+        LoginRequest, UpdateCaseStatusRequest,
+    },
+    rate_limit::LoginRateLimiter,
+    services::{auth_service, case_service},
+};
+use migration::{Migrator, MigratorTrait};
+use sea_orm::{Database, DatabaseConnection};
+use serde_json::{Value, json};
+
+pub const PASSWORD: &str = "demo-password-123";
+pub const FAMILY: &str = "family@demo.invalid";
+pub const COMMANDER: &str = "commander@demo.invalid";
+pub const VOLUNTEER: &str = "volunteer@demo.invalid";
+
+pub struct TestContext {
+    database: DatabaseConnection,
+}
+
+impl TestContext {
+    pub async fn new() -> Self {
+        let database = Database::connect("sqlite::memory:")
+            .await
+            .expect("test database should connect");
+        Migrator::up(&database, None)
+            .await
+            .expect("test migrations should succeed");
+        auth_service::bootstrap_demo_users(&database, PASSWORD)
+            .await
+            .expect("test demo users should bootstrap");
+        Self { database }
+    }
+
+    pub fn app_state(&self) -> AppState {
+        AppState {
+            db: self.database.clone(),
+            session_ttl_hours: 8,
+            login_limiter: LoginRateLimiter::default(),
+        }
+    }
+
+    pub async fn token(&self, email: &str) -> String {
+        auth_service::login(
+            &self.database,
+            LoginRequest {
+                email: email.to_owned(),
+                password: PASSWORD.to_owned(),
+            },
+            8,
+        )
+        .await
+        .expect("fixture login should succeed")
+        .token
+    }
+
+    pub async fn authenticated(&self, email: &str) -> AuthenticatedUser {
+        let token = self.token(email).await;
+        auth_service::authenticate(&self.database, &token)
+            .await
+            .expect("fixture session should authenticate")
+    }
+
+    pub async fn create_case(&self) -> String {
+        let family = self.authenticated(FAMILY).await;
+        case_service::create_case(&self.database, &family, create_case_request())
+            .await
+            .expect("fixture case should be created")
+            .id
+    }
+
+    pub async fn add_member(&self, case_id: &str, actor_email: &str, email: &str, role: &str) {
+        let actor = self.authenticated(actor_email).await;
+        case_service::add_case_member(
+            &self.database,
+            &actor,
+            case_id,
+            AddCaseMemberRequest {
+                email: email.to_owned(),
+                role: role.to_owned(),
+            },
+        )
+        .await
+        .expect("fixture case member should be added");
+    }
+
+    pub async fn create_clue(&self, case_id: &str, actor_email: &str) -> String {
+        let actor = self.authenticated(actor_email).await;
+        case_service::create_clue(&self.database, &actor, case_id, create_clue_request())
+            .await
+            .expect("fixture clue should be created")
+            .id
+    }
+
+    pub async fn close_case(&self, case_id: &str) {
+        let commander = self.authenticated(COMMANDER).await;
+        case_service::update_case_status(
+            &self.database,
+            &commander,
+            case_id,
+            UpdateCaseStatusRequest {
+                status: "closed".to_owned(),
+            },
+        )
+        .await
+        .expect("fixture case should close");
+    }
+}
+
+pub fn create_case_request() -> CreateCaseRequest {
+    CreateCaseRequest {
+        display_name: "测试老人".to_owned(),
+        age: Some(76),
+        gender: Some("female".to_owned()),
+        physical_description: Some("测试体貌".to_owned()),
+        clothing_description: Some("测试衣着".to_owned()),
+        health_notes: Some("仅用于测试的健康备注".to_owned()),
+        last_seen_at: Some("2026-07-13T09:00:00Z".to_owned()),
+        last_seen_location: Some("测试公园北门".to_owned()),
+    }
+}
+
+pub fn create_case_json() -> Value {
+    json!({
+        "display_name": "测试老人",
+        "age": 76,
+        "gender": "female",
+        "physical_description": "测试体貌",
+        "clothing_description": "测试衣着",
+        "health_notes": "仅用于测试的健康备注",
+        "last_seen_at": "2026-07-13T09:00:00Z",
+        "last_seen_location": "测试公园北门"
+    })
+}
+
+pub fn create_clue_request() -> CreateClueRequest {
+    CreateClueRequest {
+        source: "family".to_owned(),
+        content: "测试线索：曾向测试市场方向步行".to_owned(),
+        occurred_at: Some("2026-07-13T09:10:00Z".to_owned()),
+        location_text: Some("测试公园北门".to_owned()),
+    }
+}
+
+pub fn create_clue_json() -> Value {
+    json!({
+        "source": "family",
+        "content": "测试线索：曾向测试市场方向步行",
+        "occurred_at": "2026-07-13T09:10:00Z",
+        "location_text": "测试公园北门"
+    })
+}
+
+#[macro_export]
+macro_rules! init_api_app {
+    ($context:expr) => {{
+        actix_web::test::init_service(
+            actix_web::App::new()
+                .app_data(actix_web::web::Data::new($context.app_state()))
+                .configure(angui::routes::configure),
+        )
+        .await
+    }};
+}
+
+pub async fn assert_error<B>(response: ServiceResponse<B>, status: StatusCode, code: &str)
+where
+    B: MessageBody + 'static,
+{
+    assert_eq!(response.status(), status);
+    let body: Value = test::read_body_json(response).await;
+    assert_eq!(body["error"]["code"], code);
+}


### PR DESCRIPTION
## 变更内容

- 新增唯一的 Cargo HTTP/API 契约测试入口 `tests/api_contract.rs`，通过 `tests/api/mod.rs` 注册 11 个端点测试子模块与共享 `tests/support` fixture。
- 使用内存 SQLite、迁移和 `.invalid` 演示账号，测试不依赖 `data/angui.db`。
- 覆盖登录成功/账号枚举保护/限流、会话撤销、成员可见性、非成员 `404`、角色 `403`、案件状态机、关闭案件冲突、线索审核与字段裁剪。
- 修复受保护 JSON 端点在无效 token 且 body 不完整时先返回 `400` 的契约缺口：API scope 中间件先验证会话，统一返回项目错误 JSON `401`；已认证身份写入 request extensions，避免 handler 重复认证。
- 移除路由源码中重复的 health HTTP 测试，HTTP/API 测试统一从 `tests/api_contract.rs` 进入。

## 验收映射

- [x] #2 的 11 个已实现端点均有独立、可反查的测试文件。
- [x] #2 的认证、RBAC、状态机、响应字段与统一错误 JSON 验收项均有自动化覆盖。
- [x] 对照 `docs/openapi.yaml` 验证 11 个 `method + path` 与实际路由一致。

## 测试与质量检查

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --test api_contract --all-features --locked` (17 passed)
- [x] `cargo test --workspace --all-features --locked`
- [x] `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`

Closes #2