### PR TITLE
fix(api): align intake OpenAPI contract

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1018,8 +1018,8 @@ components:
       required: [name, longitude, latitude, coordinate_system]
       properties:
         name: { type: string }
-        longitude: { type: number }
-        latitude: { type: number }
+        longitude: { type: number, minimum: -180, maximum: 180 }
+        latitude: { type: number, minimum: -90, maximum: 90 }
         coordinate_system: { type: string, description: Route estimates require gcj02; other values produce an informational assessment. }
 
     IntakeCandidateField:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -188,12 +188,16 @@ paths:
       operationId: submitIntakeSessionAnswer
       summary: Submit one intake answer and receive the next rule-based question
       description: |
-        Only the session creator can append a field that has not already been answered. The raw
-        free-text answer is stored separately from its unconfirmed draft candidate field. This
-        endpoint does not call an AI provider, so model and template_version are null; text that
-        resembles an instruction is treated only as an unconfirmed answer. Closed or confirmed
-        sessions and duplicate field submissions return 409. Raw answer content is never copied
-        into audit metadata.
+        Only the session creator can append a field that has not already been answered. Send
+        `replace: true` to correct a previously submitted field; the server retains a revision
+        record and replaces the current unconfirmed draft answer. The raw free-text answer is
+        stored separately from its unconfirmed draft candidate field. Optional `structured`
+        facts are merged into the session's structured draft and produce rule assessments; an
+        assessment can block confirmation but does not turn any draft value into a formal fact.
+        This endpoint does not call an AI provider, so model and template_version are null; text
+        that resembles an instruction is treated only as an unconfirmed answer. Closed or
+        confirmed sessions and duplicate field submissions without `replace` return 409. Raw
+        answer content is never copied into audit metadata.
       security:
         - bearerAuth: []
       x-account-types: [member]
@@ -234,7 +238,7 @@ paths:
       tags: [Intake sessions]
       operationId: getIntakeSessionProfileDraft
       summary: Get the unconfirmed profile draft for an intake session
-      description: Only the session creator can read this sensitive draft. It is assembled only from that session's family-provided answers, is explicitly marked `draft`, and is never a formal case fact.
+      description: Only the session creator can read this sensitive draft. It is assembled only from that session's family-provided answers, is explicitly marked `draft`, and is never a formal case fact. Each non-empty display field has field-level provenance and a generation time so it can be reviewed before confirmation.
       security:
         - bearerAuth: []
       x-account-types: [member]
@@ -262,7 +266,7 @@ paths:
       tags: [Intake sessions]
       operationId: confirmIntakeSession
       summary: Human-confirm a profile and create the formal case
-      description: The session creator submits family-reviewed final values. Creation of the case, elder profile, family membership, `case.created` audit event, and session link is one transaction. A successful repeat is idempotent and returns the same case.
+      description: The session creator submits family-reviewed final values. Only display_name and last_seen_location are required by the current service; all other profile fields are optional overrides. Creation of the case, elder profile, family membership, `case.created` audit event, and session link is one transaction. A successful repeat is idempotent and returns the linked case's current status.
       security:
         - bearerAuth: []
       x-account-types: [member]
@@ -275,7 +279,7 @@ paths:
               $ref: "#/components/schemas/ConfirmIntakeSessionRequest"
       responses:
         "201":
-          description: Formal active case created or returned from an idempotent confirmation
+          description: Formal case created, or the linked case returned from an idempotent confirmation retry
           content:
             application/json:
               schema:
@@ -947,6 +951,7 @@ components:
         belongings: { type: [string, "null"], minLength: 1, description: Limit is configured by the active question definition. }
         transport_ability: { type: [string, "null"], minLength: 1, description: Limit is configured by the active question definition. }
         follow_up_clues: { type: [string, "null"], minLength: 1, description: Limit is configured by the active question definition. }
+        suspicious_motive: { type: [string, "null"], minLength: 1, description: Limit is configured by the active question definition. }
 
     SubmitIntakeAnswerRequest:
       type: object
@@ -961,11 +966,66 @@ components:
           type: string
           minLength: 1
           description: Trimmed server-side and limited by both the question configuration and the independent hard cap.
