### PR TITLE
feat: database-driven intake session questions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@ ANGUI_PORT=8080
 ANGUI_FRONTEND_ORIGIN=http://localhost:5173
 DATABASE_URL=sqlite://data/angui.db?mode=rwc
 ANGUI_SESSION_TTL_HOURS=8
+# Absolute safety cap for a single intake answer. Per-question business limits live in the database.
+ANGUI_INTAKE_ANSWER_HARD_MAX=2000
 # Set only while running `npm run auth:bootstrap-demo`; use 12-256 characters.
 ANGUI_DEMO_PASSWORD=replace-with-a-local-demo-password
 RUST_LOG=info

--- a/docs/API.md
+++ b/docs/API.md
@@ -14,6 +14,7 @@
 | `POST` | `/api/auth/login` | `200` | 使用邮箱和密码创建短期会话 |
 | `GET` | `/api/auth/me` | `200` | 获取当前认证用户 |
 | `POST` | `/api/auth/logout` | `204` | 撤销当前服务端会话 |
+| `POST` | `/api/intake-sessions` | `201` | 创建家属的未确认走失信息问询会话 |
 | `GET` | `/api/cases` | `200` | 按创建时间倒序列出案件 |
 | `POST` | `/api/cases` | `201` | 创建案件和老人画像 |
 | `GET` | `/api/cases/{case_id}` | `200` | 查询案件、老人画像和线索 |
@@ -145,6 +146,23 @@ AI 或其他自动化能力未来只能生成草稿或待审核输入，不得�
 ```json
 {
   "status": "resolved"
+}
+```
+
+## Intake session creation
+
+`POST /api/intake-sessions` is available only to authenticated `family` accounts. Its optional `initial_answers` object has eight structured draft fields: `basic_information`, `health_status`, `behavior_habits`, `last_seen`, `frequent_locations`, `belongings`, `transport_ability`, and `follow_up_clues`. Every supplied value is trimmed and must meet the active question's database-managed `max_answer_chars`; `ANGUI_INTAKE_ANSWER_HARD_MAX` is a server-side absolute cap (default `2000`, range `1`–`10000`) that cannot be exceeded by database configuration. Unknown properties, including `confirmed`, are rejected.
+
+The server creates a `collecting` session and records the selected `question_set_version`. It always returns `guidance_mode: "rule_based"`, `missing_fields`, and the next ordered question from the active database definition. This is the required AI-unavailable fallback; no external model is called. The values remain unconfirmed drafts, never case facts. Raw answers are not included in audit metadata or ordinary logs. The session is owned by its creator; when a later confirmation associates it with a case, only an authorized commander of that case may additionally read it. The database's unique case association protects the later confirmation flow from linking a session to multiple cases.
+
+Example:
+
+```json
+{
+  "initial_answers": {
+    "basic_information": "Fictional elder profile",
+    "last_seen": "Fictional community gate; time needs verification"
+  }
 }
 ```
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -177,3 +177,11 @@ npm run migrate:status
 - 账号删除不是当前能力；禁用账号使用 `status=disabled`，认证时立即拒绝。
 - 管理员全局角色不构成案件成员关系，不能绕过 `case_memberships` 读取业务数据。
 - 显式运行 `angui-admin bootstrap-demo` 会创建或更新五个 `.invalid` 演示账号（家属、指挥、志愿者、新人、管理员），并撤销这些账号之前的活动会话。`learner` 与 `admin` 都不是案件成员角色；后者也不能因全局管理员身份绕过 `case_memberships` 读取案件。
+
+## 12. 问询会话
+
+`intake_sessions` stores the family-created, unconfirmed intake draft before a case exists. It has a required creator, lifecycle status, structured answers JSON, timestamps, and an optional unique `case_id` for the later confirmation flow. The foreign key to the creator protects ownership; the optional case relation supports later visibility for that case's authorized commanders and prevents a session from being associated with more than one case.
+
+`intake_question_definitions` is the versioned, database-managed rule set for the initial questionnaire. Each active row provides the stable answer field code, prompt, display order, required marker, and per-question `max_answer_chars`. Sessions snapshot the selected `question_set_version` at creation so later configuration changes cannot re-label the rules that produced an existing draft. The seeded version `1` contains the initial eight questions.
+
+The current creation API writes only `collecting`. The migration also reserves `ready_for_confirmation`, `confirmed`, and `closed` for the follow-on answer and confirmation APIs. Sensitive raw answers remain in the session record and are deliberately excluded from audit metadata and ordinary logs. The database limit is intersected with the server-only `ANGUI_INTAKE_ANSWER_HARD_MAX` safety cap; database configuration cannot increase that hard limit.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -36,6 +36,8 @@ tags:
     description: 案件、老人资料、案件成员和案件内线索
   - name: Clues
     description: 线索人工审核
+  - name: Intake sessions
+    description: 家属创建的未确认走失信息问询会话
 security:
   - bearerAuth: []
 paths:
@@ -122,6 +124,43 @@ paths:
           description: 会话已撤销，无响应正文
         "401":
           $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/intake-sessions:
+    post:
+      tags: [Intake sessions]
+      operationId: createIntakeSession
+      summary: Create a family intake session
+      description: |
+        Only family accounts can create an unconfirmed intake draft. Unknown fields, including
+        confirmed, are rejected. This endpoint always returns rule-based guidance and writes no
+        raw answer content to audit metadata. Per-question business limits and question order come
+        from the active database configuration; the server also enforces an independent hard cap.
+      x-roles: [family]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateIntakeSessionRequest"
+            example:
+              initial_answers:
+                basic_information: Fictional elder profile
+                last_seen: Fictional community gate; time needs verification
+      responses:
+        "201":
+          description: Intake session created with the next rule-based question
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IntakeSession"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalError"
 
@@ -594,6 +633,56 @@ components:
           type: string
           minLength: 1
           description: 必填；只包含空白也会被拒绝。
