### PR TITLE
feat(ai): add provider gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ DATABASE_URL=sqlite://data/angui.db?mode=rwc
 ANGUI_SESSION_TTL_HOURS=8
 # Absolute safety cap for a single intake answer. Per-question business limits live in the database.
 ANGUI_INTAKE_ANSWER_HARD_MAX=2000
+# Empty by default: the gateway returns the deterministic rule-based path.
+# Set this to a JSON array of provider policies. endpoint_env and credential_env
+# are environment-variable names, not URLs or secrets. See docs/AI_GATEWAY.md.
+# ANGUI_AI_PROVIDERS_JSON=[]
 # Set only while running `npm run auth:bootstrap-demo`; use 12-256 characters.
 ANGUI_DEMO_PASSWORD=replace-with-a-local-demo-password
 RUST_LOG=info

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ dependencies = [
  "env_logger",
  "futures-util",
  "hex",
+ "http",
  "migration",
  "sea-orm",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ chrono = "0.4.42"
 env_logger = "0.11.11"
 futures-util = "0.3.32"
 hex = "0.4.3"
+http = "0.2.12"
 sea-orm = { version = "1.1.19", default-features = false, features = ["macros", "runtime-tokio-rustls", "sqlx-mysql", "sqlx-postgres", "sqlx-sqlite"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - API 说明：[docs/API.md](./docs/API.md)
 - 数据库与迁移规范：[docs/DATABASE.md](./docs/DATABASE.md)
 - 数据与 AI 规范：[docs/DATA_AND_AI.md](./docs/DATA_AND_AI.md)
+- AI Gateway 配置与协议边界：[docs/AI_GATEWAY.md](./docs/AI_GATEWAY.md)
 - 安全与隐私边界：[docs/SECURITY_AND_PRIVACY.md](./docs/SECURITY_AND_PRIVACY.md)
 - Demo 与初赛交付：[docs/DEMO_AND_DELIVERY.md](./docs/DEMO_AND_DELIVERY.md)
 - 贡献指南：[CONTRIBUTING.md](./CONTRIBUTING.md)

--- a/docs/AI_GATEWAY.md
+++ b/docs/AI_GATEWAY.md
@@ -1,0 +1,68 @@
+# AI Gateway
+
+The AI Gateway is the sole boundary between Angui business services and model-provider protocols. Business services submit an `AiRequest`; they do not import a provider SDK or assemble provider JSON payloads.
+
+## Supported Protocols
+
+`protocol` selects one of four wire formats:
+
+| Value | Native HTTP request |
+| --- | --- |
+| `open_ai_chat_completions` | `POST /v1/chat/completions` |
+| `open_ai_responses` | `POST /v1/responses` |
+| `anthropic_messages` | `POST /v1/messages` |
+| `gemini_generate_content` | `POST /v1beta/models/{model}:generateContent` |
+
+The adapter builds an `http::Request<serde_json::Value>` at the transport boundary. Endpoint and credential values are supplied there from the runtime environment. They are not present in the checked-in configuration, protocol payload metadata, or audit data.
+
+## Configuration
+
+`ANGUI_AI_PROVIDERS_JSON` is optional. Its default is `[]`, which returns the deterministic `rule_based` degradation path. A configured provider is validated during application startup.
+
+```json
+[
+  {
+    "id": "demo-openai-compatible",
+    "vendor": "demo-provider",
+    "protocol": "open_ai_responses",
+    "region": "cn-demo-1",
+    "model": "demo-model",
+    "capabilities": ["inquiry", "structured_extraction"],
+    "allowed_data_levels": ["internal"],
+    "allowed_purposes": ["intake_draft", "clue_draft"],
+    "input_limit_chars": 4000,
+    "output_limit_tokens": 600,
+    "timeout_ms": 8000,
+    "allow_fallback": false,
+    "priority": 100,
+    "weight": 1,
+    "emergency_disabled": false,
+    "compliance_scopes": [],
+    "endpoint_env": "ANGUI_DEMO_AI_ENDPOINT",
+    "credential_env": "ANGUI_DEMO_AI_KEY"
+  }
+]
+```
+
+This example intentionally contains neither a production URL nor a credential. `endpoint_env` and `credential_env` must be uppercase environment-variable names. Unknown properties, including `api_key`, `secret`, and direct URLs, are rejected by the configuration schema.
+
+Providers that permit `sensitive` data must declare at least one non-empty `compliance_scopes` value. Empty model identifiers, zero timeouts, empty data policies, duplicate IDs, zero limits, and zero weights are also rejected at startup.
+
+## Routing and Degradation
+
+Before a provider can become a candidate, the Gateway checks all of the following:
+
+- requested capability;
+- request data level;
+- allowed business purpose;
+- exact data-residency region;
+- emergency-disable state;
+- configured input and output limits.
+
+Candidates are ordered deterministically by priority, then weight, then provider ID. A gateway with no configured providers returns `rule_based / no_provider_configured`. When providers exist but none meet every policy requirement, it returns `manual_required / no_compliant_provider`. Automatic retry, circuit-breaking, and cross-provider failover are intentionally outside this component and belong to the later reliability issues.
+
+## Audit Boundary
+
+Each future execution is expected to persist the Gateway's `AiExecutionAudit` through `persist_execution_audit`. The record includes Provider ID, model, template version, input-scope reference, SHA-256 input hash, redaction-policy version, and task status. It never contains the raw request, response, health history, contact data, or precise locations.
+
+This PR provides the shared boundary and audit writer only. It does not yet call external AI services or allow an AI result to create a confirmed clue, publish a case update, or dispatch a task.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@
 | [openapi.yaml](./openapi.yaml) | 当前已注册 HTTP API 的机器可读契约、认证、角色与字段可见性 | 前端、后端、测试、集成 |
 | [DATABASE.md](./DATABASE.md) | SeaORM、SQLite/PostgreSQL/MySQL 和编号 SQL 迁移规范 | 后端、数据库、运维 |
 | [DATA_AND_AI.md](./DATA_AND_AI.md) | 数据对象、线索状态、AI 输出约束、知识库治理 | 后端、AI、数据、审核人员 |
+| [AI_GATEWAY.md](./AI_GATEWAY.md) | AI Provider 协议适配、合规路由、配置与审计边界 | 后端、AI、安全评审人员 |
 | [SECURITY_AND_PRIVACY.md](./SECURITY_AND_PRIVACY.md) | 权限分级、隐私保护、定位安全、日志和事件响应 | 全体成员、安全评审人员 |
 | [DEMO_AND_DELIVERY.md](./DEMO_AND_DELIVERY.md) | Demo 故事线、样例数据和初赛交付清单 | 产品、前端、路演团队 |
 | [ISSUE_DRAFT.md](./ISSUE_DRAFT.md) | API、数据、三端能力与交付的 GitHub Issue 拆分草案 | 产品、开发、项目管理 |

--- a/src/ai_gateway.rs
+++ b/src/ai_gateway.rs
@@ -361,22 +361,27 @@ impl AiProvider for ProtocolProvider {
                     "max_tokens": max_tokens,
                 }),
             },
-            ProviderProtocol::GeminiGenerateContent => ProviderHttpRequest {
-                method: "POST",
-                path: format!("/v1beta/models/{}:generateContent", self.config.model),
-                headers: vec![ProviderHeader {
-                    name: "x-goog-api-key",
-                    value: credential,
-                }],
-                body: json!({
-                    "systemInstruction": { "parts": [{ "text": instructions }] },
+            ProviderProtocol::GeminiGenerateContent => {
+                let mut body = json!({
                     "contents": [{
                         "role": "user",
                         "parts": [{ "text": request.input.as_str() }],
                     }],
                     "generationConfig": { "maxOutputTokens": max_tokens },
-                }),
-            },
+                });
+                if !instructions.is_empty() {
+                    body["systemInstruction"] = json!({ "parts": [{ "text": instructions }] });
+                }
+                ProviderHttpRequest {
+                    method: "POST",
+                    path: format!("/v1beta/models/{}:generateContent", self.config.model),
+                    headers: vec![ProviderHeader {
+                        name: "x-goog-api-key",
+                        value: credential,
+                    }],
+                    body,
+                }
+            }
         };
         Ok(request)
     }