+        replace:
+          type: boolean
+          default: false
+          description: Set true to correct an existing answer for this field; the current draft is replaced and its prior value is retained as a revision.
+        structured:
+          oneOf:
+            - $ref: "#/components/schemas/IntakeStructuredFacts"
+            - type: "null"
+          description: Optional structured facts merged into the session draft for rule-based assessments.
+
+    IntakeStructuredFacts:
+      type: object
+      additionalProperties: false
+      properties:
+        last_seen_at:
+          type: [string, "null"]
+          description: Expected as RFC 3339 with an explicit offset. Invalid values are retained as draft input and produce a blocking assessment rather than a request validation error.
+        last_seen_location:
+          oneOf:
+            - $ref: "#/components/schemas/IntakeLocation"
+            - type: "null"
+        follow_up_at:
+          type: [string, "null"]
+          description: Expected as RFC 3339 with an explicit offset. Invalid values produce a blocking assessment.
+        follow_up_location:
+          oneOf:
+            - $ref: "#/components/schemas/IntakeLocation"
+            - type: "null"
+        mobility:
+          type: [string, "null"]
+          description: Preferred controlled values are limited, independent, or unknown; unsupported values produce a blocking assessment.
+        transport_modes:
+          type: array
+          default: []
+          items:
+            type: string
+          description: Preferred controlled values are walking, driving, public_transit, or unknown; unsupported values produce a blocking assessment.
+        companion_status:
+          type: [string, "null"]
+          description: Preferred controlled values are alone, accompanied, or unknown; unsupported values produce a blocking assessment.
+        belongings:
+          type: array
+          default: []
+          items:
+            type: string
+
+    IntakeLocation:
+      type: object
+      additionalProperties: false
+      required: [name, longitude, latitude, coordinate_system]
+      properties:
+        name: { type: string }
+        longitude: { type: number }
+        latitude: { type: number }
+        coordinate_system: { type: string, description: Route estimates require gcj02; other values produce an informational assessment. }
 
     IntakeCandidateField:
       type: object
       additionalProperties: false
-      required: [field, value, source, status, generated_at, model, template_version]
+      required: [field, value, source, status, generated_at, model, template_version, source_text, confidence]
       properties:
         field: { type: string }
         value: { type: string, description: Unconfirmed candidate value; it is not a formal case fact. }
@@ -974,11 +1034,39 @@ components:
         generated_at: { type: string, format: date-time }
         model: { type: [string, "null"], description: Null for the current rule-based path. }
         template_version: { type: [string, "null"], description: Null for the current rule-based path. }
+        source_text: { type: string, description: Original raw answer from which the unconfirmed candidate was produced. }
+        confidence: { type: [number, "null"], minimum: 0, maximum: 1, description: Null for the current rule-based path. }
+
+    IntakeRouteEstimate:
+      type: object
+      additionalProperties: false
+      required: [distance_meters, available_seconds, minimum_seconds, basis, degraded]
+      properties:
+        distance_meters: { type: integer, minimum: 0 }
+        available_seconds: { type: integer }
+        minimum_seconds: { type: [integer, "null"], minimum: 0 }
+        basis: { type: string, description: Routing provider name or a straight-line fallback reason. }
+        degraded: { type: boolean, description: True when the estimate was produced from a fallback rather than a route provider. }
+
+    IntakeAssessment:
+      type: object
+      additionalProperties: false
+      required: [field_path, conflict_type, severity, evidence_summary, suggested_action, route_estimate]
+      properties:
+        field_path: { type: string, description: Path of the draft field that needs review. }
+        conflict_type: { type: string, description: Machine-readable rule result identifier. }
+        severity: { type: string, enum: [blocking, warning, info] }
+        evidence_summary: { type: string }
+        suggested_action: { type: string }
+        route_estimate:
+          oneOf:
+            - $ref: "#/components/schemas/IntakeRouteEstimate"
+            - type: "null"
 
     SubmitIntakeAnswerResponse:
       type: object
       additionalProperties: false