+
+    CreateIntakeSessionRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        initial_answers:
+          $ref: "#/components/schemas/IntakeInitialAnswers"
+
+    IntakeInitialAnswers:
+      type: object
+      additionalProperties: false
+      properties:
+        basic_information: { type: [string, "null"], minLength: 1, description: Limit is configured by the active question definition. }
+        health_status: { type: [string, "null"], minLength: 1, description: Sensitive; never included in audit metadata. Limit is configured by the active question definition. }
+        behavior_habits: { type: [string, "null"], minLength: 1, description: Limit is configured by the active question definition. }
+        last_seen: { type: [string, "null"], minLength: 1, description: Limit is configured by the active question definition. }
+        frequent_locations: { type: [string, "null"], minLength: 1, description: Limit is configured by the active question definition. }
+        belongings: { type: [string, "null"], minLength: 1, description: Limit is configured by the active question definition. }
+        transport_ability: { type: [string, "null"], minLength: 1, description: Limit is configured by the active question definition. }
+        follow_up_clues: { type: [string, "null"], minLength: 1, description: Limit is configured by the active question definition. }
+
+    IntakeQuestion:
+      type: object
+      additionalProperties: false
+      required: [field, prompt, required]
+      properties:
+        field: { type: string }
+        prompt: { type: string }
+        required: { type: boolean }
+
+    IntakeSession:
+      type: object
+      additionalProperties: false
+      required: [id, status, question_set_version, initial_answers, missing_fields, next_question, guidance_mode, privacy_notice, created_at, updated_at]
+      properties:
+        id: { type: string, format: uuid }
+        status: { type: string, const: collecting }
+        question_set_version: { type: integer, minimum: 1 }
+        initial_answers: { $ref: "#/components/schemas/IntakeInitialAnswers" }
+        missing_fields:
+          type: array
+          items: { type: string }
+        next_question:
+          oneOf:
+            - $ref: "#/components/schemas/IntakeQuestion"
+            - type: "null"
+        guidance_mode: { type: string, const: rule_based }
+        privacy_notice: { type: string }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
 
     UpdateCaseStatusRequest:
       type: object

--- a/migration/sql/mysql/down/0010_drop_intake_sessions.sql
+++ b/migration/sql/mysql/down/0010_drop_intake_sessions.sql
@@ -1,0 +1,3 @@
+DROP INDEX idx_intake_sessions_creator ON intake_sessions;
+-- statement-break
+DROP TABLE IF EXISTS intake_sessions;

--- a/migration/sql/mysql/down/0011_drop_intake_question_definitions.sql
+++ b/migration/sql/mysql/down/0011_drop_intake_question_definitions.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS intake_question_definitions;
+-- statement-break
+ALTER TABLE intake_sessions DROP COLUMN question_set_version;