@@ -518,6 +523,7 @@ fn provider_is_eligible(config: &ProviderConfig, request: &AiRequest) -> bool {
         && config.allowed_data_levels.contains(&request.data_level)
         && config.allowed_purposes.contains(&request.purpose)
         && config.region == request.data_region
+        && !request.input.trim().is_empty()
         && request.input.chars().count() <= config.input_limit_chars
         && request.requested_output_tokens <= config.output_limit_tokens
 }
@@ -688,6 +694,22 @@ mod tests {
     }
 
     #[test]
+    fn empty_input_degrades_before_selecting_a_provider() {
+        let gateway = AiGateway::from_configurations(vec![provider(
+            "eligible",
+            ProviderProtocol::GeminiGenerateContent,
+        )])
+        .expect("fixture is valid");
+        let mut request = request();
+        request.input = "  \n\t ".to_owned();
+
+        assert!(matches!(
+            gateway.route(&request),
+            GatewayDecision::Degraded { .. }
+        ));
+    }
+
+    #[test]
     fn validation_rejects_sensitive_provider_without_compliance_scope() {
         let mut configuration = provider("sensitive", ProviderProtocol::OpenAiChatCompletions);
         configuration.allowed_data_levels.push(DataLevel::Sensitive);
@@ -741,6 +763,29 @@ mod tests {
                     assert!(outbound.body.get("systemInstruction").is_some());
                 }
             }
+        }
+    }
+
+    #[test]
+    fn gemini_omits_system_instruction_when_it_is_absent_or_empty() {
+        let gateway = AiGateway::from_configurations(vec![provider(
+            "gemini",
+            ProviderProtocol::GeminiGenerateContent,
+        )])
+        .expect("fixture is valid");
+        let route = match gateway.route(&request()) {
+            GatewayDecision::Routed(route) => route,
+            GatewayDecision::Degraded { .. } => panic!("fixture should route"),
+        };
+
+        for system_instruction in [None, Some(String::new())] {
+            let mut request = request();
+            request.system_instruction = system_instruction;
+            let outbound = gateway
+                .build_provider_request(&route, &request)
+                .expect("request should be serializable");
+
+            assert!(outbound.body.get("systemInstruction").is_none());
         }
     }
 