-      required: [session_id, status, raw_answer, candidate_fields, missing_fields, next_question, guidance_mode, privacy_notice, updated_at]
+      required: [session_id, status, raw_answer, candidate_fields, missing_fields, phase, completed_phase_one_fields, missing_phase_one_fields, phase_transition_ready, assessments, next_question, guidance_mode, privacy_notice, updated_at]
       properties:
         session_id: { type: string, format: uuid }
         status: { type: string, enum: [collecting, ready_for_confirmation] }
@@ -991,6 +1079,18 @@ components:
         missing_fields:
           type: array
           items: { type: string }
+        phase: { type: string, enum: [phase_one, phase_two] }
+        completed_phase_one_fields:
+          type: array
+          items: { type: string }
+        missing_phase_one_fields:
+          type: array
+          items: { type: string }
+        phase_transition_ready: { type: boolean }
+        assessments:
+          type: array
+          items:
+            $ref: "#/components/schemas/IntakeAssessment"
         next_question:
           oneOf:
             - $ref: "#/components/schemas/IntakeQuestion"
@@ -1002,21 +1102,47 @@ components:
     IntakeProfileDraft:
       type: object
       additionalProperties: false
-      required: [status, source_scope, generated_at, requires_human_confirmation, profile, missing_fields]
+      required: [status, source_scope, generated_at, requires_human_confirmation, profile, field_metadata, missing_fields, assessments, confirmation_blocked_reasons, direction_hypotheses]
       properties:
         status: { type: string, const: draft }
         source_scope: { type: string }
         generated_at: { type: string, format: date-time }
         requires_human_confirmation: { type: boolean, const: true }
         profile: { $ref: "#/components/schemas/IntakeProfileDraftFields" }
+        field_metadata:
+          type: array
+          items:
+            $ref: "#/components/schemas/IntakeProfileDraftFieldMetadata"
         missing_fields:
           type: array
           items: { type: string }
+        assessments:
+          type: array
+          items:
+            $ref: "#/components/schemas/IntakeAssessment"
+        confirmation_blocked_reasons:
+          type: array
+          items: { type: string }
+        direction_hypotheses:
+          type: array
+          items:
+            $ref: "#/components/schemas/IntakeDirectionHypothesis"
+
+    IntakeProfileDraftFieldMetadata:
+      type: object
+      additionalProperties: false
+      required: [field, source_field, source, status, generated_at]
+      properties:
+        field: { type: string, description: Display field in profile. }
+        source_field: { type: string, description: Intake answer field that supplied the display value. }
+        source: { type: string, enum: [family_provided, ai_extracted] }
+        status: { type: string, const: draft }
+        generated_at: { type: string, format: date-time }
 
     IntakeProfileDraftFields:
       type: object
       additionalProperties: false
-      required: [physical_description, clothing_description, health_notes, mobility_notes, transportation_ability, frequent_locations, last_seen_information, behavior_habits]
+      required: [physical_description, clothing_description, health_notes, mobility_notes, transportation_ability, frequent_locations, last_seen_information, behavior_habits, suspicious_motive]
       properties:
         physical_description: { type: [string, "null"] }
         clothing_description: { type: [string, "null"] }
@@ -1026,6 +1152,20 @@ components:
         frequent_locations: { type: [string, "null"] }
         last_seen_information: { type: [string, "null"] }
         behavior_habits: { type: [string, "null"] }
+        suspicious_motive: { type: [string, "null"] }
+
+    IntakeDirectionHypothesis:
+      type: object
+      additionalProperties: false
+      required: [status, source_fields, generated_at, uncertainty_notice, description]
+      properties:
+        status: { type: string, const: hypothesis }
+        source_fields:
+          type: array
+          items: { type: string }
+        generated_at: { type: string, format: date-time }
+        uncertainty_notice: { type: string }
+        description: { type: string }
 
     ConfirmIntakeSessionRequest:
       type: object
@@ -1038,7 +1178,7 @@ components:
     ConfirmedIntakeProfile:
       type: object
       additionalProperties: false
-      required: [display_name, age, gender, physical_description, clothing_description, health_notes, last_seen_at, last_seen_location]
+      required: [display_name, last_seen_location]
       properties:
         display_name: { type: string, minLength: 1, maxLength: 120 }
         age: { type: [integer, "null"], minimum: 0, maximum: 130 }