--- a/migration/sql/mysql/up/0010_create_intake_sessions.sql
+++ b/migration/sql/mysql/up/0010_create_intake_sessions.sql
@@ -1,0 +1,14 @@
+CREATE TABLE intake_sessions (
+    id VARCHAR(36) PRIMARY KEY,
+    created_by_user_id VARCHAR(36) NOT NULL,
+    case_id VARCHAR(36) UNIQUE,
+    status VARCHAR(32) NOT NULL,
+    answers_json TEXT NOT NULL,
+    created_at VARCHAR(40) NOT NULL,
+    updated_at VARCHAR(40) NOT NULL,
+    CONSTRAINT chk_intake_sessions_status CHECK (status IN ('collecting', 'ready_for_confirmation', 'confirmed', 'closed')),
+    CONSTRAINT fk_intake_sessions_creator FOREIGN KEY (created_by_user_id) REFERENCES users(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_intake_sessions_case FOREIGN KEY (case_id) REFERENCES cases(id) ON DELETE SET NULL
+) ENGINE=InnoDB;
+-- statement-break
+CREATE INDEX idx_intake_sessions_creator ON intake_sessions(created_by_user_id, created_at);

--- a/migration/sql/mysql/up/0011_create_intake_question_definitions.sql
+++ b/migration/sql/mysql/up/0011_create_intake_question_definitions.sql
@@ -1,0 +1,32 @@
+ALTER TABLE intake_sessions ADD COLUMN question_set_version INT NOT NULL DEFAULT 1;
+-- statement-break
+CREATE TABLE intake_question_definitions (
+    id VARCHAR(36) PRIMARY KEY,
+    version INT NOT NULL,
+    field_code VARCHAR(64) NOT NULL,
+    prompt TEXT NOT NULL,
+    display_order INT NOT NULL,
+    is_required BOOLEAN NOT NULL,
+    max_answer_chars INT NOT NULL,
+    status VARCHAR(16) NOT NULL,
+    created_at VARCHAR(40) NOT NULL,
+    updated_at VARCHAR(40) NOT NULL,
+    CONSTRAINT chk_intake_question_definitions_version CHECK (version > 0),
+    CONSTRAINT chk_intake_question_definitions_display_order CHECK (display_order > 0),
+    CONSTRAINT chk_intake_question_definitions_answer_limit CHECK (max_answer_chars > 0),
+    CONSTRAINT chk_intake_question_definitions_status CHECK (status IN ('active', 'disabled')),
+    UNIQUE (version, field_code),
+    UNIQUE (version, display_order)
+) ENGINE=InnoDB;
+-- statement-break
+CREATE INDEX idx_intake_question_definitions_active ON intake_question_definitions(status, version, display_order);
+-- statement-break
+INSERT INTO intake_question_definitions (id, version, field_code, prompt, display_order, is_required, max_answer_chars, status, created_at, updated_at) VALUES
+    ('intake-q-0001', 1, 'basic_information', 'Please describe the person in a way your family can verify, such as their name or a safe identifying description.', 1, TRUE, 500, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0002', 1, 'health_status', 'Are there health, cognitive, mobility, or medication concerns responders should know? Share only what is necessary.', 2, FALSE, 1000, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0003', 1, 'behavior_habits', 'What routines, preferences, or behaviors may help family members recognize useful leads?', 3, FALSE, 800, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0004', 1, 'last_seen', 'When and where was the person last seen? Include uncertainty if the time or place is not exact.', 4, TRUE, 800, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0005', 1, 'frequent_locations', 'Which places do they commonly visit? Please avoid unrelated private addresses.', 5, FALSE, 800, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0006', 1, 'belongings', 'What clothing, bags, phone, identification, or other belongings were they carrying?', 6, FALSE, 800, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0007', 1, 'transport_ability', 'How might they travel independently, for example walking, public transport, or a familiar route?', 7, FALSE, 600, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0008', 1, 'follow_up_clues', 'Is there any later information or lead that still needs human verification?', 8, FALSE, 1000, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z');

--- a/migration/sql/postgres/down/0010_drop_intake_sessions.sql
+++ b/migration/sql/postgres/down/0010_drop_intake_sessions.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_intake_sessions_creator;
+-- statement-break
+DROP TABLE IF EXISTS intake_sessions;

--- a/migration/sql/postgres/down/0011_drop_intake_question_definitions.sql
+++ b/migration/sql/postgres/down/0011_drop_intake_question_definitions.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS intake_question_definitions;
+-- statement-break
+ALTER TABLE intake_sessions DROP COLUMN question_set_version;

--- a/migration/sql/postgres/up/0010_create_intake_sessions.sql
+++ b/migration/sql/postgres/up/0010_create_intake_sessions.sql
@@ -1,0 +1,13 @@
+CREATE TABLE intake_sessions (
+    id VARCHAR(36) PRIMARY KEY,
+    created_by_user_id VARCHAR(36) NOT NULL,
+    case_id VARCHAR(36) UNIQUE,
+    status VARCHAR(32) NOT NULL CHECK (status IN ('collecting', 'ready_for_confirmation', 'confirmed', 'closed')),
+    answers_json TEXT NOT NULL,
+    created_at VARCHAR(40) NOT NULL,
+    updated_at VARCHAR(40) NOT NULL,
+    CONSTRAINT fk_intake_sessions_creator FOREIGN KEY (created_by_user_id) REFERENCES users(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_intake_sessions_case FOREIGN KEY (case_id) REFERENCES cases(id) ON DELETE SET NULL
+);
+-- statement-break
+CREATE INDEX idx_intake_sessions_creator ON intake_sessions(created_by_user_id, created_at);

--- a/migration/sql/postgres/up/0011_create_intake_question_definitions.sql
+++ b/migration/sql/postgres/up/0011_create_intake_question_definitions.sql
@@ -1,0 +1,28 @@
+ALTER TABLE intake_sessions ADD COLUMN question_set_version INTEGER NOT NULL DEFAULT 1;
+-- statement-break
+CREATE TABLE intake_question_definitions (
+    id VARCHAR(36) PRIMARY KEY,
+    version INTEGER NOT NULL CHECK (version > 0),
+    field_code VARCHAR(64) NOT NULL,
+    prompt TEXT NOT NULL,
+    display_order INTEGER NOT NULL CHECK (display_order > 0),
+    is_required BOOLEAN NOT NULL,
+    max_answer_chars INTEGER NOT NULL CHECK (max_answer_chars > 0),
+    status VARCHAR(16) NOT NULL CHECK (status IN ('active', 'disabled')),
+    created_at VARCHAR(40) NOT NULL,
+    updated_at VARCHAR(40) NOT NULL,
+    UNIQUE (version, field_code),
+    UNIQUE (version, display_order)
+);
+-- statement-break
+CREATE INDEX idx_intake_question_definitions_active ON intake_question_definitions(status, version, display_order);
+-- statement-break
+INSERT INTO intake_question_definitions (id, version, field_code, prompt, display_order, is_required, max_answer_chars, status, created_at, updated_at) VALUES
+    ('intake-q-0001', 1, 'basic_information', 'Please describe the person in a way your family can verify, such as their name or a safe identifying description.', 1, TRUE, 500, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0002', 1, 'health_status', 'Are there health, cognitive, mobility, or medication concerns responders should know? Share only what is necessary.', 2, FALSE, 1000, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0003', 1, 'behavior_habits', 'What routines, preferences, or behaviors may help family members recognize useful leads?', 3, FALSE, 800, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0004', 1, 'last_seen', 'When and where was the person last seen? Include uncertainty if the time or place is not exact.', 4, TRUE, 800, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0005', 1, 'frequent_locations', 'Which places do they commonly visit? Please avoid unrelated private addresses.', 5, FALSE, 800, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0006', 1, 'belongings', 'What clothing, bags, phone, identification, or other belongings were they carrying?', 6, FALSE, 800, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0007', 1, 'transport_ability', 'How might they travel independently, for example walking, public transport, or a familiar route?', 7, FALSE, 600, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0008', 1, 'follow_up_clues', 'Is there any later information or lead that still needs human verification?', 8, FALSE, 1000, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z');

--- a/migration/sql/sqlite/down/0010_drop_intake_sessions.sql
+++ b/migration/sql/sqlite/down/0010_drop_intake_sessions.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_intake_sessions_creator;
+-- statement-break
+DROP TABLE IF EXISTS intake_sessions;

--- a/migration/sql/sqlite/down/0011_drop_intake_question_definitions.sql
+++ b/migration/sql/sqlite/down/0011_drop_intake_question_definitions.sql
@@ -1,0 +1,27 @@
+DROP TABLE IF EXISTS intake_question_definitions;
+-- statement-break
+PRAGMA foreign_keys = OFF;
+-- statement-break
+CREATE TABLE intake_sessions_without_question_set_version (
+    id TEXT PRIMARY KEY NOT NULL,
+    created_by_user_id TEXT NOT NULL,
+    case_id TEXT,
+    status TEXT NOT NULL CHECK (status IN ('collecting', 'ready_for_confirmation', 'confirmed', 'closed')),
+    answers_json TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (created_by_user_id) REFERENCES users(id) ON DELETE RESTRICT,
+    FOREIGN KEY (case_id) REFERENCES cases(id) ON DELETE SET NULL,
+    UNIQUE (case_id)
+);
+-- statement-break
+INSERT INTO intake_sessions_without_question_set_version (id, created_by_user_id, case_id, status, answers_json, created_at, updated_at)
+SELECT id, created_by_user_id, case_id, status, answers_json, created_at, updated_at FROM intake_sessions;
+-- statement-break
+DROP TABLE intake_sessions;
+-- statement-break
+ALTER TABLE intake_sessions_without_question_set_version RENAME TO intake_sessions;
+-- statement-break
+CREATE INDEX idx_intake_sessions_creator ON intake_sessions(created_by_user_id, created_at);
+-- statement-break
+PRAGMA foreign_keys = ON;

--- a/migration/sql/sqlite/up/0010_create_intake_sessions.sql
+++ b/migration/sql/sqlite/up/0010_create_intake_sessions.sql
@@ -1,0 +1,14 @@
+CREATE TABLE intake_sessions (
+    id TEXT PRIMARY KEY NOT NULL,
+    created_by_user_id TEXT NOT NULL,
+    case_id TEXT,
+    status TEXT NOT NULL CHECK (status IN ('collecting', 'ready_for_confirmation', 'confirmed', 'closed')),
+    answers_json TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (created_by_user_id) REFERENCES users(id) ON DELETE RESTRICT,
+    FOREIGN KEY (case_id) REFERENCES cases(id) ON DELETE SET NULL,
+    UNIQUE (case_id)
+);
+-- statement-break
+CREATE INDEX idx_intake_sessions_creator ON intake_sessions(created_by_user_id, created_at);

--- a/migration/sql/sqlite/up/0011_create_intake_question_definitions.sql
+++ b/migration/sql/sqlite/up/0011_create_intake_question_definitions.sql
@@ -1,0 +1,28 @@
+ALTER TABLE intake_sessions ADD COLUMN question_set_version INTEGER NOT NULL DEFAULT 1;
+-- statement-break
+CREATE TABLE intake_question_definitions (
+    id TEXT PRIMARY KEY NOT NULL,
+    version INTEGER NOT NULL CHECK (version > 0),
+    field_code TEXT NOT NULL,
+    prompt TEXT NOT NULL,
+    display_order INTEGER NOT NULL CHECK (display_order > 0),
+    is_required BOOLEAN NOT NULL,
+    max_answer_chars INTEGER NOT NULL CHECK (max_answer_chars > 0),
+    status TEXT NOT NULL CHECK (status IN ('active', 'disabled')),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE (version, field_code),
+    UNIQUE (version, display_order)
+);
+-- statement-break
+CREATE INDEX idx_intake_question_definitions_active ON intake_question_definitions(status, version, display_order);
+-- statement-break
+INSERT INTO intake_question_definitions (id, version, field_code, prompt, display_order, is_required, max_answer_chars, status, created_at, updated_at) VALUES
+    ('intake-q-0001', 1, 'basic_information', 'Please describe the person in a way your family can verify, such as their name or a safe identifying description.', 1, 1, 500, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0002', 1, 'health_status', 'Are there health, cognitive, mobility, or medication concerns responders should know? Share only what is necessary.', 2, 0, 1000, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0003', 1, 'behavior_habits', 'What routines, preferences, or behaviors may help family members recognize useful leads?', 3, 0, 800, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0004', 1, 'last_seen', 'When and where was the person last seen? Include uncertainty if the time or place is not exact.', 4, 1, 800, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0005', 1, 'frequent_locations', 'Which places do they commonly visit? Please avoid unrelated private addresses.', 5, 0, 800, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0006', 1, 'belongings', 'What clothing, bags, phone, identification, or other belongings were they carrying?', 6, 0, 800, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0007', 1, 'transport_ability', 'How might they travel independently, for example walking, public transport, or a familiar route?', 7, 0, 600, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z'),
+    ('intake-q-0008', 1, 'follow_up_clues', 'Is there any later information or lead that still needs human verification?', 8, 0, 1000, 'active', '2026-07-24T00:00:00.000Z', '2026-07-24T00:00:00.000Z');

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -9,6 +9,8 @@ mod m0006_create_auth_sessions;
 mod m0007_create_case_memberships;
 mod m0008_create_clue_attributions;
 mod m0009_add_learner_role;
+mod m0010_create_intake_sessions;
+mod m0011_create_intake_question_definitions;
 
 use sea_orm_migration::sea_orm::DbBackend;
 
@@ -27,6 +29,8 @@ impl MigratorTrait for Migrator {
             Box::new(m0007_create_case_memberships::Migration),
             Box::new(m0008_create_clue_attributions::Migration),
             Box::new(m0009_add_learner_role::Migration),
+            Box::new(m0010_create_intake_sessions::Migration),
+            Box::new(m0011_create_intake_question_definitions::Migration),
         ]
     }
 }
@@ -124,6 +128,8 @@ mod tests {
         include_str!("../sql/mysql/down/0007_drop_case_memberships.sql"),
         include_str!("../sql/mysql/down/0008_drop_clue_attributions.sql"),
         include_str!("../sql/mysql/down/0009_remove_learner_role.sql"),
+        include_str!("../sql/mysql/down/0010_drop_intake_sessions.sql"),
+        include_str!("../sql/mysql/down/0011_drop_intake_question_definitions.sql"),
     ];
 
     #[tokio::test]

--- a/migration/src/m0010_create_intake_sessions.rs
+++ b/migration/src/m0010_create_intake_sessions.rs
@@ -1,0 +1,34 @@
+use sea_orm_migration::prelude::*;
+
+use crate::{execute_script, sql_for_backend};
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m0010_create_intake_sessions"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let sql = sql_for_backend(
+            manager,
+            include_str!("../sql/sqlite/up/0010_create_intake_sessions.sql"),
+            include_str!("../sql/postgres/up/0010_create_intake_sessions.sql"),
+            include_str!("../sql/mysql/up/0010_create_intake_sessions.sql"),
+        );
+        execute_script(manager, sql).await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let sql = sql_for_backend(
+            manager,
+            include_str!("../sql/sqlite/down/0010_drop_intake_sessions.sql"),
+            include_str!("../sql/postgres/down/0010_drop_intake_sessions.sql"),
+            include_str!("../sql/mysql/down/0010_drop_intake_sessions.sql"),
+        );
+        execute_script(manager, sql).await
+    }
+}