--- a/src/ai_gateway.rs
+++ b/src/ai_gateway.rs
@@ -1,0 +1,831 @@
+use std::{collections::HashSet, sync::Arc};
+
+use chrono::{SecondsFormat, Utc};
+use http::Request as HttpRequest;
+use sea_orm::{ActiveModelTrait, ConnectionTrait, Set};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::entities::audit_events;
+
+/// The only model-provider protocols supported by the gateway. Business code
+/// uses `AiRequest`, so it never needs a provider SDK or protocol payload.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderProtocol {
+    OpenAiChatCompletions,
+    OpenAiResponses,
+    AnthropicMessages,
+    GeminiGenerateContent,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AiCapability {
+    Inquiry,
+    StructuredExtraction,
+    CaseSummary,
+    KnowledgeAnswer,
+    CaseOrganization,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DataLevel {
+    Public,
+    Collaborative,
+    Internal,
+    Sensitive,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AiPurpose {
+    IntakeDraft,
+    ClueDraft,
+    CaseSummaryDraft,
+    KnowledgeAnswer,
+    CaseArchiveDraft,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProviderConfig {
+    pub id: String,
+    pub vendor: String,
+    pub protocol: ProviderProtocol,
+    pub region: String,
+    pub model: String,
+    pub capabilities: Vec<AiCapability>,
+    pub allowed_data_levels: Vec<DataLevel>,
+    pub allowed_purposes: Vec<AiPurpose>,
+    pub input_limit_chars: usize,
+    pub output_limit_tokens: usize,
+    pub timeout_ms: u64,
+    pub allow_fallback: bool,
+    pub priority: u16,
+    pub weight: u16,
+    pub emergency_disabled: bool,
+    pub compliance_scopes: Vec<String>,
+    /// Name of an environment variable containing the provider base URL.
+    /// The URL itself is deliberately not committed in provider configuration.
+    pub endpoint_env: String,
+    /// Name of an environment variable containing the provider credential.
+    /// This configuration contains a reference only, never a secret value.
+    pub credential_env: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct AiRequest {
+    pub capability: AiCapability,
+    pub data_level: DataLevel,
+    pub purpose: AiPurpose,
+    pub data_region: String,
+    pub system_instruction: Option<String>,
+    pub input: String,
+    pub requested_output_tokens: usize,
+    pub template_version: String,
+    pub input_scope_reference: String,
+    pub redaction_policy_version: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProviderRoute {
+    pub provider_id: String,
+    pub vendor: String,
+    pub protocol: ProviderProtocol,
+    pub model: String,
+    pub endpoint_env: String,
+    pub credential_env: String,
+    pub timeout_ms: u64,
+    pub allow_fallback: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DegradationStatus {
+    RuleBased,
+    ManualRequired,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DegradationReason {
+    NoProviderConfigured,
+    NoCompliantProvider,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum GatewayDecision {
+    Routed(ProviderRoute),
+    Degraded {
+        status: DegradationStatus,
+        reason: DegradationReason,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProviderHttpRequest {
+    pub method: &'static str,
+    pub path: String,
+    pub headers: Vec<ProviderHeader>,
+    pub body: Value,
+}
+
+impl ProviderHttpRequest {
+    /// Materializes a protocol request only at the transport boundary. The
+    /// endpoint and credential come from the runtime environment, not the
+    /// checked-in provider configuration or audit metadata.
+    pub fn into_native_request(
+        self,
+        endpoint: &str,
+        credential: &str,
+    ) -> Result<HttpRequest<Value>, AiGatewayError> {
+        let endpoint = endpoint.trim_end_matches('/');
+        if endpoint.is_empty() || credential.is_empty() {
+            return Err(AiGatewayError::InvalidNativeRequest(
+                "endpoint and credential must be supplied by the runtime environment".to_owned(),
+            ));
+        }
+        let uri = format!("{endpoint}{}", self.path)
+            .parse::<http::Uri>()
+            .map_err(|_| {
+                AiGatewayError::InvalidNativeRequest("invalid provider endpoint".to_owned())
+            })?;
+        let mut builder = HttpRequest::builder()
+            .method(self.method)
+            .uri(uri)
+            .header("content-type", "application/json");
+        for header in self.headers {
+            let value = match header.value {
+                HeaderValue::Literal(value) => value.to_owned(),
+                HeaderValue::EnvironmentSecret(_) if header.name == "authorization" => {
+                    format!("Bearer {credential}")
+                }
+                HeaderValue::EnvironmentSecret(_) => credential.to_owned(),
+            };
+            builder = builder.header(header.name, value);
+        }
+        builder.body(self.body).map_err(|_| {
+            AiGatewayError::InvalidNativeRequest("invalid provider request headers".to_owned())
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ProviderHeader {
+    pub name: &'static str,
+    pub value: HeaderValue,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum HeaderValue {
+    Literal(&'static str),
+    EnvironmentSecret(String),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AiTaskStatus {
+    Routed,
+    Completed,
+    Degraded,
+    Failed,
+}
+
+impl AiTaskStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Routed => "routed",
+            Self::Completed => "completed",
+            Self::Degraded => "degraded",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+/// Metadata safe for the existing audit event store. It intentionally has no
+/// raw prompt, response, medical history, contact details, or location data.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AiExecutionAudit {
+    pub id: String,
+    pub provider_id: Option<String>,
+    pub model: Option<String>,
+    pub template_version: String,
+    pub input_scope_reference: String,
+    pub input_hash: String,
+    pub redaction_policy_version: String,
+    pub status: AiTaskStatus,
+}
+
+impl AiExecutionAudit {
+    pub fn for_request(
+        request: &AiRequest,
+        decision: &GatewayDecision,
+        status: AiTaskStatus,
+    ) -> Self {
+        let (provider_id, model) = match decision {
+            GatewayDecision::Routed(route) => {
+                (Some(route.provider_id.clone()), Some(route.model.clone()))
+            }
+            GatewayDecision::Degraded { .. } => (None, None),
+        };
+
+        Self {
+            id: Uuid::new_v4().to_string(),
+            provider_id,
+            model,
+            template_version: request.template_version.clone(),
+            input_scope_reference: request.input_scope_reference.clone(),
+            input_hash: hex::encode(Sha256::digest(request.input.as_bytes())),
+            redaction_policy_version: request.redaction_policy_version.clone(),
+            status,
+        }
+    }
+
+    pub fn metadata_json(&self) -> Value {
+        json!({
+            "provider_id": self.provider_id,
+            "model": self.model,
+            "template_version": self.template_version,
+            "input_scope_reference": self.input_scope_reference,
+            "input_hash": self.input_hash,
+            "redaction_policy_version": self.redaction_policy_version,
+            "status": self.status.as_str(),
+        })
+    }
+}
+
+pub async fn persist_execution_audit<C: ConnectionTrait>(
+    db: &C,
+    audit: &AiExecutionAudit,
+    actor: &str,
+    case_id: Option<&str>,
+) -> Result<(), sea_orm::DbErr> {
+    audit_events::ActiveModel {
+        id: Set(Uuid::new_v4().to_string()),
+        case_id: Set(case_id.map(str::to_owned)),
+        actor: Set(actor.to_owned()),
+        action: Set("ai.execution".to_owned()),
+        entity_type: Set("ai_execution".to_owned()),
+        entity_id: Set(audit.id.clone()),
+        metadata_json: Set(Some(audit.metadata_json().to_string())),
+        created_at: Set(Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)),
+    }
+    .insert(db)
+    .await?;
+    Ok(())
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub enum AiGatewayError {
+    #[error("invalid AI provider configuration: {0}")]
+    InvalidConfiguration(String),
+    #[error("request must not be empty")]
+    EmptyRequest,
+    #[error("invalid native AI request: {0}")]
+    InvalidNativeRequest(String),
+}
+
+/// Provider adapters only produce protocol requests. A later transport layer
+/// resolves the two environment references and performs the network call.
+pub trait AiProvider: Send + Sync {
+    fn route(&self) -> ProviderRoute;
+    fn build_request(&self, request: &AiRequest) -> Result<ProviderHttpRequest, AiGatewayError>;
+}
+
+#[derive(Clone)]
+struct ProtocolProvider {
+    config: ProviderConfig,
+}
+
+impl AiProvider for ProtocolProvider {
+    fn route(&self) -> ProviderRoute {
+        route_for(&self.config)
+    }
+
+    fn build_request(&self, request: &AiRequest) -> Result<ProviderHttpRequest, AiGatewayError> {
+        if request.input.trim().is_empty() {
+            return Err(AiGatewayError::EmptyRequest);
+        }
+
+        let instructions = request.system_instruction.as_deref().unwrap_or_default();
+        let max_tokens = request
+            .requested_output_tokens
+            .min(self.config.output_limit_tokens);
+        let credential = HeaderValue::EnvironmentSecret(self.config.credential_env.clone());
+        let request = match self.config.protocol {
+            ProviderProtocol::OpenAiChatCompletions => ProviderHttpRequest {
+                method: "POST",
+                path: "/v1/chat/completions".to_owned(),
+                headers: vec![ProviderHeader {
+                    name: "authorization",
+                    value: credential,
+                }],
+                body: json!({
+                    "model": self.config.model,
+                    "messages": openai_messages(instructions, request.input.as_str()),
+                    "max_tokens": max_tokens,
+                }),
+            },
+            ProviderProtocol::OpenAiResponses => ProviderHttpRequest {
+                method: "POST",
+                path: "/v1/responses".to_owned(),
+                headers: vec![ProviderHeader {
+                    name: "authorization",
+                    value: credential,
+                }],
+                body: json!({
+                    "model": self.config.model,
+                    "input": openai_messages(instructions, request.input.as_str()),
+                    "max_output_tokens": max_tokens,
+                }),
+            },
+            ProviderProtocol::AnthropicMessages => ProviderHttpRequest {
+                method: "POST",
+                path: "/v1/messages".to_owned(),
+                headers: vec![
+                    ProviderHeader {
+                        name: "x-api-key",
+                        value: credential,
+                    },
+                    ProviderHeader {
+                        name: "anthropic-version",
+                        value: HeaderValue::Literal("2023-06-01"),
+                    },
+                ],
+                body: json!({
+                    "model": self.config.model,
+                    "system": instructions,
+                    "messages": [{ "role": "user", "content": request.input.as_str() }],
+                    "max_tokens": max_tokens,
+                }),
+            },
+            ProviderProtocol::GeminiGenerateContent => ProviderHttpRequest {
+                method: "POST",
+                path: format!("/v1beta/models/{}:generateContent", self.config.model),
+                headers: vec![ProviderHeader {
+                    name: "x-goog-api-key",
+                    value: credential,
+                }],
+                body: json!({
+                    "systemInstruction": { "parts": [{ "text": instructions }] },
+                    "contents": [{
+                        "role": "user",
+                        "parts": [{ "text": request.input.as_str() }],
+                    }],
+                    "generationConfig": { "maxOutputTokens": max_tokens },
+                }),
+            },
+        };
+        Ok(request)
+    }
+}
+
+fn openai_messages(instructions: &str, input: &str) -> Vec<Value> {
+    let mut messages = Vec::new();
+    if !instructions.is_empty() {
+        messages.push(json!({ "role": "system", "content": instructions }));
+    }
+    messages.push(json!({ "role": "user", "content": input }));
+    messages
+}
+
+#[derive(Clone)]
+pub struct AiGateway {
+    providers: Vec<RegisteredProvider>,
+}
+
+#[derive(Clone)]
+struct RegisteredProvider {
+    config: ProviderConfig,
+    provider: Arc<dyn AiProvider>,
+}
+
+impl AiGateway {
+    pub fn from_configurations(
+        configurations: Vec<ProviderConfig>,
+    ) -> Result<Self, AiGatewayError> {
+        validate_provider_configurations(&configurations)?;
+        let providers = configurations
+            .into_iter()
+            .map(|config| RegisteredProvider {
+                provider: Arc::new(ProtocolProvider {
+                    config: config.clone(),
+                }) as Arc<dyn AiProvider>,
+                config,
+            })
+            .collect();
+        Ok(Self { providers })
+    }
+
+    pub fn route(&self, request: &AiRequest) -> GatewayDecision {
+        let mut candidates: Vec<_> = self
+            .providers
+            .iter()
+            .filter_map(|registered| {
+                let route = registered.provider.route();
+                provider_is_eligible(&registered.config, request).then_some((
+                    route,
+                    registered.config.priority,
+                    registered.config.weight,
+                ))
+            })
+            .collect();
+
+        candidates.sort_by(|left, right| {
+            right
+                .1
+                .cmp(&left.1)
+                .then_with(|| right.2.cmp(&left.2))
+                .then_with(|| left.0.provider_id.cmp(&right.0.provider_id))
+        });
+
+        candidates
+            .into_iter()
+            .next()
+            .map(|(route, _, _)| GatewayDecision::Routed(route))
+            .unwrap_or_else(|| {
+                if self.providers.is_empty() {
+                    GatewayDecision::Degraded {
+                        status: DegradationStatus::RuleBased,
+                        reason: DegradationReason::NoProviderConfigured,
+                    }
+                } else {
+                    GatewayDecision::Degraded {
+                        status: DegradationStatus::ManualRequired,
+                        reason: DegradationReason::NoCompliantProvider,
+                    }
+                }
+            })
+    }
+
+    pub fn build_provider_request(
+        &self,
+        route: &ProviderRoute,
+        request: &AiRequest,
+    ) -> Result<ProviderHttpRequest, AiGatewayError> {
+        let registered = self
+            .providers
+            .iter()
+            .find(|registered| registered.provider.route().provider_id == route.provider_id)
+            .ok_or_else(|| {
+                AiGatewayError::InvalidConfiguration(
+                    "selected provider is not registered".to_owned(),
+                )
+            })?;
+        if registered.provider.route() != *route {
+            return Err(AiGatewayError::InvalidConfiguration(
+                "selected provider route does not match its registered configuration".to_owned(),
+            ));
+        }
+        if !provider_is_eligible(&registered.config, request) {
+            return Err(AiGatewayError::InvalidConfiguration(
+                "selected provider does not satisfy the request policy".to_owned(),
+            ));
+        }
+        registered.provider.build_request(request)
+    }
+
+    pub fn build_native_request(
+        &self,
+        route: &ProviderRoute,
+        request: &AiRequest,
+        endpoint: &str,
+        credential: &str,
+    ) -> Result<HttpRequest<Value>, AiGatewayError> {
+        self.build_provider_request(route, request)?
+            .into_native_request(endpoint, credential)
+    }
+}
+
+fn route_for(config: &ProviderConfig) -> ProviderRoute {
+    ProviderRoute {
+        provider_id: config.id.clone(),
+        vendor: config.vendor.clone(),
+        protocol: config.protocol,
+        model: config.model.clone(),
+        endpoint_env: config.endpoint_env.clone(),
+        credential_env: config.credential_env.clone(),
+        timeout_ms: config.timeout_ms,
+        allow_fallback: config.allow_fallback,
+    }
+}
+
+fn provider_is_eligible(config: &ProviderConfig, request: &AiRequest) -> bool {
+    !config.emergency_disabled
+        && config.capabilities.contains(&request.capability)
+        && config.allowed_data_levels.contains(&request.data_level)
+        && config.allowed_purposes.contains(&request.purpose)
+        && config.region == request.data_region
+        && request.input.chars().count() <= config.input_limit_chars
+        && request.requested_output_tokens <= config.output_limit_tokens
+}
+
+pub fn validate_provider_configurations(
+    configurations: &[ProviderConfig],
+) -> Result<(), AiGatewayError> {
+    let mut identifiers = HashSet::new();
+    for config in configurations {
+        let invalid_text = [
+            ("id", config.id.as_str()),
+            ("vendor", config.vendor.as_str()),
+            ("region", config.region.as_str()),
+            ("model", config.model.as_str()),
+        ]
+        .into_iter()
+        .find(|(_, value)| value.trim().is_empty());
+        if let Some((field, _)) = invalid_text {
+            return Err(AiGatewayError::InvalidConfiguration(format!(
+                "provider {} must not be empty",
+                field
+            )));
+        }
+        if !identifiers.insert(config.id.as_str()) {
+            return Err(AiGatewayError::InvalidConfiguration(format!(
+                "provider id {:?} is duplicated",
+                config.id
+            )));
+        }
+        if config.capabilities.is_empty()
+            || config.allowed_data_levels.is_empty()
+            || config.allowed_purposes.is_empty()
+        {
+            return Err(AiGatewayError::InvalidConfiguration(format!(
+                "provider {:?} must declare capabilities and data policy",
+                config.id
+            )));
+        }
+        if config.input_limit_chars == 0
+            || config.output_limit_tokens == 0
+            || config.timeout_ms == 0
+        {
+            return Err(AiGatewayError::InvalidConfiguration(format!(
+                "provider {:?} must declare positive input, output, and timeout limits",
+                config.id
+            )));
+        }
+        if config.weight == 0 {
+            return Err(AiGatewayError::InvalidConfiguration(format!(
+                "provider {:?} must have a non-zero weight",
+                config.id
+            )));
+        }
+        if config.allowed_data_levels.contains(&DataLevel::Sensitive)
+            && config
+                .compliance_scopes
+                .iter()
+                .all(|scope| scope.trim().is_empty())
+        {
+            return Err(AiGatewayError::InvalidConfiguration(format!(
+                "provider {:?} permits sensitive data without a compliance scope",
+                config.id
+            )));
+        }
+        for (field, value) in [
+            ("endpoint_env", config.endpoint_env.as_str()),
+            ("credential_env", config.credential_env.as_str()),
+        ] {
+            if !is_environment_variable_name(value) {
+                return Err(AiGatewayError::InvalidConfiguration(format!(
+                    "provider {:?} has an invalid {} reference",
+                    config.id, field
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn is_environment_variable_name(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte == b'_' || byte.is_ascii_uppercase() || byte.is_ascii_digit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn provider(id: &str, protocol: ProviderProtocol) -> ProviderConfig {
+        ProviderConfig {
+            id: id.to_owned(),
+            vendor: "test-vendor".to_owned(),
+            protocol,
+            region: "cn-test-1".to_owned(),
+            model: "test-model".to_owned(),
+            capabilities: vec![AiCapability::Inquiry],
+            allowed_data_levels: vec![DataLevel::Internal],
+            allowed_purposes: vec![AiPurpose::IntakeDraft],
+            input_limit_chars: 1_000,
+            output_limit_tokens: 128,
+            timeout_ms: 5_000,
+            allow_fallback: false,
+            priority: 10,
+            weight: 1,
+            emergency_disabled: false,
+            compliance_scopes: Vec::new(),
+            endpoint_env: "ANGUI_TEST_AI_ENDPOINT".to_owned(),
+            credential_env: "ANGUI_TEST_AI_KEY".to_owned(),
+        }
+    }
+
+    fn request() -> AiRequest {
+        AiRequest {
+            capability: AiCapability::Inquiry,
+            data_level: DataLevel::Internal,
+            purpose: AiPurpose::IntakeDraft,
+            data_region: "cn-test-1".to_owned(),
+            system_instruction: Some("Follow the approved template.".to_owned()),
+            input: "A simulated intake answer".to_owned(),
+            requested_output_tokens: 100,
+            template_version: "intake-v1".to_owned(),
+            input_scope_reference: "intake-session:simulated".to_owned(),
+            redaction_policy_version: "redaction-v1".to_owned(),
+        }
+    }
+
+    #[test]
+    fn routes_only_to_an_enabled_compliant_provider() {
+        let mut wrong_region = provider("wrong-region", ProviderProtocol::OpenAiResponses);
+        wrong_region.priority = 100;
+        wrong_region.region = "us-test-1".to_owned();
+        let mut disabled = provider("disabled", ProviderProtocol::AnthropicMessages);
+        disabled.priority = 90;
+        disabled.emergency_disabled = true;
+        let eligible = provider("eligible", ProviderProtocol::GeminiGenerateContent);
+        let gateway = AiGateway::from_configurations(vec![wrong_region, disabled, eligible])
+            .expect("fixtures are valid");
+
+        assert_eq!(
+            gateway.route(&request()),
+            GatewayDecision::Routed(ProviderRoute {
+                provider_id: "eligible".to_owned(),
+                vendor: "test-vendor".to_owned(),
+                protocol: ProviderProtocol::GeminiGenerateContent,
+                model: "test-model".to_owned(),
+                endpoint_env: "ANGUI_TEST_AI_ENDPOINT".to_owned(),
+                credential_env: "ANGUI_TEST_AI_KEY".to_owned(),
+                timeout_ms: 5_000,
+                allow_fallback: false,
+            })
+        );
+    }
+
+    #[test]
+    fn no_provider_configuration_uses_rule_based_degradation() {
+        let gateway =
+            AiGateway::from_configurations(Vec::new()).expect("empty configuration is valid");
+
+        assert_eq!(
+            gateway.route(&request()),
+            GatewayDecision::Degraded {
+                status: DegradationStatus::RuleBased,
+                reason: DegradationReason::NoProviderConfigured,
+            }
+        );
+    }
+
+    #[test]
+    fn validation_rejects_sensitive_provider_without_compliance_scope() {
+        let mut configuration = provider("sensitive", ProviderProtocol::OpenAiChatCompletions);
+        configuration.allowed_data_levels.push(DataLevel::Sensitive);
+
+        assert!(matches!(
+            validate_provider_configurations(&[configuration]),
+            Err(AiGatewayError::InvalidConfiguration(message))
+                if message.contains("without a compliance scope")
+        ));
+    }
+
+    #[test]
+    fn protocol_adapters_generate_the_supported_wire_formats_without_secrets() {
+        for protocol in [
+            ProviderProtocol::OpenAiChatCompletions,
+            ProviderProtocol::OpenAiResponses,
+            ProviderProtocol::AnthropicMessages,
+            ProviderProtocol::GeminiGenerateContent,
+        ] {
+            let gateway = AiGateway::from_configurations(vec![provider("format", protocol)])
+                .expect("fixture is valid");
+            let route = match gateway.route(&request()) {
+                GatewayDecision::Routed(route) => route,
+                GatewayDecision::Degraded { .. } => panic!("fixture should route"),
+            };
+            let outbound = gateway
+                .build_provider_request(&route, &request())
+                .expect("request should be serializable");
+
+            assert_eq!(outbound.method, "POST");
+            assert!(outbound
+                .headers
+                .iter()
+                .any(|header| matches!(&header.value, HeaderValue::EnvironmentSecret(name) if name == "ANGUI_TEST_AI_KEY")));
+            assert!(!outbound.body.to_string().contains("ANGUI_TEST_AI_KEY"));
+            match protocol {
+                ProviderProtocol::OpenAiChatCompletions => {
+                    assert_eq!(outbound.path, "/v1/chat/completions");
+                    assert!(outbound.body.get("messages").is_some());
+                }
+                ProviderProtocol::OpenAiResponses => {
+                    assert_eq!(outbound.path, "/v1/responses");
+                    assert!(outbound.body.get("input").is_some());
+                }
+                ProviderProtocol::AnthropicMessages => {
+                    assert_eq!(outbound.path, "/v1/messages");
+                    assert!(outbound.body.get("system").is_some());
+                }
+                ProviderProtocol::GeminiGenerateContent => {
+                    assert_eq!(outbound.path, "/v1beta/models/test-model:generateContent");
+                    assert!(outbound.body.get("systemInstruction").is_some());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn native_request_materializes_credentials_only_at_the_transport_boundary() {
+        let gateway = AiGateway::from_configurations(vec![provider(
+            "native",
+            ProviderProtocol::OpenAiResponses,
+        )])
+        .expect("fixture is valid");
+        let route = match gateway.route(&request()) {
+            GatewayDecision::Routed(route) => route,
+            GatewayDecision::Degraded { .. } => panic!("fixture should route"),
+        };
+        let native = gateway
+            .build_native_request(
+                &route,
+                &request(),
+                "https://ai.example.invalid/",
+                "simulated-runtime-secret",
+            )
+            .expect("valid runtime values should build a request");
+
+        assert_eq!(native.method(), "POST");
+        assert_eq!(native.uri(), "https://ai.example.invalid/v1/responses");
+        assert_eq!(
+            native.headers()["authorization"],
+            "Bearer simulated-runtime-secret"
+        );
+        assert!(
+            !native
+                .body()
+                .to_string()
+                .contains("simulated-runtime-secret")
+        );
+    }
+
+    #[test]
+    fn native_request_refuses_a_handcrafted_route_that_bypasses_policy_selection() {
+        let gateway = AiGateway::from_configurations(vec![provider(
+            "restricted",
+            ProviderProtocol::OpenAiResponses,
+        )])
+        .expect("fixture is valid");
+        let forged = ProviderRoute {
+            provider_id: "restricted".to_owned(),
+            vendor: "test-vendor".to_owned(),
+            protocol: ProviderProtocol::OpenAiResponses,
+            model: "different-model".to_owned(),
+            endpoint_env: "ANGUI_TEST_AI_ENDPOINT".to_owned(),
+            credential_env: "ANGUI_TEST_AI_KEY".to_owned(),
+            timeout_ms: 5_000,
+            allow_fallback: false,
+        };
+
+        assert!(matches!(
+            gateway.build_native_request(
+                &forged,
+                &request(),
+                "https://ai.example.invalid",
+                "simulated-runtime-secret",
+            ),
+            Err(AiGatewayError::InvalidConfiguration(message))
+                if message.contains("does not match")
+        ));
+    }
+
+    #[test]
+    fn execution_audit_hashes_the_input_and_never_copies_it() {
+        let request = AiRequest {
+            input: "simulated health detail that must not enter audit metadata".to_owned(),
+            ..request()
+        };
+        let gateway = AiGateway::from_configurations(vec![provider(
+            "audit-provider",
+            ProviderProtocol::OpenAiResponses,
+        )])
+        .expect("fixture is valid");
+        let decision = gateway.route(&request);
+        let audit = AiExecutionAudit::for_request(&request, &decision, AiTaskStatus::Routed);
+        let metadata = audit.metadata_json().to_string();
+
+        assert_eq!(audit.input_hash.len(), 64);
+        assert!(!metadata.contains(&request.input));
+        assert!(!metadata.contains("system_instruction"));
+        assert_eq!(audit.metadata_json()["status"], "routed");
+    }
+}

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,11 +1,12 @@
 use sea_orm::DatabaseConnection;
 
-use crate::rate_limit::LoginRateLimiter;
+use crate::{ai_gateway::AiGateway, rate_limit::LoginRateLimiter};
 
 #[derive(Clone)]
 pub struct AppState {
     pub db: DatabaseConnection,
     pub session_ttl_hours: i64,
     pub intake_answer_hard_max: usize,
+    pub ai_gateway: AiGateway,
     pub login_limiter: LoginRateLimiter,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,7 @@
 use std::env;
 
+use crate::ai_gateway::{ProviderConfig, validate_provider_configurations};
+
 #[derive(Clone, Debug)]
 pub struct Settings {
     pub host: String,
@@ -8,6 +10,7 @@ pub struct Settings {
     pub database_url: String,
     pub session_ttl_hours: i64,
     pub intake_answer_hard_max: usize,
+    pub ai_provider_configurations: Vec<ProviderConfig>,
 }
 
 impl Settings {
@@ -39,6 +42,18 @@ impl Settings {
         if !(1..=10_000).contains(&intake_answer_hard_max) {
             return Err("ANGUI_INTAKE_ANSWER_HARD_MAX must be between 1 and 10000".to_owned());
         }
+        let provider_configurations_value =
+            env::var("ANGUI_AI_PROVIDERS_JSON").unwrap_or_else(|_| "[]".to_owned());
+        let ai_provider_configurations: Vec<ProviderConfig> = serde_json::from_str(
+            &provider_configurations_value,
+        )
+        .map_err(|error| {
+            format!(
+                "ANGUI_AI_PROVIDERS_JSON must be a JSON array of provider configurations: {error}"
+            )
+        })?;
+        validate_provider_configurations(&ai_provider_configurations)
+            .map_err(|error| error.to_string())?;
 
         Ok(Self {
             host,
@@ -47,6 +62,7 @@ impl Settings {
             database_url,
             session_ttl_hours,
             intake_answer_hard_max,
+            ai_provider_configurations,
         })
     }
 
@@ -68,6 +84,7 @@ mod tests {
             database_url: "sqlite::memory:".to_owned(),
             session_ttl_hours: 8,
             intake_answer_hard_max: 2_000,
+            ai_provider_configurations: Vec::new(),
         };
 
         assert_eq!(settings.address(), ("127.0.0.1".to_owned(), 8080));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod ai_gateway;
 pub mod app_state;
 pub mod auth;
 pub mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,10 @@ use std::io;
 
 use actix_cors::Cors;
 use actix_web::{App, HttpServer, http, middleware::Logger, web};
-use angui::{app_state::AppState, config::Settings, rate_limit::LoginRateLimiter, routes};
+use angui::{
+    ai_gateway::AiGateway, app_state::AppState, config::Settings, rate_limit::LoginRateLimiter,
+    routes,
+};
 use sea_orm::Database;
 
 #[actix_web::main]
@@ -15,10 +18,13 @@ async fn main() -> io::Result<()> {
     let database = Database::connect(&settings.database_url)
         .await
         .map_err(|error| io::Error::other(format!("database connection failed: {error}")))?;
+    let ai_gateway = AiGateway::from_configurations(settings.ai_provider_configurations.clone())
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error.to_string()))?;
     let state = web::Data::new(AppState {
         db: database,
         session_ttl_hours: settings.session_ttl_hours,
         intake_answer_hard_max: settings.intake_answer_hard_max,
+        ai_gateway,
         login_limiter: LoginRateLimiter::default(),
     });
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,5 +1,6 @@
 use actix_web::{body::MessageBody, dev::ServiceResponse, http::StatusCode, test};
 use angui::{
+    ai_gateway::AiGateway,
     app_state::AppState,
     models::{
         AddCaseMemberRequest, AuthenticatedUser, CreateCaseRequest, CreateClueRequest,
@@ -42,6 +43,8 @@ impl TestContext {
             db: self.database.clone(),
             session_ttl_hours: 8,
             intake_answer_hard_max: 2_000,
+            ai_gateway: AiGateway::from_configurations(Vec::new())
+                .expect("empty AI provider configuration should be valid"),
             login_limiter: LoginRateLimiter::default(),
         }
     }


### PR DESCRIPTION
Closes #96

## 变更内容
- 新增 SDK 无关的 `AiGateway` 和 `AiProvider` 边界，注册问询、结构化提取、案情摘要、知识问答和案例整理五种能力。
- 支持 OpenAI Chat Completions、OpenAI Responses、Anthropic Messages、Gemini generateContent 四种协议，构造原生 `http::Request<serde_json::Value>`，不依赖供应商 SDK。
- 新增 `ANGUI_AI_PROVIDERS_JSON` 启动配置校验；Provider 配置只保留 endpoint/credential 的环境变量引用，拒绝缺模型、超时、数据策略、权重或敏感数据合规范围的危险配置。
- 路由同时校验能力、数据等级、用途、区域、启用状态和输入/输出限制；无 Provider 时返回 `rule_based`，无合规候选时返回 `manual_required`。
- 新增无原文审计元数据和持久化写入器，仅保存 Provider/模型、模板版本、输入范围引用与哈希、脱敏策略版本及状态。
- 补充安全配置示例和 AI Gateway 文档。

## 验收对应
- [x] 业务层仅依赖 Gateway 与统一请求；协议 JSON 位于 Provider 适配器中。
- [x] 非合规 Provider 不进入候选集；手工伪造路由也会被拒绝。
- [x] 无有效 Provider 配置返回确定性降级状态。
- [x] 配置示例不包含密钥、生产 URL 或真实案件数据；启动时验证危险配置。
- [x] 审计元数据不复制原始输入、病史、联系方式或精确位置。
- [x] 已同步配置示例与文档。

## 测试与质量检查
- [x] `cargo fmt --all -- --check`
- [x] `CARGO_TARGET_DIR=F:\bian\rsproject\Angui\target cargo check --offline`
- [x] `CARGO_TARGET_DIR=F:\bian\rsproject\Angui\target cargo check --offline --tests`
- [x] `CARGO_TARGET_DIR=F:\bian\rsproject\Angui\target cargo clippy --offline --lib --no-deps -- -D warnings`
- [ ] `cargo test --offline ai_gateway`：测试代码可通过 `cargo check --tests`，但链接测试二进制时本机磁盘空间耗尽（LNK1180 / OS error 112）；没有将其标记为通过。

## 风险与边界
- 本 PR 不发起任何外部 AI 调用，也不允许 AI 自动确认线索、发布案情或派发任务。
- 传输执行、重试、熔断、并发/预算准入和跨 Provider failover 由后续可靠性 Issue 处理。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 AI Gateway：支持多协议提供方适配、基于策略/可用性路由选择，以及确定性降级路径。
  - 引入执行审计：记录输入哈希与脱敏元数据，并持久化审计结果（不保存原始输入与敏感细节）。
- **配置**
  - 新增 `ANGUI_AI_PROVIDERS_JSON`（默认空数组）解析与启动校验，并在 `Settings` 中提供 `ai_provider_configurations`。
- **文档**
  - 新增 `AI_GATEWAY` 协议边界说明文档，并更新文档导航与环境示例注释。
- **依赖/测试**
  - 增加 HTTP 相关依赖；补充网关路由、降级、协议格式与审计行为测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->