@@ -1046,7 +1186,7 @@ components:
         physical_description: { type: [string, "null"] }
         clothing_description: { type: [string, "null"] }
         health_notes: { type: [string, "null"] }
-        last_seen_at: { type: [string, "null"], format: date-time }
+        last_seen_at: { type: [string, "null"], description: Trimmed server-side but not parsed or format-validated during confirmation. }
         last_seen_location: { type: string, minLength: 1 }
 
     ConfirmIntakeSessionResponse:
@@ -1056,7 +1196,9 @@ components:
       properties:
         case_id: { type: string, format: uuid }
         case_code: { type: string }
-        status: { type: string, const: active }
+        status:
+          $ref: "#/components/schemas/CaseStatus"
+          description: Active on first confirmation; an idempotent retry returns the linked case's current status.
         confirmation_status: { type: string, const: human_confirmed }
         confirmed_at: { type: string, format: date-time }
 
@@ -1072,15 +1214,23 @@ components:
     IntakeSession:
       type: object
       additionalProperties: false
-      required: [id, status, question_set_version, initial_answers, missing_fields, next_question, guidance_mode, privacy_notice, created_at, updated_at]
+      required: [id, status, question_set_version, initial_answers, missing_fields, phase, completed_phase_one_fields, missing_phase_one_fields, phase_transition_ready, next_question, guidance_mode, privacy_notice, created_at, updated_at]
       properties:
         id: { type: string, format: uuid }
-        status: { type: string, const: collecting }
+        status: { type: string, enum: [collecting, ready_for_confirmation] }
         question_set_version: { type: integer, minimum: 1 }
         initial_answers: { $ref: "#/components/schemas/IntakeInitialAnswers" }
         missing_fields:
           type: array
           items: { type: string }
+        phase: { type: string, enum: [phase_one, phase_two] }
+        completed_phase_one_fields:
+          type: array
+          items: { type: string }
+        missing_phase_one_fields:
+          type: array
+          items: { type: string }
+        phase_transition_ready: { type: boolean }
         next_question:
           oneOf:
             - $ref: "#/components/schemas/IntakeQuestion"

--- a/src/models.rs
+++ b/src/models.rs
@@ -225,10 +225,23 @@ pub struct IntakeProfileDraft {
     pub generated_at: String,
     pub requires_human_confirmation: bool,
     pub profile: IntakeProfileDraftFields,
+    pub field_metadata: Vec<IntakeProfileDraftFieldMetadata>,
     pub missing_fields: Vec<String>,
     pub assessments: Vec<IntakeAssessment>,
     pub confirmation_blocked_reasons: Vec<String>,
     pub direction_hypotheses: Vec<IntakeDirectionHypothesis>,
+}
+
+/// Provenance for a non-empty field in an unconfirmed intake profile draft.
+/// The value itself remains in `profile`; this metadata lets clients display
+/// the draft's origin without treating it as a confirmed case fact.
+#[derive(Clone, Debug, Serialize)]
+pub struct IntakeProfileDraftFieldMetadata {
+    pub field: String,
+    pub source_field: String,
+    pub source: String,
+    pub status: String,
+    pub generated_at: String,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/src/services/intake_session_service.rs
+++ b/src/services/intake_session_service.rs
@@ -16,8 +16,9 @@ use crate::{
     models::{
         AuthenticatedUser, ConfirmIntakeSessionRequest, ConfirmIntakeSessionResponse,
         CreateCaseRequest, CreateIntakeSessionRequest, IntakeInitialAnswers, IntakePhaseProgress,
-        IntakeProfileDraft, IntakeProfileDraftFields, IntakeQuestion, IntakeSessionResponse,
-        IntakeStructuredFacts, SubmitIntakeAnswerRequest, SubmitIntakeAnswerResponse,
+        IntakeProfileDraft, IntakeProfileDraftFieldMetadata, IntakeProfileDraftFields,
+        IntakeQuestion, IntakeSessionResponse, IntakeStructuredFacts, SubmitIntakeAnswerRequest,
+        SubmitIntakeAnswerResponse,
     },
     roles::AccountType,
 };
@@ -288,6 +289,10 @@ pub async fn get_intake_profile_draft(
     require_session_creator(&session, auth)?;
     let questions = questions_for_version(db, session.question_set_version).await?;
     let answers = parse_answers(&session)?;
+    let stored_answers = intake_session_answers::Entity::find()
+        .filter(intake_session_answers::Column::SessionId.eq(session_id))
+        .all(db)
+        .await?;
     let assessments = parse_assessments(&session)?;
     let confirmation_blocked_reasons = assessments
         .iter()
@@ -311,11 +316,71 @@ pub async fn get_intake_profile_draft(
             behavior_habits: answers.behavior_habits.clone(),
             suspicious_motive: answers.suspicious_motive.clone(),
         },
+        field_metadata: profile_draft_field_metadata(&answers, &stored_answers, &session),
         missing_fields: missing_fields(&answers, &questions),
         assessments,
         confirmation_blocked_reasons,
         direction_hypotheses: direction_hypotheses(&answers, &session.updated_at),
     })