--- a/migration/src/m0011_create_intake_question_definitions.rs
+++ b/migration/src/m0011_create_intake_question_definitions.rs
@@ -1,0 +1,34 @@
+use sea_orm_migration::prelude::*;
+
+use crate::{execute_script, sql_for_backend};
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m0011_create_intake_question_definitions"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let sql = sql_for_backend(
+            manager,
+            include_str!("../sql/sqlite/up/0011_create_intake_question_definitions.sql"),
+            include_str!("../sql/postgres/up/0011_create_intake_question_definitions.sql"),
+            include_str!("../sql/mysql/up/0011_create_intake_question_definitions.sql"),
+        );
+        execute_script(manager, sql).await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let sql = sql_for_backend(
+            manager,
+            include_str!("../sql/sqlite/down/0011_drop_intake_question_definitions.sql"),
+            include_str!("../sql/postgres/down/0011_drop_intake_question_definitions.sql"),
+            include_str!("../sql/mysql/down/0011_drop_intake_question_definitions.sql"),
+        );
+        execute_script(manager, sql).await
+    }
+}

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -6,5 +6,6 @@ use crate::rate_limit::LoginRateLimiter;
 pub struct AppState {
     pub db: DatabaseConnection,
     pub session_ttl_hours: i64,
+    pub intake_answer_hard_max: usize,
     pub login_limiter: LoginRateLimiter,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ pub struct Settings {
     pub frontend_origin: String,
     pub database_url: String,
     pub session_ttl_hours: i64,
+    pub intake_answer_hard_max: usize,
 }
 
 impl Settings {
@@ -28,6 +29,16 @@ impl Settings {
         if !(1..=168).contains(&session_ttl_hours) {
             return Err("ANGUI_SESSION_TTL_HOURS must be between 1 and 168".to_owned());
         }
+        let intake_answer_hard_max_value =
+            env::var("ANGUI_INTAKE_ANSWER_HARD_MAX").unwrap_or_else(|_| "2000".to_owned());
+        let intake_answer_hard_max = intake_answer_hard_max_value.parse::<usize>().map_err(|_| {
+            format!(
+                "ANGUI_INTAKE_ANSWER_HARD_MAX must be a positive integer, got {intake_answer_hard_max_value:?}"
+            )
+        })?;
+        if !(1..=10_000).contains(&intake_answer_hard_max) {
+            return Err("ANGUI_INTAKE_ANSWER_HARD_MAX must be between 1 and 10000".to_owned());
+        }
 
         Ok(Self {
             host,
@@ -35,6 +46,7 @@ impl Settings {
             frontend_origin,
             database_url,
             session_ttl_hours,
+            intake_answer_hard_max,
         })
     }
 
@@ -55,6 +67,7 @@ mod tests {
             frontend_origin: "http://localhost:5173".to_owned(),
             database_url: "sqlite::memory:".to_owned(),
             session_ttl_hours: 8,
+            intake_answer_hard_max: 2_000,
         };
 
         assert_eq!(settings.address(), ("127.0.0.1".to_owned(), 8080));

--- a/src/entities/intake_question_definitions.rs
+++ b/src/entities/intake_question_definitions.rs
@@ -1,0 +1,23 @@
+use sea_orm::entity::prelude::*;
+use serde::Serialize;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize)]
+#[sea_orm(table_name = "intake_question_definitions")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub version: i32,
+    pub field_code: String,
+    pub prompt: String,
+    pub display_order: i32,
+    pub is_required: bool,
+    pub max_answer_chars: i32,
+    pub status: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/entities/intake_sessions.rs
+++ b/src/entities/intake_sessions.rs
@@ -1,0 +1,38 @@
+use sea_orm::entity::prelude::*;
+use serde::Serialize;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize)]
+#[sea_orm(table_name = "intake_sessions")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub created_by_user_id: String,
+    pub case_id: Option<String>,
+    pub question_set_version: i32,
+    pub status: String,
+    pub answers_json: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::users::Entity",
+        from = "Column::CreatedByUserId",
+        to = "super::users::Column::Id",
+        on_update = "Cascade",
+        on_delete = "Restrict"
+    )]
+    Creator,
+    #[sea_orm(
+        belongs_to = "super::cases::Entity",
+        from = "Column::CaseId",
+        to = "super::cases::Column::Id",
+        on_update = "Cascade",
+        on_delete = "SetNull"
+    )]
+    Case,
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -5,4 +5,6 @@ pub mod cases;
 pub mod clue_attributions;
 pub mod clues;
 pub mod elder_profiles;
