### PR TITLE
test(cases): verify membership and lifecycle API baselines

### DIFF
--- a/tests/api/case_members_post.rs
+++ b/tests/api/case_members_post.rs
@@ -2,10 +2,10 @@ use actix_web::{
     http::{StatusCode, header},
     test,
 };
-use sea_orm::{ActiveModelTrait, Set};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set};
 use serde_json::Value;
 
-use angui::entities::{user_global_capabilities, users};
+use angui::entities::{audit_events, user_global_capabilities, users};
 
 use crate::support::{ADMIN, COMMANDER, FAMILY, LEARNER, TestContext, VOLUNTEER, assert_error};
 
@@ -34,6 +34,21 @@ async fn post_case_members_applies_invitation_role_and_duplicate_rules() {
     );
     assert_eq!(body["case_role"], "commander");
 
+    let family = context.authenticated(FAMILY).await;
+    let audit = audit_events::Entity::find()
+        .filter(audit_events::Column::CaseId.eq(&case_id))
+        .filter(audit_events::Column::Action.eq("case.member_added"))
+        .one(&context.database)
+        .await
+        .expect("member invitation audit should be readable")
+        .expect("successful invitation should be audited");
+    assert_eq!(audit.actor, family.id);
+    assert_eq!(audit.entity_type, "user");
+    let metadata: Value =
+        serde_json::from_str(audit.metadata_json.as_deref().expect("audit metadata"))
+            .expect("audit metadata should be JSON");
+    assert_eq!(metadata["case_role"], "commander");
+
     let duplicate = test::call_service(
         &app,
         test::TestRequest::post()
@@ -59,6 +74,19 @@ async fn post_case_members_applies_invitation_role_and_duplicate_rules() {
         "forbidden",
     )
     .await;
+
+    let unrelated_case_id = context.create_case().await;
+    let commander_token = context.token(COMMANDER).await;
+    let unrelated_case = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{unrelated_case_id}/members"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(serde_json::json!({ "email": VOLUNTEER, "case_role": "volunteer" }))
+            .to_request(),
+    )
+    .await;
+    assert_error(unrelated_case, StatusCode::NOT_FOUND, "not_found").await;
 }
 
 #[actix_web::test]

--- a/tests/api/case_status_patch.rs
+++ b/tests/api/case_status_patch.rs
@@ -2,9 +2,12 @@ use actix_web::{
     http::{StatusCode, header},
     test,
 };
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use serde_json::Value;
 