+}
+
+fn profile_draft_field_metadata(
+    answers: &IntakeInitialAnswers,
+    stored_answers: &[intake_session_answers::Model],
+    session: &intake_sessions::Model,
+) -> Vec<IntakeProfileDraftFieldMetadata> {
+    [
+        (
+            "physical_description",
+            "basic_information",
+            &answers.basic_information,
+        ),
+        ("clothing_description", "belongings", &answers.belongings),
+        ("health_notes", "health_status", &answers.health_status),
+        ("mobility_notes", "health_status", &answers.health_status),
+        (
+            "transportation_ability",
+            "transport_ability",
+            &answers.transport_ability,
+        ),
+        (
+            "frequent_locations",
+            "frequent_locations",
+            &answers.frequent_locations,
+        ),
+        ("last_seen_information", "last_seen", &answers.last_seen),
+        (
+            "behavior_habits",
+            "behavior_habits",
+            &answers.behavior_habits,
+        ),
+        (
+            "suspicious_motive",
+            "suspicious_motive",
+            &answers.suspicious_motive,
+        ),
+    ]
+    .into_iter()
+    .filter_map(|(field, source_field, value)| {
+        value.as_ref()?;
+        let stored = stored_answers
+            .iter()
+            .find(|answer| answer.field_code == source_field);
+        Some(IntakeProfileDraftFieldMetadata {
+            field: field.to_owned(),
+            source_field: source_field.to_owned(),
+            source: stored
+                .map(|answer| answer.source.clone())
+                .unwrap_or_else(|| "family_provided".to_owned()),
+            status: stored
+                .map(|answer| answer.status.clone())
+                .unwrap_or_else(|| "draft".to_owned()),
+            generated_at: stored
+                .map(|answer| answer.generated_at.clone())
+                .unwrap_or_else(|| session.created_at.clone()),
+        })
+    })
+    .collect()
 }
 
 pub async fn confirm_intake_session(

--- a/tests/api/intake_session_answers_post.rs
+++ b/tests/api/intake_session_answers_post.rs
@@ -98,6 +98,21 @@ async fn post_intake_session_answers_stores_raw_and_draft_candidate_then_returns
     assert_eq!(body["candidate_fields"][0]["status"], "draft");
     assert_eq!(body["candidate_fields"][0]["model"], Value::Null);
     assert_eq!(body["candidate_fields"][0]["template_version"], Value::Null);
+    assert_eq!(body["candidate_fields"][0]["source_text"], raw_answer);
+    assert_eq!(body["candidate_fields"][0]["confidence"], Value::Null);
+    assert_eq!(body["phase"], "phase_one");
+    assert_eq!(body["phase_transition_ready"], false);
+    assert!(
+        body["completed_phase_one_fields"]
+            .as_array()
+            .is_some_and(|fields| fields.iter().any(|field| field == "basic_information"))
+    );
+    assert!(
+        body["missing_phase_one_fields"]
+            .as_array()
+            .is_some_and(|fields| fields.iter().any(|field| field == "last_seen"))
+    );
+    assert_eq!(body["assessments"], serde_json::json!([]));
     assert_eq!(body["guidance_mode"], "rule_based");
     assert_eq!(body["next_question"]["field"], "behavior_habits");
 

--- a/tests/api/intake_session_confirm_post.rs
+++ b/tests/api/intake_session_confirm_post.rs
@@ -230,6 +230,34 @@ async fn post_confirm_creates_one_active_case_from_human_confirmed_overrides() {
 }
 
 #[actix_web::test]
+async fn post_confirm_accepts_the_two_runtime_required_profile_fields() {
+    let context = TestContext::new().await;
+    let session_id = ready_session(&context).await;
+    let token = context.token(FAMILY).await;
+    let app = crate::init_api_app!(&context);
+
+    let response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/intake-sessions/{session_id}/confirm"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .set_json(json!({
+                "human_confirmed": true,
+                "profile": {
+                    "display_name": "Minimal fictional elder",
+                    "last_seen_location": "Fictional community gate"
+                }
+            }))
+            .to_request(),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body: Value = test::read_body_json(response).await;
+    assert_eq!(body["status"], "active");
+}
+
+#[actix_web::test]
 async fn post_confirm_requires_creator_human_confirmation_and_valid_profile_without_partial_case() {
     let context = TestContext::new().await;
     let session_id = ready_session(&context).await;

--- a/tests/api/intake_session_profile_draft_get.rs
+++ b/tests/api/intake_session_profile_draft_get.rs
@@ -68,6 +68,16 @@ async fn get_profile_draft_returns_only_unconfirmed_family_source_data() {
         body["profile"]["last_seen_information"],
         "Fictional community gate; time is not yet verified."
     );
+    let health_notes_metadata = body["field_metadata"]
+        .as_array()
+        .expect("profile draft metadata must be an array")
+        .iter()
+        .find(|metadata| metadata["field"] == "health_notes")
+        .expect("health notes must include field-level draft metadata");
+    assert_eq!(health_notes_metadata["source_field"], "health_status");
+    assert_eq!(health_notes_metadata["source"], "family_provided");
+    assert_eq!(health_notes_metadata["status"], "draft");
+    assert!(health_notes_metadata["generated_at"].is_string());
     assert!(
         body["missing_fields"]
             .as_array()

--- a/tests/api/intake_sessions_create_post.rs
+++ b/tests/api/intake_sessions_create_post.rs
@@ -38,6 +38,13 @@ async fn post_intake_sessions_creates_a_family_owned_rule_guided_draft() {
     assert_eq!(body["status"], "ready_for_confirmation");
     assert_eq!(body["question_set_version"], 2);
     assert_eq!(body["guidance_mode"], "rule_based");
+    assert_eq!(body["phase"], "phase_two");
+    assert_eq!(body["phase_transition_ready"], true);
+    assert_eq!(
+        body["completed_phase_one_fields"],
+        serde_json::json!(["basic_information", "last_seen"])
+    );
+    assert_eq!(body["missing_phase_one_fields"], serde_json::json!([]));
     assert_eq!(
         body["initial_answers"]["basic_information"],
         "Fictional elder profile"

--- a/tests/api/mod.rs
+++ b/tests/api/mod.rs
@@ -15,3 +15,4 @@ mod intake_session_answers_post;
 mod intake_session_confirm_post;
 mod intake_session_profile_draft_get;
 mod intake_sessions_create_post;
+mod openapi_intake_contract;

--- a/tests/api/openapi_intake_contract.rs
+++ b/tests/api/openapi_intake_contract.rs
@@ -1,0 +1,142 @@
+use std::sync::LazyLock;
+
+static OPENAPI: LazyLock<String> =
+    LazyLock::new(|| include_str!("../../docs/openapi.yaml").replace("\r\n", "\n"));
+
+fn schema(name: &str) -> &str {
+    let marker = format!("\n    {name}:\n");
+    let (_, after_marker) = OPENAPI
+        .split_once(&marker)
+        .unwrap_or_else(|| panic!("OpenAPI schema {name} must exist"));
+    let next_schema = after_marker
+        .match_indices("\n    ")
+        .find(|(index, _)| after_marker.as_bytes().get(*index + 5) != Some(&b' '))
+        .map(|(index, _)| index)
+        .unwrap_or(after_marker.len());
+    &after_marker[..next_schema]
+}
+
+fn assert_schema_contains(name: &str, expected_fragments: &[&str]) {
+    let actual = schema(name);
+    for expected in expected_fragments {
+        assert!(
+            actual.contains(expected),
+            "OpenAPI schema {name} must declare {expected:?}"
+        );
+    }
+}
+
+#[test]
+fn intake_openapi_contract_covers_runtime_requests_and_responses() {
+    assert_schema_contains("IntakeInitialAnswers", &["suspicious_motive:"]);
+    assert_schema_contains(
+        "SubmitIntakeAnswerRequest",
+        &[
+            "replace:",
+            "default: false",
+            "structured:",
+            "#/components/schemas/IntakeStructuredFacts",
+        ],
+    );
+    assert_schema_contains(
+        "IntakeStructuredFacts",
+        &[
+            "last_seen_at:",
+            "last_seen_location:",
+            "follow_up_at:",
+            "follow_up_location:",
+            "mobility:",
+            "transport_modes:",
+            "companion_status:",
+            "belongings:",
+        ],
+    );
+    assert_schema_contains(
+        "IntakeLocation",
+        &[
+            "required: [name, longitude, latitude, coordinate_system]",
+            "longitude:",
+            "latitude:",
+        ],
+    );
+    assert_schema_contains("IntakeCandidateField", &["source_text:", "confidence:"]);
+    assert_schema_contains(
+        "IntakeSession",
+        &[
+            "phase:",
+            "completed_phase_one_fields:",
+            "missing_phase_one_fields:",
+            "phase_transition_ready:",
+            "enum: [collecting, ready_for_confirmation]",
+        ],
+    );
+    assert_schema_contains(
+        "SubmitIntakeAnswerResponse",
+        &[
+            "phase:",
+            "completed_phase_one_fields:",
+            "missing_phase_one_fields:",
+            "phase_transition_ready:",
+            "assessments:",
+            "#/components/schemas/IntakeAssessment",
+        ],
+    );
+}
+
+#[test]
+fn intake_openapi_contract_covers_draft_provenance_assessments_and_confirmation() {
+    assert_schema_contains(
+        "IntakeAssessment",
+        &[
+            "field_path:",
+            "conflict_type:",
+            "severity:",
+            "enum: [blocking, warning, info]",
+            "evidence_summary:",
+            "suggested_action:",
+            "route_estimate:",
+        ],
+    );
+    assert_schema_contains(
+        "IntakeRouteEstimate",
+        &[
+            "distance_meters:",
+            "available_seconds:",
+            "minimum_seconds:",
+            "basis:",
+            "degraded:",
+        ],
+    );
+    assert_schema_contains(
+        "IntakeProfileDraft",
+        &[
+            "field_metadata:",
+            "assessments:",
+            "confirmation_blocked_reasons:",
+            "direction_hypotheses:",
+        ],
+    );
+    assert_schema_contains(
+        "IntakeProfileDraftFieldMetadata",
+        &[
+            "field:",
+            "source_field:",
+            "source:",
+            "status:",
+            "generated_at:",
+        ],
+    );
+    assert_schema_contains("IntakeProfileDraftFields", &["suspicious_motive:"]);
+    assert_schema_contains(
+        "IntakeDirectionHypothesis",
+        &["source_fields:", "uncertainty_notice:", "description:"],
+    );
+
+    let confirmed_profile = schema("ConfirmedIntakeProfile");
+    assert!(confirmed_profile.contains("required: [display_name, last_seen_location]"));
+    assert!(!confirmed_profile.contains("format: date-time"));
+    assert_schema_contains(
+        "ConfirmIntakeSessionResponse",
+        &["#/components/schemas/CaseStatus"],
+    );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * Intake 会话现支持分阶段进度展示：phase、已完成/缺失字段、以及转换就绪标记。
  * 草稿档案新增字段级元数据（来源字段、状态、生成时间等），并补充评估与方向假设相关信息。
  * 候选字段支持展示来源文本、置信度与结构化结果；初始答案新增可疑动机字段；确认响应返回关联案件状态语义。
* **文档**
  * 更新 OpenAPI 文档，扩展与调整相关模型/接口约束（含两阶段字段与确认语义）。
* **测试**
  * 新增两阶段、草稿元数据与 OpenAPI 合约断言用例覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->