+pub mod intake_question_definitions;
+pub mod intake_sessions;
 pub mod users;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ async fn main() -> io::Result<()> {
     let state = web::Data::new(AppState {
         db: database,
         session_ttl_hours: settings.session_ttl_hours,
+        intake_answer_hard_max: settings.intake_answer_hard_max,
         login_limiter: LoginRateLimiter::default(),
     });
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::entities::{cases, clue_attributions, clues, elder_profiles, users};
+use crate::entities::{cases, clue_attributions, clues, elder_profiles, intake_sessions, users};
 
 #[derive(Clone, Debug)]
 pub struct AuthenticatedUser {
@@ -44,6 +44,71 @@ pub struct CreateCaseRequest {
     pub health_notes: Option<String>,
     pub last_seen_at: Option<String>,
     pub last_seen_location: Option<String>,
+}
+
+/// Starts a family-owned intake session. These values remain unconfirmed
+/// collection input; clients cannot set a fact-confirmation state here.
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct CreateIntakeSessionRequest {
+    #[serde(default)]
+    pub initial_answers: IntakeInitialAnswers,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct IntakeInitialAnswers {
+    pub basic_information: Option<String>,
+    pub health_status: Option<String>,
+    pub behavior_habits: Option<String>,
+    pub last_seen: Option<String>,
+    pub frequent_locations: Option<String>,
+    pub belongings: Option<String>,
+    pub transport_ability: Option<String>,
+    pub follow_up_clues: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct IntakeQuestion {
+    pub field: String,
+    pub prompt: String,
+    pub required: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct IntakeSessionResponse {
+    pub id: String,
+    pub status: String,
+    pub question_set_version: i32,
+    pub initial_answers: IntakeInitialAnswers,
+    pub missing_fields: Vec<String>,
+    pub next_question: Option<IntakeQuestion>,
+    pub guidance_mode: String,
+    pub privacy_notice: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl IntakeSessionResponse {
+    pub fn new(
+        model: intake_sessions::Model,
+        initial_answers: IntakeInitialAnswers,
+        missing_fields: Vec<String>,
+        next_question: Option<IntakeQuestion>,
+    ) -> Self {
+        Self {
+            id: model.id,
+            status: model.status,
+            question_set_version: model.question_set_version,
+            initial_answers,
+            missing_fields,
+            next_question,
+            guidance_mode: "rule_based".to_owned(),
+            privacy_notice: "Answers are visible only to the session creator and, after case authorization, the case's authorized commanders. They are unconfirmed drafts and are not copied into audit metadata.".to_owned(),
+            created_at: model.created_at,
+            updated_at: model.updated_at,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/routes/intake_sessions.rs
+++ b/src/routes/intake_sessions.rs
@@ -1,0 +1,27 @@
+use actix_web::{HttpResponse, web};
+
+use crate::{
+    app_state::AppState,
+    error::ApiError,
+    models::{AuthenticatedUser, CreateIntakeSessionRequest},
+    services::intake_session_service,
+};
+
+pub fn configure(config: &mut web::ServiceConfig) {
+    config.service(web::scope("/intake-sessions").route("", web::post().to(create_intake_session)));
+}
+
+async fn create_intake_session(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    request: web::Json<CreateIntakeSessionRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let session = intake_session_service::create_intake_session(
+        &state.db,
+        &auth,
+        request.into_inner(),
+        state.intake_answer_hard_max,
+    )
+    .await?;
+    Ok(HttpResponse::Created().json(session))
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -2,6 +2,7 @@ mod auth;
 mod cases;
 mod clues;
 mod health;
+mod intake_sessions;
 
 use actix_web::web;
 
@@ -14,6 +15,7 @@ pub fn configure(config: &mut web::ServiceConfig) {
             .service(health::get_health)
             .configure(auth::configure)
             .configure(cases::configure)
+            .configure(intake_sessions::configure)
             .configure(clues::configure),
     );
 }

--- a/src/services/intake_session_service.rs
+++ b/src/services/intake_session_service.rs
@@ -1,0 +1,224 @@
+use chrono::{SecondsFormat, Utc};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseConnection, EntityTrait, QueryFilter,
+    QueryOrder, Set, TransactionTrait,
+};
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::{
+    entities::{audit_events, intake_question_definitions, intake_sessions},
+    error::ApiError,
+    models::{
+        AuthenticatedUser, CreateIntakeSessionRequest, IntakeInitialAnswers, IntakeQuestion,
+        IntakeSessionResponse,
+    },
+};
+
+pub async fn create_intake_session(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    request: CreateIntakeSessionRequest,
+    answer_hard_max: usize,
+) -> Result<IntakeSessionResponse, ApiError> {
+    if auth.role != "family" {
+        return Err(ApiError::Forbidden(
+            "only family accounts can create intake sessions".to_owned(),
+        ));
+    }
+
+    let transaction = db.begin().await?;
+    let questions = active_questions(&transaction).await?;
+    let question_set_version = questions
+        .first()
+        .map(|question| question.version)
+        .ok_or(ApiError::Internal)?;
+    let answers = normalize_answers(request.initial_answers, &questions, answer_hard_max)?;
+    let answers_json = serde_json::to_string(&answers).map_err(|_| ApiError::Internal)?;
+    let timestamp = now();
+    let session_id = Uuid::new_v4().to_string();
+
+    let session = intake_sessions::ActiveModel {
+        id: Set(session_id.clone()),
+        created_by_user_id: Set(auth.id.clone()),
+        case_id: Set(None),
+        question_set_version: Set(question_set_version),
+        status: Set("collecting".to_owned()),
+        answers_json: Set(answers_json),
+        created_at: Set(timestamp.clone()),
+        updated_at: Set(timestamp),
+    }
+    .insert(&transaction)
+    .await?;
+
+    // Deliberately omit answers from audit metadata: they can include health and
+    // identifying information and must not become broadly queryable metadata.
+    write_audit(
+        &transaction,
+        auth,
+        session_id,
+        Some(json!({ "status": "collecting", "guidance_mode": "rule_based" })),
+    )
+    .await?;
+
+    transaction.commit().await?;
+    Ok(response_for(session, answers, &questions))
+}
+
+async fn active_questions<C: ConnectionTrait>(
+    db: &C,
+) -> Result<Vec<intake_question_definitions::Model>, ApiError> {
+    let latest = intake_question_definitions::Entity::find()
+        .filter(intake_question_definitions::Column::Status.eq("active"))
+        .order_by_desc(intake_question_definitions::Column::Version)
+        .one(db)
+        .await?
+        .ok_or(ApiError::Internal)?;
+    let questions = intake_question_definitions::Entity::find()
+        .filter(intake_question_definitions::Column::Status.eq("active"))
+        .filter(intake_question_definitions::Column::Version.eq(latest.version))
+        .order_by_asc(intake_question_definitions::Column::DisplayOrder)
+        .all(db)
+        .await?;
+    validate_question_configuration(&questions)?;
+    Ok(questions)
+}
+
+async fn write_audit<C: ConnectionTrait>(
+    db: &C,
+    auth: &AuthenticatedUser,
+    session_id: String,
+    metadata: Option<serde_json::Value>,
+) -> Result<(), ApiError> {
+    let metadata_json = metadata.map(|mut value| {
+        if let Some(object) = value.as_object_mut() {
+            object.insert("actor_role".to_owned(), json!(auth.role));
+        }
+        value.to_string()
+    });
+    audit_events::ActiveModel {
+        id: Set(Uuid::new_v4().to_string()),
+        case_id: Set(None),
+        actor: Set(auth.id.clone()),
+        action: Set("intake_session.created".to_owned()),
+        entity_type: Set("intake_session".to_owned()),
+        entity_id: Set(session_id),
+        metadata_json: Set(metadata_json),
+        created_at: Set(now()),
+    }
+    .insert(db)
+    .await?;
+    Ok(())
+}
+
+fn normalize_answers(
+    mut answers: IntakeInitialAnswers,
+    questions: &[intake_question_definitions::Model],
+    answer_hard_max: usize,
+) -> Result<IntakeInitialAnswers, ApiError> {
+    for (field_code, answer) in [
+        ("basic_information", &mut answers.basic_information),
+        ("health_status", &mut answers.health_status),
+        ("behavior_habits", &mut answers.behavior_habits),
+        ("last_seen", &mut answers.last_seen),
+        ("frequent_locations", &mut answers.frequent_locations),
+        ("belongings", &mut answers.belongings),
+        ("transport_ability", &mut answers.transport_ability),
+        ("follow_up_clues", &mut answers.follow_up_clues),
+    ]
+    .into_iter()
+    {
+        let Some(answer) = answer else {
+            continue;
+        };
+        let question = questions
+            .iter()
+            .find(|question| question.field_code == field_code)
+            .ok_or_else(|| {
+                ApiError::Validation(format!(
+                    "{field_code} is not enabled in the active intake question set"
+                ))
+            })?;
+        let answer_limit = usize::try_from(question.max_answer_chars)
+            .map_err(|_| ApiError::Internal)?
+            .min(answer_hard_max);
+        let trimmed = answer.trim();
+        if trimmed.is_empty() || trimmed.chars().count() > answer_limit {
+            return Err(ApiError::Validation(format!(
+                "{field_code} must contain between 1 and {answer_limit} characters"
+            )));
+        }
+        *answer = trimmed.to_owned();
+    }
+    Ok(answers)
+}
+
+fn response_for(
+    model: intake_sessions::Model,
+    answers: IntakeInitialAnswers,
+    questions: &[intake_question_definitions::Model],
+) -> IntakeSessionResponse {
+    let missing_fields = missing_fields(&answers, questions);
+    let next_question = questions
+        .iter()
+        .find(|question| missing_fields.contains(&question.field_code))
+        .map(|question| IntakeQuestion {
+            field: question.field_code.clone(),
+            prompt: question.prompt.clone(),
+            required: question.is_required,
+        });
+    IntakeSessionResponse::new(model, answers, missing_fields, next_question)
+}
+
+fn missing_fields(
+    answers: &IntakeInitialAnswers,
+    questions: &[intake_question_definitions::Model],
+) -> Vec<String> {
+    questions
+        .iter()
+        .filter(|question| answer_for(answers, &question.field_code).is_none())
+        .map(|question| question.field_code.clone())
+        .collect()
+}
+
+fn answer_for<'a>(answers: &'a IntakeInitialAnswers, field_code: &str) -> Option<&'a String> {
+    match field_code {
+        "basic_information" => answers.basic_information.as_ref(),
+        "health_status" => answers.health_status.as_ref(),
+        "behavior_habits" => answers.behavior_habits.as_ref(),
+        "last_seen" => answers.last_seen.as_ref(),
+        "frequent_locations" => answers.frequent_locations.as_ref(),
+        "belongings" => answers.belongings.as_ref(),
+        "transport_ability" => answers.transport_ability.as_ref(),
+        "follow_up_clues" => answers.follow_up_clues.as_ref(),
+        _ => None,
+    }
+}
+
+fn validate_question_configuration(
+    questions: &[intake_question_definitions::Model],
+) -> Result<(), ApiError> {
+    if questions.is_empty()
+        || questions.iter().any(|question| {
+            question.max_answer_chars <= 0
+                || !matches!(
+                    question.field_code.as_str(),
+                    "basic_information"
+                        | "health_status"
+                        | "behavior_habits"
+                        | "last_seen"
+                        | "frequent_locations"
+                        | "belongings"
+                        | "transport_ability"
+                        | "follow_up_clues"
+                )
+        })
+    {
+        return Err(ApiError::Internal);
+    }
+    Ok(())
+}
+
+fn now() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,2 +1,3 @@
 pub mod auth_service;
 pub mod case_service;
+pub mod intake_session_service;

--- a/tests/api/intake_sessions_create_post.rs
+++ b/tests/api/intake_sessions_create_post.rs
@@ -1,0 +1,204 @@
+use actix_web::{
+    http::{StatusCode, header},
+    test,
+};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
+use serde_json::Value;
+
+use angui::{
+    entities::{audit_events, intake_question_definitions, intake_sessions},
+    models::{CreateIntakeSessionRequest, IntakeInitialAnswers},
+    services::intake_session_service,
+};
+
+use crate::support::{ADMIN, COMMANDER, FAMILY, TestContext, assert_error};
+
+#[actix_web::test]
+async fn post_intake_sessions_creates_a_family_owned_rule_guided_draft() {
+    let context = TestContext::new().await;
+    let token = context.token(FAMILY).await;
+    let app = crate::init_api_app!(&context);
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/intake-sessions")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .set_json(serde_json::json!({
+                "initial_answers": {
+                    "basic_information": "  Fictional elder profile  ",
+                    "last_seen": "Fictional community gate, approximate time"
+                }
+            }))
+            .to_request(),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body: Value = test::read_body_json(response).await;
+    assert_eq!(body["status"], "collecting");
+    assert_eq!(body["question_set_version"], 1);
+    assert_eq!(body["guidance_mode"], "rule_based");
+    assert_eq!(
+        body["initial_answers"]["basic_information"],
+        "Fictional elder profile"
+    );
+    assert_eq!(body["next_question"]["field"], "health_status");
+    assert!(
+        body["missing_fields"]
+            .as_array()
+            .unwrap()
+            .contains(&Value::String("health_status".to_owned()))
+    );
+
+    let session_id = body["id"].as_str().unwrap();
+    let stored = intake_sessions::Entity::find_by_id(session_id)
+        .one(&context.database)
+        .await
+        .unwrap()
+        .expect("session should be stored");
+    assert_eq!(stored.status, "collecting");
+    assert!(stored.answers_json.contains("Fictional elder profile"));
+
+    let audit = audit_events::Entity::find()
+        .filter(audit_events::Column::EntityId.eq(session_id))
+        .one(&context.database)
+        .await
+        .unwrap()
+        .expect("creation should be audited");
+    assert_eq!(audit.action, "intake_session.created");
+    assert!(
+        !audit
+            .metadata_json
+            .unwrap_or_default()
+            .contains("Fictional elder profile")
+    );
+}
+
+#[actix_web::test]
+async fn post_intake_sessions_reads_question_order_prompt_and_limit_from_database() {
+    let context = TestContext::new().await;
+    let health_question = intake_question_definitions::Entity::find()
+        .filter(intake_question_definitions::Column::FieldCode.eq("health_status"))
+        .one(&context.database)
+        .await
+        .unwrap()
+        .expect("seeded health question should exist");
+    let mut configured_question = health_question.into_active_model();
+    configured_question.prompt = Set("Configured health question".to_owned());
+    configured_question.max_answer_chars = Set(5);
+    configured_question.update(&context.database).await.unwrap();
+
+    let token = context.token(FAMILY).await;
+    let app = crate::init_api_app!(&context);
+    let configured_prompt = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/intake-sessions")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .set_json(serde_json::json!({
+                "initial_answers": { "basic_information": "Fictional elder" }
+            }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(configured_prompt.status(), StatusCode::CREATED);
+    let body: Value = test::read_body_json(configured_prompt).await;
+    assert_eq!(body["next_question"]["field"], "health_status");
+    assert_eq!(
+        body["next_question"]["prompt"],
+        "Configured health question"
+    );
+
+    let limit_from_database = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/intake-sessions")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .set_json(serde_json::json!({
+                "initial_answers": { "health_status": "123456" }
+            }))
+            .to_request(),
+    )
+    .await;
+    assert_error(
+        limit_from_database,
+        StatusCode::BAD_REQUEST,
+        "validation_error",
+    )
+    .await;
+}
+
+#[actix_web::test]
+async fn intake_answer_hard_max_caps_the_database_question_limit() {
+    let context = TestContext::new().await;
+    let family = context.authenticated(FAMILY).await;
+    let result = intake_session_service::create_intake_session(
+        &context.database,
+        &family,
+        CreateIntakeSessionRequest {
+            initial_answers: IntakeInitialAnswers {
+                basic_information: Some("123456".to_owned()),
+                ..Default::default()
+            },
+        },
+        5,
+    )
+    .await;
+    assert!(matches!(result, Err(angui::error::ApiError::Validation(_))));
+}
+
+#[actix_web::test]
+async fn post_intake_sessions_rejects_non_family_accounts() {
+    let context = TestContext::new().await;
+    let app = crate::init_api_app!(&context);
+
+    for email in [COMMANDER, ADMIN] {
+        let token = context.token(email).await;
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/api/intake-sessions")
+                .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+                .set_json(serde_json::json!({}))
+                .to_request(),
+        )
+        .await;
+        assert_error(response, StatusCode::FORBIDDEN, "forbidden").await;
+    }
+}
+
+#[actix_web::test]
+async fn post_intake_sessions_validates_answers_and_refuses_client_confirmed_facts() {
+    let context = TestContext::new().await;
+    let token = context.token(FAMILY).await;
+    let app = crate::init_api_app!(&context);
+
+    for payload in [
+        serde_json::json!({ "initial_answers": { "health_status": "   " } }),
+        serde_json::json!({ "initial_answers": { "basic_information": "x".repeat(1001) } }),
+    ] {
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri("/api/intake-sessions")
+                .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+                .set_json(payload)
+                .to_request(),
+        )
+        .await;
+        assert_error(response, StatusCode::BAD_REQUEST, "validation_error").await;
+    }
+
+    let rejected_confirmed_fact = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/intake-sessions")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .set_json(serde_json::json!({
+                "initial_answers": { "basic_information": "Fictional elder", "confirmed": true }
+            }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(rejected_confirmed_fact.status(), StatusCode::BAD_REQUEST);
+}