-use crate::support::{COMMANDER, FAMILY, TestContext, assert_error};
+use angui::entities::audit_events;
+
+use crate::support::{COMMANDER, FAMILY, TestContext, VOLUNTEER, assert_error, create_clue_json};
 
 #[actix_web::test]
 async fn patch_case_status_requires_commander_and_enforces_the_state_machine() {
@@ -13,8 +16,12 @@ async fn patch_case_status_requires_commander_and_enforces_the_state_machine() {
     context
         .add_member(&case_id, FAMILY, COMMANDER, "commander")
         .await;
+    context
+        .add_member(&case_id, COMMANDER, VOLUNTEER, "volunteer")
+        .await;
     let family_token = context.token(FAMILY).await;
     let commander_token = context.token(COMMANDER).await;
+    let volunteer_token = context.token(VOLUNTEER).await;
     let app = crate::init_api_app!(&context);
 
     let forbidden = test::call_service(
@@ -27,28 +34,31 @@ async fn patch_case_status_requires_commander_and_enforces_the_state_machine() {
     )
     .await;
     assert_error(forbidden, StatusCode::FORBIDDEN, "forbidden").await;
-    let resolved = test::call_service(
+    let volunteer_forbidden = test::call_service(
         &app,
         test::TestRequest::patch()
             .uri(&format!("/api/cases/{case_id}/status"))
-            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {volunteer_token}")))
             .set_json(serde_json::json!({ "status": "resolved" }))
             .to_request(),
     )
     .await;
-    assert_eq!(resolved.status(), StatusCode::OK);
-    let body: Value = test::read_body_json(resolved).await;
-    assert_eq!(body["status"], "resolved");
-    let closed = test::call_service(
-        &app,
-        test::TestRequest::patch()
-            .uri(&format!("/api/cases/{case_id}/status"))
-            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
-            .set_json(serde_json::json!({ "status": "closed" }))
-            .to_request(),
-    )
-    .await;
-    assert_eq!(closed.status(), StatusCode::OK);
+    assert_error(volunteer_forbidden, StatusCode::FORBIDDEN, "forbidden").await;
+
+    for expected_status in ["resolved", "active", "closed", "closed"] {
+        let response = test::call_service(
+            &app,
+            test::TestRequest::patch()
+                .uri(&format!("/api/cases/{case_id}/status"))
+                .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+                .set_json(serde_json::json!({ "status": expected_status }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(body["status"], expected_status);
+    }
     let invalid_transition = test::call_service(
         &app,
         test::TestRequest::patch()
@@ -59,4 +69,47 @@ async fn patch_case_status_requires_commander_and_enforces_the_state_machine() {
     )
     .await;
     assert_error(invalid_transition, StatusCode::CONFLICT, "conflict").await;
+
+    let closed_case_clue = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/clues"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {family_token}")))
+            .set_json(create_clue_json())
+            .to_request(),
+    )
+    .await;
+    assert_error(closed_case_clue, StatusCode::CONFLICT, "conflict").await;
+
+    let audits = audit_events::Entity::find()
+        .filter(audit_events::Column::CaseId.eq(&case_id))
+        .filter(audit_events::Column::Action.eq("case.status_changed"))
+        .all(&context.database)
+        .await
+        .expect("status audit query should succeed");
+    let transitions: Vec<Value> = audits
+        .into_iter()
+        .map(|audit| {
+            serde_json::from_str(
+                audit
+                    .metadata_json
+                    .as_deref()
+                    .expect("status audit metadata"),
+            )
+            .expect("status audit metadata should be JSON")
+        })
+        .collect();
+    for (from, to) in [
+        ("active", "resolved"),
+        ("resolved", "active"),
+        ("active", "closed"),
+        ("closed", "closed"),
+    ] {
+        assert!(
+            transitions
+                .iter()
+                .any(|metadata| metadata["from"] == from && metadata["to"] == to),
+            "missing audit transition from {from} to {to}"
+        );
+    }
 }

--- a/tests/api/cases_list_get.rs
+++ b/tests/api/cases_list_get.rs
@@ -4,14 +4,21 @@ use actix_web::{
 };
 use serde_json::Value;
 
-use crate::support::{ADMIN, COMMANDER, FAMILY, LEARNER, TestContext, assert_error};
+use crate::support::{ADMIN, COMMANDER, FAMILY, LEARNER, TestContext, VOLUNTEER, assert_error};
 
 #[actix_web::test]
 async fn get_cases_only_returns_cases_where_the_user_is_a_member() {
     let context = TestContext::new().await;
     let case_id = context.create_case().await;
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    context
+        .add_member(&case_id, COMMANDER, VOLUNTEER, "volunteer")
+        .await;
     let family_token = context.token(FAMILY).await;
     let commander_token = context.token(COMMANDER).await;
+    let volunteer_token = context.token(VOLUNTEER).await;
     let app = crate::init_api_app!(&context);
 
     let family_response = test::call_service(
@@ -26,8 +33,15 @@ async fn get_cases_only_returns_cases_where_the_user_is_a_member() {
     let family_cases: Value = test::read_body_json(family_response).await;
     assert_eq!(family_cases[0]["id"], case_id);
     assert_eq!(family_cases[0]["access_role"], "family");
+    let family_case = family_cases[0].as_object().expect("case list item object");
+    for private_field in ["health_notes", "clues", "members", "attachments", "places"] {
+        assert!(
+            !family_case.contains_key(private_field),
+            "case list must not expose {private_field}"
+        );
+    }
 
-    let absent_member = test::call_service(
+    let commander_response = test::call_service(
         &app,
         test::TestRequest::get()
             .uri("/api/cases")
@@ -35,8 +49,21 @@ async fn get_cases_only_returns_cases_where_the_user_is_a_member() {
             .to_request(),
     )
     .await;
-    let absent_cases: Value = test::read_body_json(absent_member).await;
-    assert_eq!(absent_cases, Value::Array(vec![]));
+    let commander_cases: Value = test::read_body_json(commander_response).await;
+    assert_eq!(commander_cases[0]["id"], case_id);
+    assert_eq!(commander_cases[0]["access_role"], "commander");
+
+    let volunteer_response = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/api/cases")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {volunteer_token}")))
+            .to_request(),
+    )
+    .await;
+    let volunteer_cases: Value = test::read_body_json(volunteer_response).await;
+    assert_eq!(volunteer_cases[0]["id"], case_id);
+    assert_eq!(volunteer_cases[0]["access_role"], "volunteer");
 
     let missing = test::call_service(
         &app,
@@ -50,11 +77,12 @@ async fn get_cases_only_returns_cases_where_the_user_is_a_member() {
 async fn learner_and_admin_capability_do_not_gain_case_access_without_membership() {
     let context = TestContext::new().await;
     context.create_case().await;
+    let commander_token = context.token(COMMANDER).await;
     let learner_token = context.token(LEARNER).await;
     let admin_token = context.token(ADMIN).await;
     let app = crate::init_api_app!(&context);
 
-    for token in [learner_token, admin_token] {
+    for token in [commander_token, learner_token, admin_token] {
         let response = test::call_service(
             &app,
             test::TestRequest::get()


### PR DESCRIPTION
## Summary
- expands member invitation coverage with audit and cross-case authorization assertions
- verifies case-list role projection, explicit membership, and privacy-minimal response shape
- covers all documented lifecycle transitions, non-commander denial, closed-case clue rejection, and status audit records

Closes #9
Closes #10
Closes #11

## Validation
- cargo test --workspace
- cargo clippy --workspace -- -D warnings
- git diff --check