--- a/tests/api/mod.rs
+++ b/tests/api/mod.rs
@@ -10,3 +10,4 @@ mod cases_create_post;
 mod cases_list_get;
 mod clue_review_patch;
 mod health_get;
+mod intake_sessions_create_post;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -20,7 +20,7 @@ pub const LEARNER: &str = "learner@demo.invalid";
 pub const ADMIN: &str = "admin@demo.invalid";
 
 pub struct TestContext {
-    database: DatabaseConnection,
+    pub(crate) database: DatabaseConnection,
 }
 
 impl TestContext {
@@ -41,6 +41,7 @@ impl TestContext {
         AppState {
             db: self.database.clone(),
             session_ttl_hours: 8,
+            intake_answer_hard_max: 2_000,
             login_limiter: LoginRateLimiter::default(),
         }
     }


### PR DESCRIPTION
## Summary
- implement Issue #4 family intake-session creation API and audited persistence
- move rule-based intake question text, order, required flags, and per-question answer limits into versioned database definitions
- retain a server-only ANGUI_INTAKE_ANSWER_HARD_MAX cap as a safety boundary and store question_set_version on each session
- add SQLite, PostgreSQL, and MySQL migrations; API/OpenAPI/database docs; and regression coverage

## Validation
- cargo fmt --check
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo test --workspace --all-features --locked

Closes #4