### PR TITLE
feat(frontend): complete family intake confirmation

### DIFF
--- a/frontend/src/api/intake.ts
+++ b/frontend/src/api/intake.ts
@@ -1,15 +1,42 @@
 import { apiRequest } from './client'
 
-export interface IntakeQuestion { field: string; prompt: string; required: boolean }
+export interface IntakeQuestion {
+  field: string
+  prompt: string
+  required: boolean
+}
 
 export interface IntakeSession {
   id: string
   status: 'collecting' | 'ready_for_confirmation'
   missing_fields: string[]
   phase: 'phase_one' | 'phase_two'
+  completed_phase_one_fields: string[]
   missing_phase_one_fields: string[]
   phase_transition_ready: boolean
   next_question: IntakeQuestion | null
+  guidance_mode: 'rule_based'
+  privacy_notice: string
+}
+
+export interface IntakeCandidateField {
+  field: string
+  value: string
+  source: 'family_provided' | 'ai_extracted'
+  status: 'draft'
+  generated_at: string
+  model: string | null
+  template_version: string | null
+  source_text: string
+  confidence: number | null
+}
+
+export interface IntakeRouteEstimate {
+  distance_meters: number
+  available_seconds: number
+  minimum_seconds: number | null
+  basis: string
+  degraded: boolean
 }
 
 export interface IntakeAssessment {
@@ -18,26 +45,54 @@ export interface IntakeAssessment {
   severity: 'info' | 'warning' | 'blocking'
   evidence_summary: string
   suggested_action: string
+  route_estimate: IntakeRouteEstimate | null
+}
+
+export interface SubmitIntakeAnswerResponse extends IntakeSession {
+  raw_answer: string
+  candidate_fields: IntakeCandidateField[]
+  assessments: IntakeAssessment[]
+}
+
+export interface IntakeProfileDraftFieldMetadata {
+  field: string
+  source_field: string
+  source: 'family_provided' | 'ai_extracted'
+  status: 'draft'
+  generated_at: string
+}
+
+export interface IntakeDraftProfile {
+  physical_description: string | null
+  clothing_description: string | null
+  health_notes: string | null
+  mobility_notes: string | null
+  transportation_ability: string | null
+  frequent_locations: string | null
+  last_seen_information: string | null
+  behavior_habits: string | null
+  suspicious_motive: string | null
+}
+
+export interface IntakeDirectionHypothesis {
+  status: 'hypothesis'
+  description: string
+  uncertainty_notice: string
+  source_fields: string[]
+  generated_at: string
 }
 
 export interface IntakeDraft {
   status: 'draft'
+  source_scope: string
+  generated_at: string
   requires_human_confirmation: true
-  profile: {
-    physical_description: string | null
-    clothing_description: string | null
-    health_notes: string | null
-    mobility_notes: string | null
-    transportation_ability: string | null
-    frequent_locations: string | null
-    last_seen_information: string | null
-    behavior_habits: string | null
-    suspicious_motive: string | null
-  }
+  profile: IntakeDraftProfile
+  field_metadata: IntakeProfileDraftFieldMetadata[]
   missing_fields: string[]
   assessments: IntakeAssessment[]
   confirmation_blocked_reasons: string[]
-  direction_hypotheses: Array<{ description: string; uncertainty_notice: string; source_fields: string[] }>
+  direction_hypotheses: IntakeDirectionHypothesis[]
 }
 
 export interface ConfirmedIntakeProfile {
@@ -51,20 +106,42 @@ export interface ConfirmedIntakeProfile {
   last_seen_location: string
 }
 
-export interface ConfirmIntakeResponse { case_id: string; case_code: string; status: 'active'; confirmation_status: 'human_confirmed'; confirmed_at: string }
+export interface ConfirmIntakeResponse {
+  case_id: string
+  case_code: string
+  status: 'active' | 'resolved' | 'closed'
+  confirmation_status: 'human_confirmed'
+  confirmed_at: string
+}
 
 export function createIntakeSession(token: string): Promise<IntakeSession> {
   return apiRequest<IntakeSession>('/intake-sessions', { method: 'POST', body: JSON.stringify({}) }, token)
 }
 
-export function submitIntakeAnswer(token: string, sessionId: string, field: string, answer: string): Promise<IntakeSession & { assessments: IntakeAssessment[] }> {
-  return apiRequest<IntakeSession & { assessments: IntakeAssessment[] }>(`/intake-sessions/${sessionId}/answers`, { method: 'POST', body: JSON.stringify({ field, answer }) }, token)
+export function submitIntakeAnswer(
+  token: string,
+  sessionId: string,
+  payload: { field: string; answer: string; replace?: boolean },
+): Promise<SubmitIntakeAnswerResponse> {
+  return apiRequest<SubmitIntakeAnswerResponse>(
+    `/intake-sessions/${sessionId}/answers`,
+    { method: 'POST', body: JSON.stringify(payload) },
+    token,
+  )
 }
 
 export function getIntakeDraft(token: string, sessionId: string): Promise<IntakeDraft> {
   return apiRequest<IntakeDraft>(`/intake-sessions/${sessionId}/profile-draft`, {}, token)
 }
 
-export function confirmIntakeSession(token: string, sessionId: string, profile: ConfirmedIntakeProfile): Promise<ConfirmIntakeResponse> {
-  return apiRequest<ConfirmIntakeResponse>(`/intake-sessions/${sessionId}/confirm`, { method: 'POST', body: JSON.stringify({ human_confirmed: true, profile }) }, token)
+export function confirmIntakeSession(
+  token: string,
+  sessionId: string,
+  profile: ConfirmedIntakeProfile,
+): Promise<ConfirmIntakeResponse> {
+  return apiRequest<ConfirmIntakeResponse>(
+    `/intake-sessions/${sessionId}/confirm`,
+    { method: 'POST', body: JSON.stringify({ human_confirmed: true, profile }) },
+    token,
+  )
 }

--- a/frontend/src/pages/FamilyIntakeForm.test.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.test.tsx
@@ -1,0 +1,154 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { IntakeDraft, IntakeSession, SubmitIntakeAnswerResponse } from '../api/intake'
+import { FamilyIntakeForm } from './FamilyIntakeForm'
+
+const mocked = vi.hoisted(() => ({
+  confirmIntakeSession: vi.fn(),
+  createIntakeSession: vi.fn(),
+  getIntakeDraft: vi.fn(),
+  submitIntakeAnswer: vi.fn(),
+}))
+
+vi.mock('../auth/useAuth', () => ({
+  useAuth: () => ({ token: 'family-session', user: { id: 'family-1' } }),
+}))
+
+vi.mock('../api/intake', () => ({
+  confirmIntakeSession: (...args: unknown[]) => mocked.confirmIntakeSession(...args),
+  createIntakeSession: (...args: unknown[]) => mocked.createIntakeSession(...args),
+  getIntakeDraft: (...args: unknown[]) => mocked.getIntakeDraft(...args),
+  submitIntakeAnswer: (...args: unknown[]) => mocked.submitIntakeAnswer(...args),
+}))
+
+const collectingSession: IntakeSession = {
+  id: 'intake-1',
+  status: 'collecting',
+  missing_fields: ['last_seen'],
+  phase: 'phase_one',
+  completed_phase_one_fields: ['basic_information'],
+  missing_phase_one_fields: ['last_seen'],
+  phase_transition_ready: false,
+  next_question: { field: 'last_seen', prompt: '请描述最后出现的地点和时间', required: true },
+  guidance_mode: 'rule_based',
+  privacy_notice: '仅用于本次问询。',
+}
+
+const readySession: IntakeSession = {
+  ...collectingSession,
+  status: 'ready_for_confirmation',
+  completed_phase_one_fields: ['basic_information', 'health_status', 'behavior_habits', 'last_seen'],
+  missing_phase_one_fields: [],
+  phase_transition_ready: true,
+  next_question: null,
+}
+
+const profileDraft: IntakeDraft = {
+  status: 'draft',
+  source_scope: 'family_provided intake answers from this session only',
+  generated_at: '2026-07-25T08:00:00Z',
+  requires_human_confirmation: true,
+  profile: {
+    physical_description: '佩戴眼镜，穿蓝色外套。',
+    clothing_description: null,
+    health_notes: '行动较慢，需要留意。',
+    mobility_notes: '行动较慢，需要留意。',
+    transportation_ability: null,
+    frequent_locations: null,
+    last_seen_information: '模拟社区北门',
+    behavior_habits: null,
+    suspicious_motive: null,
+  },
+  field_metadata: [
+    { field: 'physical_description', source_field: 'basic_information', source: 'family_provided', status: 'draft', generated_at: '2026-07-25T08:00:00Z' },
+    { field: 'health_notes', source_field: 'health_status', source: 'family_provided', status: 'draft', generated_at: '2026-07-25T08:01:00Z' },
+    { field: 'last_seen_information', source_field: 'last_seen', source: 'family_provided', status: 'draft', generated_at: '2026-07-25T08:02:00Z' },
+  ],
+  missing_fields: [],
+  assessments: [],
+  confirmation_blocked_reasons: [],
+  direction_hypotheses: [],
+}
+
+function answerResponse(session: IntakeSession): SubmitIntakeAnswerResponse {
+  return {
+    ...session,
+    raw_answer: '模拟社区北门',
+    candidate_fields: [{
+      field: 'last_seen',
+      value: '模拟社区北门',
+      source: 'family_provided',
+      status: 'draft',
+      generated_at: '2026-07-25T08:02:00Z',
+      model: null,
+      template_version: null,
+      source_text: '模拟社区北门',
+      confidence: null,
+    }],
+    assessments: [],
+  }
+}
+
+describe('FamilyIntakeForm', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  it('restores the current-tab draft and does not create a second intake session', async () => {
+    window.sessionStorage.setItem('angui:intake-tab-draft:family-1', JSON.stringify({ session: collectingSession, answer: '尚未提交的地点描述' }))
+
+    render(<FamilyIntakeForm onCancel={vi.fn()} onConfirmed={vi.fn().mockResolvedValue(undefined)} />)
+
+    expect(await screen.findByRole('heading', { name: '最后出现情况' })).toBeInTheDocument()
+    expect(screen.getByDisplayValue('尚未提交的地点描述')).toBeInTheDocument()
+    expect(mocked.createIntakeSession).not.toHaveBeenCalled()
+  })
+
+  it('shows field-level provenance and sends a replacement when the family corrects a draft answer', async () => {
+    mocked.createIntakeSession.mockResolvedValue(collectingSession)
+    mocked.submitIntakeAnswer.mockResolvedValue(answerResponse(readySession))
+    mocked.getIntakeDraft.mockResolvedValue(profileDraft)
+
+    render(<FamilyIntakeForm onCancel={vi.fn()} onConfirmed={vi.fn().mockResolvedValue(undefined)} />)
+
+    fireEvent.click(screen.getByRole('button', { name: '开始问询' }))
+    await screen.findByRole('heading', { name: '最后出现情况' })
+    fireEvent.change(screen.getByRole('textbox', { name: /请描述最后出现的地点和时间/ }), { target: { value: '模拟社区北门' } })
+    fireEvent.click(screen.getByRole('button', { name: '保存并继续' }))
+
+    expect(await screen.findByText('问询整理出的画像草稿')).toBeInTheDocument()
+    expect(screen.getByText('来源：家属提供 · 健康情况')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '修改健康情况' }))
+    const editInput = screen.getByRole('textbox', { name: '修订后的家属回答' })
+    fireEvent.change(editInput, { target: { value: '家属已核对：行动不受限。' } })
+    fireEvent.click(screen.getByRole('button', { name: '保存修订并刷新草稿' }))
+
+    await waitFor(() => expect(mocked.submitIntakeAnswer).toHaveBeenLastCalledWith(
+      'family-session',
+      'intake-1',
+      { field: 'health_status', answer: '家属已核对：行动不受限。', replace: true },
+    ))
+  })
+
+  it('requires an explicit second confirmation before it creates a case', async () => {
+    window.sessionStorage.setItem('angui:intake-tab-draft:family-1', JSON.stringify({ session: readySession, answer: '' }))
+    mocked.getIntakeDraft.mockResolvedValue(profileDraft)
+    mocked.confirmIntakeSession.mockResolvedValue({ case_id: 'case-1', case_code: 'AG-0001', status: 'active', confirmation_status: 'human_confirmed', confirmed_at: '2026-07-25T08:10:00Z' })
+    const onConfirmed = vi.fn().mockResolvedValue(undefined)
+
+    render(<FamilyIntakeForm onCancel={vi.fn()} onConfirmed={onConfirmed} />)
+
+    await screen.findByText('确认后写入案件的资料')
+    fireEvent.change(screen.getByRole('textbox', { name: '姓名或称呼' }), { target: { value: '模拟老人' } })
+    fireEvent.click(screen.getByRole('button', { name: '人工确认并创建案件' }))
+
+    expect(mocked.confirmIntakeSession).not.toHaveBeenCalled()
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '确认并创建案件' }))
+    await waitFor(() => expect(mocked.confirmIntakeSession).toHaveBeenCalledTimes(1))
+    expect(onConfirmed).toHaveBeenCalledWith('case-1', 'AG-0001')
+  })
+})

--- a/frontend/src/pages/FamilyIntakeForm.test.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.test.tsx
@@ -146,6 +146,7 @@ describe('FamilyIntakeForm', () => {
 
     expect(mocked.confirmIntakeSession).not.toHaveBeenCalled()
     expect(screen.getByRole('alertdialog')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '请完成二次确认' })).toBeDisabled()
 
     fireEvent.click(screen.getByRole('button', { name: '确认并创建案件' }))
     await waitFor(() => expect(mocked.confirmIntakeSession).toHaveBeenCalledTimes(1))

--- a/frontend/src/pages/FamilyIntakeForm.test.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.test.tsx
@@ -116,13 +116,11 @@ describe('FamilyIntakeForm', () => {
     expect(window.sessionStorage.getItem('angui:intake-tab-draft:family-1')).toBeNull()
   })
 
-  it('discards cached sessions with invalid enums or next-question structures', async () => {
-    const malformedSession = {
-      ...collectingSession,
-      status: 'stale',
-      phase: 'unknown_phase',
-      next_question: { field: 'last_seen', prompt: 'Missing required flag' },
-    }
+  it.each([
+    ['an invalid status', { ...collectingSession, status: 'stale' }],
+    ['an invalid phase', { ...collectingSession, phase: 'unknown_phase' }],
+    ['a malformed next question', { ...collectingSession, next_question: { field: 'last_seen', prompt: 'Missing required flag' } }],
+  ])('discards cached sessions with %s', async (_description, malformedSession) => {
     window.sessionStorage.setItem('angui:intake-tab-draft:family-1', JSON.stringify({ session: malformedSession, answer: '' }))
 
     render(<FamilyIntakeForm onCancel={vi.fn()} onConfirmed={vi.fn().mockResolvedValue(undefined)} />)
@@ -131,15 +129,16 @@ describe('FamilyIntakeForm', () => {
     expect(window.sessionStorage.getItem('angui:intake-tab-draft:family-1')).toBeNull()
   })
 
-  it('clears an expired ready-for-confirmation session when its draft is unavailable', async () => {
+  it.each([403, 404])('clears a %i unavailable ready-for-confirmation session', async (status) => {
     window.sessionStorage.setItem('angui:intake-tab-draft:family-1', JSON.stringify({ session: readySession, answer: '' }))
-    mocked.getIntakeDraft.mockRejectedValue(new ApiClientError(404, 'not_found', 'Draft is no longer available'))
+    const message = `Draft is no longer available (${status})`
+    mocked.getIntakeDraft.mockRejectedValue(new ApiClientError(status, status === 403 ? 'forbidden' : 'not_found', message))
 
     render(<FamilyIntakeForm onCancel={vi.fn()} onConfirmed={vi.fn().mockResolvedValue(undefined)} />)
 
     expect(await screen.findByRole('button', { name: '开始问询' })).toBeInTheDocument()
     expect(window.sessionStorage.getItem('angui:intake-tab-draft:family-1')).toBeNull()
-    expect(screen.getByText('Draft is no longer available')).toBeInTheDocument()
+    expect(screen.getByText(message)).toBeInTheDocument()
   })
 
   it('shows field-level provenance and sends a replacement when the family corrects a draft answer', async () => {

--- a/frontend/src/pages/FamilyIntakeForm.test.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { IntakeDraft, IntakeSession, SubmitIntakeAnswerResponse } from '../api/intake'
+import { ApiClientError } from '../api/client'
 import { FamilyIntakeForm } from './FamilyIntakeForm'
 
 const mocked = vi.hoisted(() => ({
@@ -113,6 +114,32 @@ describe('FamilyIntakeForm', () => {
 
     expect(await screen.findByRole('button', { name: '开始问询' })).toBeInTheDocument()
     expect(window.sessionStorage.getItem('angui:intake-tab-draft:family-1')).toBeNull()
+  })
+
+  it('discards cached sessions with invalid enums or next-question structures', async () => {
+    const malformedSession = {
+      ...collectingSession,
+      status: 'stale',
+      phase: 'unknown_phase',
+      next_question: { field: 'last_seen', prompt: 'Missing required flag' },
+    }
+    window.sessionStorage.setItem('angui:intake-tab-draft:family-1', JSON.stringify({ session: malformedSession, answer: '' }))
+
+    render(<FamilyIntakeForm onCancel={vi.fn()} onConfirmed={vi.fn().mockResolvedValue(undefined)} />)
+
+    expect(await screen.findByRole('button', { name: '开始问询' })).toBeInTheDocument()
+    expect(window.sessionStorage.getItem('angui:intake-tab-draft:family-1')).toBeNull()
+  })
+
+  it('clears an expired ready-for-confirmation session when its draft is unavailable', async () => {
+    window.sessionStorage.setItem('angui:intake-tab-draft:family-1', JSON.stringify({ session: readySession, answer: '' }))
+    mocked.getIntakeDraft.mockRejectedValue(new ApiClientError(404, 'not_found', 'Draft is no longer available'))
+
+    render(<FamilyIntakeForm onCancel={vi.fn()} onConfirmed={vi.fn().mockResolvedValue(undefined)} />)
+
+    expect(await screen.findByRole('button', { name: '开始问询' })).toBeInTheDocument()
+    expect(window.sessionStorage.getItem('angui:intake-tab-draft:family-1')).toBeNull()
+    expect(screen.getByText('Draft is no longer available')).toBeInTheDocument()
   })
 
   it('shows field-level provenance and sends a replacement when the family corrects a draft answer', async () => {

--- a/frontend/src/pages/FamilyIntakeForm.test.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.test.tsx
@@ -105,6 +105,16 @@ describe('FamilyIntakeForm', () => {
     expect(mocked.createIntakeSession).not.toHaveBeenCalled()
   })
 
+  it('discards a malformed stored session before rendering the intake flow', async () => {
+    const malformedSession = { ...collectingSession, missing_phase_one_fields: undefined }
+    window.sessionStorage.setItem('angui:intake-tab-draft:family-1', JSON.stringify({ session: malformedSession, answer: 'stale answer' }))
+
+    render(<FamilyIntakeForm onCancel={vi.fn()} onConfirmed={vi.fn().mockResolvedValue(undefined)} />)
+
+    expect(await screen.findByRole('button', { name: '开始问询' })).toBeInTheDocument()
+    expect(window.sessionStorage.getItem('angui:intake-tab-draft:family-1')).toBeNull()
+  })
+
   it('shows field-level provenance and sends a replacement when the family corrects a draft answer', async () => {
     mocked.createIntakeSession.mockResolvedValue(collectingSession)
     mocked.submitIntakeAnswer.mockResolvedValue(answerResponse(readySession))
@@ -145,7 +155,8 @@ describe('FamilyIntakeForm', () => {
     fireEvent.click(screen.getByRole('button', { name: '人工确认并创建案件' }))
 
     expect(mocked.confirmIntakeSession).not.toHaveBeenCalled()
-    expect(screen.getByRole('alertdialog')).toBeInTheDocument()
+    const confirmationDialog = screen.getByRole('alertdialog')
+    expect(confirmationDialog).toHaveFocus()
     expect(screen.getByRole('button', { name: '请完成二次确认' })).toBeDisabled()
 
     fireEvent.click(screen.getByRole('button', { name: '确认并创建案件' }))

--- a/frontend/src/pages/FamilyIntakeForm.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.tsx
@@ -1,6 +1,6 @@
 import { Button, Chip, Input, Spinner, TextArea } from '@heroui/react'
 import { AlertTriangle, ArrowLeft, CheckCircle2, CircleHelp, FilePenLine, ShieldCheck } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ApiClientError } from '../api/client'
 import {
   confirmIntakeSession,
@@ -92,10 +92,15 @@ export function FamilyIntakeForm({
   const [busyAction, setBusyAction] = useState<'begin' | 'answer' | 'replace' | 'confirm' | null>(null)
   const [error, setError] = useState('')
   const [hasHydrated, setHasHydrated] = useState(false)
+  const confirmDialogRef = useRef<HTMLDivElement>(null)
 
   const isBusy = busyAction !== null
   const displayedAssessments = draft?.assessments ?? assessments
   const sourceOptions = useMemo(() => uniqueSourceOptions(draft), [draft])
+
+  useEffect(() => {
+    if (confirmReviewOpen) confirmDialogRef.current?.focus()
+  }, [confirmReviewOpen])
 
   const loadDraft = useCallback(async (sessionId: string, initializeProfile: boolean) => {
     if (!token) return null
@@ -366,7 +371,7 @@ export function FamilyIntakeForm({
               }}
             />
             {confirmReviewOpen && (
-              <div className="mt-4 rounded-md border border-brand-100 bg-brand-50 p-4" role="alertdialog" aria-labelledby="confirm-case-title">
+              <div ref={confirmDialogRef} tabIndex={-1} className="mt-4 rounded-md border border-brand-100 bg-brand-50 p-4" role="alertdialog" aria-labelledby="confirm-case-title">
                 <h4 id="confirm-case-title" className="m-0 text-sm font-bold text-slate-950">确认创建案件？</h4>
                 <p className="mb-3 mt-1 text-sm leading-6 text-slate-700">创建后将生成正式案件。问询草稿会保留为本次确认的依据，但不会替代您刚刚核对的资料。</p>
                 <div className="flex flex-wrap gap-2">
@@ -629,11 +634,24 @@ function readStoredState(storageKey: string): StoredIntakeState | null {
     const value = window.sessionStorage.getItem(storageKey)
     if (!value) return null
     const parsed = JSON.parse(value) as Partial<StoredIntakeState>
-    if (!parsed.session?.id || !parsed.session.next_question && parsed.session.status !== 'ready_for_confirmation') return null
-    return { session: parsed.session as StoredIntakeSession, answer: typeof parsed.answer === 'string' ? parsed.answer : '' }
+    const session = parsed.session
+    if (!session || typeof session.id !== 'string') return discardStoredState(storageKey)
+    if (!Array.isArray(session.missing_fields)) return discardStoredState(storageKey)
+    if (!Array.isArray(session.completed_phase_one_fields)) return discardStoredState(storageKey)
+    if (!Array.isArray(session.missing_phase_one_fields)) return discardStoredState(storageKey)
+    if (!session.next_question && (session.status !== 'ready_for_confirmation')) return discardStoredState(storageKey)
+    return {
+      session: session as StoredIntakeSession,
+      answer: typeof parsed.answer === 'string' ? parsed.answer : '',
+    }
   } catch {
-    return null
+    return discardStoredState(storageKey)
   }
+}
+
+function discardStoredState(storageKey: string): null {
+  window.sessionStorage.removeItem(storageKey)
+  return null
 }
 
 function clearStoredState(storageKey: string) {

--- a/frontend/src/pages/FamilyIntakeForm.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.tsx
@@ -113,11 +113,19 @@ export function FamilyIntakeForm({
     } catch (cause) {
       setError(messageFrom(cause))
       if (cause instanceof ApiClientError && (cause.status === 403 || cause.status === 404)) {
+        clearStoredState(storageKey)
+        setSession(null)
         setDraft(null)
+        setAssessments([])
+        setAnswer('')
+        setProfile(blankProfile)
+        setEditSource(null)
+        setEditAnswer('')
+        setConfirmReviewOpen(false)
       }
       return null
     }
-  }, [token])
+  }, [storageKey, token])
 
   useEffect(() => {
     setHasHydrated(false)
@@ -636,9 +644,18 @@ function readStoredState(storageKey: string): StoredIntakeState | null {
     const parsed = JSON.parse(value) as Partial<StoredIntakeState>
     const session = parsed.session
     if (!session || typeof session.id !== 'string') return discardStoredState(storageKey)
+    if (!['collecting', 'ready_for_confirmation'].includes(session.status)) return discardStoredState(storageKey)
+    if (!['phase_one', 'phase_two'].includes(session.phase)) return discardStoredState(storageKey)
     if (!Array.isArray(session.missing_fields)) return discardStoredState(storageKey)
     if (!Array.isArray(session.completed_phase_one_fields)) return discardStoredState(storageKey)
     if (!Array.isArray(session.missing_phase_one_fields)) return discardStoredState(storageKey)
+    if (typeof session.phase_transition_ready !== 'boolean') return discardStoredState(storageKey)
+    if (session.next_question !== null && (
+      typeof session.next_question !== 'object'
+      || typeof session.next_question.field !== 'string'
+      || typeof session.next_question.prompt !== 'string'
+      || typeof session.next_question.required !== 'boolean'
+    )) return discardStoredState(storageKey)
     if (!session.next_question && (session.status !== 'ready_for_confirmation')) return discardStoredState(storageKey)
     return {
       session: session as StoredIntakeSession,

--- a/frontend/src/pages/FamilyIntakeForm.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.tsx
@@ -186,9 +186,13 @@ export function FamilyIntakeForm({
       setSession(next)
       setAssessments(next.assessments)
       if (replace) {
+        const replacedFields = draft?.field_metadata
+          .filter((item) => item.source_field === field)
+          .map((item) => item.field) ?? []
         setEditSource(null)
         setEditAnswer('')
-        await loadDraft(next.id, false)
+        const refreshed = await loadDraft(next.id, false)
+        if (refreshed) syncProfileFields(refreshed, replacedFields)
       } else {
         setAnswer('')
         if (next.status === 'ready_for_confirmation') {

--- a/frontend/src/pages/FamilyIntakeForm.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.tsx
@@ -377,7 +377,11 @@ export function FamilyIntakeForm({
               </div>
             )}
             <div className="mt-5 flex flex-wrap gap-2">
-              <Button variant="primary" onPress={() => void confirmCase()} isDisabled={isBusy || draft.confirmation_blocked_reasons.length > 0}>
+              <Button
+                variant="primary"
+                onPress={() => void confirmCase()}
+                isDisabled={isBusy || confirmReviewOpen || draft.confirmation_blocked_reasons.length > 0}
+              >
                 {confirmReviewOpen ? '请完成二次确认' : '人工确认并创建案件'}
               </Button>
               <Button variant="ghost" onPress={requestCancel} isDisabled={isBusy}>暂不确认</Button>

--- a/frontend/src/pages/FamilyIntakeForm.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.tsx
@@ -98,17 +98,19 @@ export function FamilyIntakeForm({
   const sourceOptions = useMemo(() => uniqueSourceOptions(draft), [draft])
 
   const loadDraft = useCallback(async (sessionId: string, initializeProfile: boolean) => {
-    if (!token) return
+    if (!token) return null
     try {
       const nextDraft = await getIntakeDraft(token, sessionId)
       setDraft(nextDraft)
       setAssessments(nextDraft.assessments)
       if (initializeProfile) setProfile(profileFromDraft(nextDraft))
+      return nextDraft
     } catch (cause) {
       setError(messageFrom(cause))
       if (cause instanceof ApiClientError && (cause.status === 403 || cause.status === 404)) {
         setDraft(null)
       }
+      return null
     }
   }, [token])
 
@@ -192,7 +194,7 @@ export function FamilyIntakeForm({
         setEditSource(null)
         setEditAnswer('')
         const refreshed = await loadDraft(next.id, false)
-        if (refreshed) syncProfileFields(refreshed, replacedFields)
+        if (refreshed) setProfile((current) => syncProfileFields(current, refreshed, replacedFields))
       } else {
         setAnswer('')
         if (next.status === 'ready_for_confirmation') {
@@ -572,6 +574,27 @@ function profileFromDraft(draft: IntakeDraft): ConfirmedIntakeProfile {
     health_notes: draft.profile.health_notes,
     last_seen_location: draft.profile.last_seen_information ?? '',
   }
+}
+
+function syncProfileFields(current: ConfirmedIntakeProfile, draft: IntakeDraft, replacedFields: string[]) {
+  const next = { ...current }
+  for (const field of replacedFields) {
+    switch (field) {
+      case 'physical_description':
+        next.physical_description = draft.profile.physical_description
+        break
+      case 'clothing_description':
+        next.clothing_description = draft.profile.clothing_description
+        break
+      case 'health_notes':
+        next.health_notes = draft.profile.health_notes
+        break
+      case 'last_seen_information':
+        next.last_seen_location = draft.profile.last_seen_information ?? ''
+        break
+    }
+  }
+  return next
 }
 
 function normalizedProfile(profile: ConfirmedIntakeProfile): ConfirmedIntakeProfile {

--- a/frontend/src/pages/FamilyIntakeForm.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.tsx
@@ -1,63 +1,652 @@
-import { Button, Input, TextArea } from '@heroui/react'
-import { useState } from 'react'
-import { confirmIntakeSession, createIntakeSession, getIntakeDraft, submitIntakeAnswer } from '../api/intake'
-import type { ConfirmedIntakeProfile, IntakeAssessment, IntakeDraft, IntakeSession } from '../api/intake'
+import { Button, Chip, Input, Spinner, TextArea } from '@heroui/react'
+import { AlertTriangle, ArrowLeft, CheckCircle2, CircleHelp, FilePenLine, ShieldCheck } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { ApiClientError } from '../api/client'
+import {
+  confirmIntakeSession,
+  createIntakeSession,
+  getIntakeDraft,
+  submitIntakeAnswer,
+} from '../api/intake'
+import type {
+  ConfirmedIntakeProfile,
+  IntakeAssessment,
+  IntakeDraft,
+  IntakeDraftProfile,
+  IntakeProfileDraftFieldMetadata,
+  IntakeSession,
+} from '../api/intake'
 import { useAuth } from '../auth/useAuth'
 
-const blankProfile: ConfirmedIntakeProfile = { display_name: '', age: null, gender: null, physical_description: null, clothing_description: null, health_notes: null, last_seen_at: null, last_seen_location: '' }
+const questionLabels: Record<string, string> = {
+  basic_information: '基本信息',
+  health_status: '健康情况',
+  behavior_habits: '行为习惯',
+  last_seen: '最后出现情况',
+  frequent_locations: '常去地点',
+  suspicious_motive: '可疑动机',
+  belongings: '随身物品与衣着',
+  transport_ability: '出行能力',
+  follow_up_clues: '后续线索',
+}
 
-export function FamilyIntakeForm({ onCancel, onConfirmed }: { onCancel: () => void; onConfirmed: (caseId: string, caseCode: string) => Promise<void> }) {
-  const { token } = useAuth()
+const questionReasons: Record<string, string> = {
+  basic_information: '用于区分被寻找的人，后续仍需要家属逐项核对。',
+  health_status: '帮助现场人员理解可能需要的照护与沟通方式。',
+  behavior_habits: '帮助判断可能的行动习惯，不会自动成为正式事实。',
+  last_seen: '用于建立初始的时间和地点线索。',
+  frequent_locations: '可作为待核实的寻找方向，不会直接发布。',
+  suspicious_motive: '仅用于记录家属的待核实判断。',
+  belongings: '便于后续人工比对衣着和随身物品。',
+  transport_ability: '帮助评估可能的行动范围。',
+  follow_up_clues: '记录家属尚待核实的补充信息。',
+}
+
+const blankProfile: ConfirmedIntakeProfile = {
+  display_name: '',
+  age: null,
+  gender: null,
+  physical_description: null,
+  clothing_description: null,
+  health_notes: null,
+  last_seen_at: null,
+  last_seen_location: '',
+}
+
+type StoredIntakeSession = Pick<
+  IntakeSession,
+  | 'id'
+  | 'status'
+  | 'missing_fields'
+  | 'phase'
+  | 'completed_phase_one_fields'
+  | 'missing_phase_one_fields'
+  | 'phase_transition_ready'
+  | 'next_question'
+  | 'guidance_mode'
+  | 'privacy_notice'
+>
+
+interface StoredIntakeState {
+  session: StoredIntakeSession
+  answer: string
+}
+
+export function FamilyIntakeForm({
+  onCancel,
+  onConfirmed,
+}: {
+  onCancel: () => void
+  onConfirmed: (caseId: string, caseCode: string) => Promise<void>
+}) {
+  const { token, user } = useAuth()
+  const storageKey = `angui:intake-tab-draft:${user?.id ?? 'anonymous'}`
   const [session, setSession] = useState<IntakeSession | null>(null)
   const [draft, setDraft] = useState<IntakeDraft | null>(null)
   const [answer, setAnswer] = useState('')
   const [profile, setProfile] = useState<ConfirmedIntakeProfile>(blankProfile)
   const [assessments, setAssessments] = useState<IntakeAssessment[]>([])
-  const [busy, setBusy] = useState(false)
+  const [editSource, setEditSource] = useState<IntakeProfileDraftFieldMetadata | null>(null)
+  const [editAnswer, setEditAnswer] = useState('')
+  const [confirmReviewOpen, setConfirmReviewOpen] = useState(false)
+  const [busyAction, setBusyAction] = useState<'begin' | 'answer' | 'replace' | 'confirm' | null>(null)
   const [error, setError] = useState('')
+  const [hasHydrated, setHasHydrated] = useState(false)
+
+  const isBusy = busyAction !== null
+  const displayedAssessments = draft?.assessments ?? assessments
+  const sourceOptions = useMemo(() => uniqueSourceOptions(draft), [draft])
+
+  const loadDraft = useCallback(async (sessionId: string, initializeProfile: boolean) => {
+    if (!token) return
+    try {
+      const nextDraft = await getIntakeDraft(token, sessionId)
+      setDraft(nextDraft)
+      setAssessments(nextDraft.assessments)
+      if (initializeProfile) setProfile(profileFromDraft(nextDraft))
+    } catch (cause) {
+      setError(messageFrom(cause))
+      if (cause instanceof ApiClientError && (cause.status === 403 || cause.status === 404)) {
+        setDraft(null)
+      }
+    }
+  }, [token])
+
+  useEffect(() => {
+    setHasHydrated(false)
+    if (!token || typeof window === 'undefined') {
+      setHasHydrated(true)
+      return
+    }
+
+    const stored = readStoredState(storageKey)
+    if (stored) {
+      setSession(stored.session)
+      setAnswer(stored.answer)
+      if (stored.session.status === 'ready_for_confirmation') {
+        void loadDraft(stored.session.id, true)
+      }
+    }
+    setHasHydrated(true)
+  }, [loadDraft, storageKey, token])
+
+  useEffect(() => {
+    if (!hasHydrated || typeof window === 'undefined') return
+    if (!session) {
+      window.sessionStorage.removeItem(storageKey)
+      return
+    }
+    const stored: StoredIntakeState = {
+      session: toStoredSession(session),
+      answer,
+    }
+    window.sessionStorage.setItem(storageKey, JSON.stringify(stored))
+  }, [answer, hasHydrated, session, storageKey])
+
+  useEffect(() => {
+    if (!answer.trim() || typeof window === 'undefined') return
+    const warnBeforeLeave = (event: BeforeUnloadEvent) => {
+      event.preventDefault()
+      event.returnValue = ''
+    }
+    window.addEventListener('beforeunload', warnBeforeLeave)
+    return () => window.removeEventListener('beforeunload', warnBeforeLeave)
+  }, [answer])
 
   async function begin() {
     if (!token) return
-    setBusy(true); setError('')
-    try { setSession(await createIntakeSession(token)) } catch (cause) { setError(messageFrom(cause)) } finally { setBusy(false) }
+    setBusyAction('begin')
+    setError('')
+    try {
+      const nextSession = await createIntakeSession(token)
+      setSession(nextSession)
+      setDraft(null)
+      setAssessments([])
+      setAnswer('')
+    } catch (cause) {
+      setError(messageFrom(cause))
+    } finally {
+      setBusyAction(null)
+    }
   }
 
-  async function submitAnswer(value = answer) {
-    if (!token || !session?.next_question || !value.trim()) { setError('请填写答案，或选择“标记为未知”。'); return }
-    setBusy(true); setError('')
+  async function sendAnswer(field: string, value: string, replace = false) {
+    if (!token || !session || !value.trim()) {
+      setError('请填写答案，或选择“标记为未知”。')
+      return
+    }
+    setBusyAction(replace ? 'replace' : 'answer')
+    setError('')
     try {
-      const next = await submitIntakeAnswer(token, session.id, session.next_question.field, value.trim())
-      setSession(next); setAssessments(next.assessments); setAnswer('')
-      if (next.status === 'ready_for_confirmation') {
-        const nextDraft = await getIntakeDraft(token, session.id)
-        setDraft(nextDraft)
-        setProfile({ ...blankProfile, physical_description: nextDraft.profile.physical_description, clothing_description: nextDraft.profile.clothing_description, health_notes: nextDraft.profile.health_notes })
+      const next = await submitIntakeAnswer(token, session.id, {
+        field,
+        answer: value.trim(),
+        replace,
+      })
+      setSession(next)
+      setAssessments(next.assessments)
+      if (replace) {
+        setEditSource(null)
+        setEditAnswer('')
+        await loadDraft(next.id, false)
+      } else {
+        setAnswer('')
+        if (next.status === 'ready_for_confirmation') {
+          await loadDraft(next.id, true)
+        }
       }
-    } catch (cause) { setError(messageFrom(cause)) } finally { setBusy(false) }
+    } catch (cause) {
+      setError(messageFrom(cause))
+      if (cause instanceof ApiClientError && cause.status === 409 && session.status === 'ready_for_confirmation') {
+        await loadDraft(session.id, false)
+      }
+    } finally {
+      setBusyAction(null)
+    }
   }
 
-  async function confirm() {
+  async function submitCurrentAnswer(value = answer) {
+    if (!session?.next_question) {
+      setError('当前问询状态已变化，请刷新后继续。')
+      return
+    }
+    await sendAnswer(session.next_question.field, value)
+  }
+
+  async function confirmCase() {
     if (!token || !session || !draft) return
-    if (draft.confirmation_blocked_reasons.length > 0) { setError('存在阻断性冲突，请修改、补充说明或将相关问题标记为未知后再确认。'); return }
-    if (!profile.display_name.trim() || !profile.last_seen_location.trim()) { setError('请确认姓名/称呼和最后出现地点。'); return }
-    setBusy(true); setError('')
+    if (draft.confirmation_blocked_reasons.length > 0) {
+      setError('当前存在阻断性核对项。请返回修改相关问询内容，再重新确认。')
+      return
+    }
+    if (!profile.display_name.trim() || !profile.last_seen_location.trim()) {
+      setError('请先确认姓名或称呼，以及最后出现地点。')
+      return
+    }
+    if (!confirmReviewOpen) {
+      setConfirmReviewOpen(true)
+      return
+    }
+
+    setBusyAction('confirm')
+    setError('')
     try {
-      const response = await confirmIntakeSession(token, session.id, { ...profile, display_name: profile.display_name.trim(), last_seen_location: profile.last_seen_location.trim() })
+      const response = await confirmIntakeSession(token, session.id, normalizedProfile(profile))
       await onConfirmed(response.case_id, response.case_code)
-    } catch (cause) { setError(messageFrom(cause)) } finally { setBusy(false) }
+      clearStoredState(storageKey)
+    } catch (cause) {
+      setError(messageFrom(cause))
+      setConfirmReviewOpen(false)
+      if (cause instanceof ApiClientError && cause.status === 409) {
+        await loadDraft(session.id, false)
+      }
+    } finally {
+      setBusyAction(null)
+    }
   }
 
-  if (!session) return <section className="border-y border-slate-200 bg-white px-4 py-6 sm:px-5"><h2 className="m-0 text-base font-bold text-slate-950">开始走失求助问询</h2><p className="mb-4 mt-2 text-sm leading-6 text-slate-600">分两步收集信息。所有内容都是待确认草稿；可随时补充或标记未知，系统不会把规则整理直接当作案件事实。</p>{error && <Alert>{error}</Alert>}<div className="flex gap-2"><Button variant="primary" onPress={() => void begin()} isDisabled={busy}>{busy ? '正在开始' : '开始问询'}</Button><Button variant="ghost" onPress={onCancel}>取消</Button></div></section>
+  function openSourceEditor(source: IntakeProfileDraftFieldMetadata) {
+    const value = draft?.profile[source.field as keyof IntakeDraftProfile] ?? ''
+    setEditSource(source)
+    setEditAnswer(value ?? '')
+    setConfirmReviewOpen(false)
+    setError('')
+  }
 
-  if (draft) return <section className="border-y border-slate-200 bg-white px-4 py-6 sm:px-5"><h2 className="m-0 text-base font-bold text-slate-950">确认老人画像草稿</h2><p className="mt-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">AI/规则整理草稿，必须由家属人工确认；它不代表已核实事实。</p>{error && <Alert>{error}</Alert>}<AssessmentList items={draft.assessments} />{draft.direction_hypotheses.map((item, index) => <div key={index} className="mt-3 rounded-md border border-slate-200 p-3 text-sm"><strong>可能方向（不确定）</strong><p className="mb-1 mt-1">{item.description}</p><span className="text-xs text-slate-600">{item.uncertainty_notice}</span></div>)}<DraftContextFields profile={draft.profile} /><div className="mt-5 grid gap-3 sm:grid-cols-2"><Field label="姓名或称呼" required><Input value={profile.display_name} maxLength={120} onChange={(event) => setProfile({ ...profile, display_name: event.target.value })} fullWidth /></Field><Field label="年龄"><Input type="number" min={0} max={130} value={profile.age ?? ''} onChange={(event) => setProfile({ ...profile, age: event.target.value ? Number(event.target.value) : null })} fullWidth /></Field><Field label="性别"><Input value={profile.gender ?? ''} onChange={(event) => setProfile({ ...profile, gender: event.target.value || null })} fullWidth /></Field><Field label="最后出现地点" required><Input value={profile.last_seen_location} onChange={(event) => setProfile({ ...profile, last_seen_location: event.target.value })} fullWidth /></Field><Field label="最后出现时间"><Input type="datetime-local" onChange={(event) => setProfile({ ...profile, last_seen_at: event.target.value ? new Date(event.target.value).toISOString() : null })} fullWidth /></Field></div><div className="mt-3 grid gap-3"><Field label="体貌描述"><TextArea value={profile.physical_description ?? ''} onChange={(event) => setProfile({ ...profile, physical_description: event.target.value || null })} rows={2} fullWidth /></Field><Field label="衣着描述"><TextArea value={profile.clothing_description ?? ''} onChange={(event) => setProfile({ ...profile, clothing_description: event.target.value || null })} rows={2} fullWidth /></Field><Field label="健康注意事项"><TextArea value={profile.health_notes ?? ''} onChange={(event) => setProfile({ ...profile, health_notes: event.target.value || null })} rows={2} fullWidth /></Field></div><div className="mt-5 flex flex-wrap gap-2"><Button variant="primary" onPress={() => void confirm()} isDisabled={busy || draft.confirmation_blocked_reasons.length > 0}>{busy ? '正在创建案件' : '人工确认并创建案件'}</Button><Button variant="ghost" onPress={onCancel}>暂不确认</Button></div></section>
+  function requestCancel() {
+    if (answer.trim() && typeof window !== 'undefined') {
+      const proceed = window.confirm('当前答案尚未提交。它会仅保留在此标签页草稿中；确定暂时离开吗？')
+      if (!proceed) return
+    }
+    onCancel()
+  }
+
+  if (!session) {
+    return (
+      <section className="border-y border-slate-200 bg-white px-4 py-6 sm:px-5" aria-labelledby="intake-start-title">
+        <span className="text-xs font-semibold text-brand-700">家属建档 · 规则化问询</span>
+        <h2 id="intake-start-title" className="mt-1 text-xl font-bold text-slate-950">先整理信息，再由您确认建案</h2>
+        <p className="max-w-2xl text-sm leading-6 text-slate-600">
+          问询分阶段进行。家属提供的内容会先作为待确认草稿，系统不会将规则整理结果直接写成案件事实。
+        </p>
+        <ul className="mt-4 grid gap-2 text-sm text-slate-700 sm:grid-cols-3">
+          <li className="rounded-md bg-slate-50 px-3 py-2">1. 分步填写，随时标记未知</li>
+          <li className="rounded-md bg-slate-50 px-3 py-2">2. 查看来源与待核对项</li>
+          <li className="rounded-md bg-slate-50 px-3 py-2">3. 人工确认后才创建案件</li>
+        </ul>
+        {error && <Alert>{error}</Alert>}
+        <div className="mt-5 flex flex-wrap gap-2">
+          <Button variant="primary" onPress={() => void begin()} isDisabled={!hasHydrated || isBusy}>
+            {busyAction === 'begin' && <Spinner size="sm" aria-label="正在创建问询" />}
+            开始问询
+          </Button>
+          <Button variant="ghost" onPress={requestCancel} isDisabled={isBusy}>暂不开始</Button>
+        </div>
+      </section>
+    )
+  }
+
+  if (draft) {
+    return (
+      <section className="border-y border-slate-200 bg-white px-4 py-6 sm:px-5" aria-labelledby="intake-draft-title">
+        <header className="flex flex-col justify-between gap-3 border-b border-slate-100 pb-4 sm:flex-row sm:items-start">
+          <div>
+            <span className="text-xs font-semibold text-brand-700">第 3 步 · 人工确认</span>
+            <h2 id="intake-draft-title" className="mt-1 text-xl font-bold text-slate-950">核对老人画像草稿</h2>
+            <p className="mb-0 mt-1 text-sm leading-6 text-slate-600">每项内容均保持为草稿，只有您完成确认后才会创建正式案件。</p>
+          </div>
+          <Chip size="sm" variant="soft"><Chip.Label>需要人工确认</Chip.Label></Chip>
+        </header>
+
+        <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-3 text-sm leading-6 text-amber-950" role="status">
+          <div className="flex items-start gap-2"><ShieldCheck className="mt-0.5 shrink-0" size={17} aria-hidden="true" /><span>以下信息仅来自本次家属问询。请核对来源、时间与内容；未确认前，它们不是正式案件事实。</span></div>
+        </div>
+
+        {error && <Alert>{error}</Alert>}
+        <AssessmentList items={displayedAssessments} />
+        <DraftProfileReview draft={draft} onEditSource={openSourceEditor} />
+
+        {draft.direction_hypotheses.length > 0 && (
+          <section className="mt-5" aria-labelledby="direction-hypotheses-title">
+            <h3 id="direction-hypotheses-title" className="text-sm font-bold text-slate-950">待核实方向</h3>
+            <div className="grid gap-3 md:grid-cols-2">
+              {draft.direction_hypotheses.map((item, index) => (
+                <article key={`${item.generated_at}-${index}`} className="rounded-md border border-slate-200 bg-slate-50 p-3 text-sm">
+                  <strong className="text-slate-900">可能方向（不确定）</strong>
+                  <p className="mb-1 mt-2 leading-6 text-slate-700">{item.description}</p>
+                  <p className="m-0 text-xs leading-5 text-slate-600">{item.uncertainty_notice}</p>
+                </article>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {editSource && (
+          <section className="mt-5 rounded-md border border-brand-100 bg-brand-50 p-4" aria-labelledby="source-editor-title">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div>
+                <span className="text-xs font-semibold text-brand-700">返回问询修改</span>
+                <h3 id="source-editor-title" className="m-0 text-base font-bold text-slate-950">修改“{questionLabels[editSource.source_field] ?? editSource.source_field}”</h3>
+              </div>
+              <Button size="sm" variant="ghost" onPress={() => setEditSource(null)} isDisabled={isBusy}>取消修改</Button>
+            </div>
+            <Field label="修订后的家属回答" required>
+              <TextArea value={editAnswer} rows={4} maxLength={2000} onChange={(event) => setEditAnswer(event.target.value)} fullWidth />
+            </Field>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <Button variant="secondary" onPress={() => void sendAnswer(editSource.source_field, editAnswer, true)} isDisabled={isBusy}>
+                {busyAction === 'replace' && <Spinner size="sm" aria-label="正在保存修订" />}
+                保存修订并刷新草稿
+              </Button>
+              <Button variant="ghost" onPress={() => void sendAnswer(editSource.source_field, '未知', true)} isDisabled={isBusy}>标记为未知</Button>
+            </div>
+          </section>
+        )}
+
+        {!editSource && (
+          <section className="mt-5 border-t border-slate-200 pt-5" aria-labelledby="confirmed-profile-title">
+            <div className="flex items-start gap-2">
+              <CheckCircle2 className="mt-0.5 shrink-0 text-brand-700" size={18} aria-hidden="true" />
+              <div>
+                <h3 id="confirmed-profile-title" className="m-0 text-base font-bold text-slate-950">确认后写入案件的资料</h3>
+                <p className="mb-0 mt-1 text-sm leading-6 text-slate-600">请在这里修订正式资料。带 * 的两项为当前服务端真正必填内容。</p>
+              </div>
+            </div>
+            <ProfileForm
+              profile={profile}
+              onChange={(nextProfile) => {
+                setProfile(nextProfile)
+                setConfirmReviewOpen(false)
+              }}
+            />
+            {confirmReviewOpen && (
+              <div className="mt-4 rounded-md border border-brand-100 bg-brand-50 p-4" role="alertdialog" aria-labelledby="confirm-case-title">
+                <h4 id="confirm-case-title" className="m-0 text-sm font-bold text-slate-950">确认创建案件？</h4>
+                <p className="mb-3 mt-1 text-sm leading-6 text-slate-700">创建后将生成正式案件。问询草稿会保留为本次确认的依据，但不会替代您刚刚核对的资料。</p>
+                <div className="flex flex-wrap gap-2">
+                  <Button variant="primary" onPress={() => void confirmCase()} isDisabled={isBusy || draft.confirmation_blocked_reasons.length > 0}>
+                    {busyAction === 'confirm' && <Spinner size="sm" aria-label="正在创建案件" />}
+                    确认并创建案件
+                  </Button>
+                  <Button variant="ghost" onPress={() => setConfirmReviewOpen(false)} isDisabled={isBusy}>返回编辑</Button>
+                </div>
+              </div>
+            )}
+            <div className="mt-5 flex flex-wrap gap-2">
+              <Button variant="primary" onPress={() => void confirmCase()} isDisabled={isBusy || draft.confirmation_blocked_reasons.length > 0}>
+                {confirmReviewOpen ? '请完成二次确认' : '人工确认并创建案件'}
+              </Button>
+              <Button variant="ghost" onPress={requestCancel} isDisabled={isBusy}>暂不确认</Button>
+            </div>
+          </section>
+        )}
+
+        {!editSource && sourceOptions.length > 0 && (
+          <section className="mt-5 border-t border-slate-200 pt-4">
+            <h3 className="m-0 text-sm font-bold text-slate-950">需要补充或修改问询？</h3>
+            <p className="mb-3 mt-1 text-xs leading-5 text-slate-600">修订会作为新的草稿答案保存，并刷新当前画像与核对项。</p>
+            <div className="flex flex-wrap gap-2">
+              {sourceOptions.map((source) => (
+                <Button key={source.source_field} size="sm" variant="ghost" onPress={() => openSourceEditor(source)} isDisabled={isBusy}>
+                  <FilePenLine size={15} aria-hidden="true" /> 修改{questionLabels[source.source_field] ?? source.source_field}
+                </Button>
+              ))}
+            </div>
+          </section>
+        )}
+      </section>
+    )
+  }
 
   const question = session.next_question
-  return <section className="border-y border-slate-200 bg-white px-4 py-6 sm:px-5"><div className="flex items-center justify-between gap-3"><div><h2 className="m-0 text-base font-bold text-slate-950">{session.phase === 'phase_one' ? '第一步：基本情况与最后出现' : '第二步：地点、动机、物品与后续线索'}</h2><p className="mb-0 mt-1 text-xs text-slate-500">缺失必填项：{session.missing_fields.length ? session.missing_fields.join('、') : '无'}；保存状态：{busy ? '保存中' : '已保存'}</p></div><span className="text-xs text-slate-500">规则问询</span></div>{error && <Alert>{error}</Alert>}<AssessmentList items={assessments} />{question ? <form className="mt-4" onSubmit={(event) => { event.preventDefault(); void submitAnswer() }}><Field label={question.prompt} required={question.required}><TextArea value={answer} onChange={(event) => setAnswer(event.target.value)} rows={4} maxLength={2000} fullWidth /></Field><div className="mt-3 flex flex-wrap gap-2"><Button type="submit" variant="primary" isDisabled={busy}>{busy ? '正在保存' : '保存并继续'}</Button><Button type="button" variant="ghost" onPress={() => void submitAnswer('未知')}>标记为未知</Button><Button type="button" variant="ghost" onPress={onCancel}>取消</Button></div></form> : <p className="mt-4 text-sm text-slate-600">正在整理草稿，请稍候。</p>}</section>
+  const completed = session.completed_phase_one_fields.length
+  const phaseTotal = 4
+  const currentLabel = question ? questionLabels[question.field] ?? question.field : '正在整理草稿'
+
+  return (
+    <section className="border-y border-slate-200 bg-white px-4 py-6 sm:px-5" aria-labelledby="intake-question-title">
+      <header className="border-b border-slate-100 pb-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <span className="text-xs font-semibold text-brand-700">{session.phase === 'phase_one' ? '第 1 步 · 基本情况' : '第 2 步 · 补充线索'}</span>
+            <h2 id="intake-question-title" className="mt-1 text-xl font-bold text-slate-950">{currentLabel}</h2>
+          </div>
+          <Chip size="sm" variant="soft"><Chip.Label>{session.guidance_mode === 'rule_based' ? '规则化问询' : '问询中'}</Chip.Label></Chip>
+        </div>
+        <div className="mt-4" aria-label="问询进度">
+          <div className="flex items-center justify-between text-xs text-slate-600">
+            <span>第一阶段已填写 {completed} / {phaseTotal} 项</span>
+            <span>{session.phase_transition_ready ? '必要信息已齐全' : `仍缺：${session.missing_phase_one_fields.map(questionLabel).join('、')}`}</span>
+          </div>
+          <div className="mt-2 h-2 overflow-hidden rounded-full bg-slate-100">
+            <div className="h-full rounded-full bg-brand-600 transition-[width] duration-200 motion-reduce:transition-none" style={{ width: `${Math.min(100, (completed / phaseTotal) * 100)}%` }} />
+          </div>
+        </div>
+      </header>
+
+      {error && <Alert>{error}</Alert>}
+      <AssessmentList items={displayedAssessments} />
+
+      {question ? (
+        <form
+          className="mt-5"
+          onSubmit={(event) => {
+            event.preventDefault()
+            void submitCurrentAnswer()
+          }}
+        >
+          <Field label={question.prompt} required={question.required} hint={questionReasons[question.field]}>
+            <TextArea value={answer} onChange={(event) => setAnswer(event.target.value)} rows={5} maxLength={2000} fullWidth />
+          </Field>
+          <p className="mt-2 text-xs leading-5 text-slate-500">仅在当前浏览器标签页暂存尚未提交的答案；不会写入 URL、日志或跨设备存储。</p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Button type="submit" variant="primary" isDisabled={isBusy}>
+              {busyAction === 'answer' && <Spinner size="sm" aria-label="正在保存答案" />}
+              保存并继续
+            </Button>
+            <Button type="button" variant="ghost" onPress={() => void submitCurrentAnswer('未知')} isDisabled={isBusy}>标记为未知</Button>
+            <Button type="button" variant="ghost" onPress={requestCancel} isDisabled={isBusy}><ArrowLeft size={16} aria-hidden="true" />暂时离开</Button>
+          </div>
+        </form>
+      ) : (
+        <div className="mt-5 rounded-md border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+          <div className="flex items-center gap-2"><Spinner size="sm" /><span>问询已完成，正在获取需要人工确认的画像草稿。</span></div>
+          <Button className="mt-3" size="sm" variant="ghost" onPress={() => void loadDraft(session.id, true)} isDisabled={isBusy}>重新获取草稿</Button>
+        </div>
+      )}
+    </section>
+  )
 }
 
-function AssessmentList({ items }: { items: IntakeAssessment[] }) { return items.length ? <div className="mt-4 space-y-2">{items.map((item, index) => <div key={`${item.field_path}-${index}`} className={`rounded-md border px-3 py-2 text-sm ${item.severity === 'blocking' ? 'border-red-200 bg-red-50 text-red-800' : item.severity === 'warning' ? 'border-amber-200 bg-amber-50 text-amber-900' : 'border-blue-200 bg-blue-50 text-blue-900'}`}><strong>{item.severity === 'blocking' ? '阻断性冲突' : item.severity === 'warning' ? '请注意' : '提示'}</strong><span className="ml-2">{item.evidence_summary}</span><p className="mb-0 mt-1 text-xs">{item.suggested_action}</p></div>)}</div> : null }
-function DraftContextFields({ profile }: { profile: IntakeDraft['profile'] }) { const fields = [['行动与移动', profile.mobility_notes], ['交通能力', profile.transportation_ability], ['常去地点', profile.frequent_locations], ['最后出现补充', profile.last_seen_information], ['行为习惯', profile.behavior_habits], ['可疑动机', profile.suspicious_motive]].filter(([, value]) => value); return fields.length ? <section className="mt-4 rounded-md border border-slate-200 bg-slate-50 p-3"><h3 className="m-0 text-sm font-semibold text-slate-900">问询草稿补充</h3><p className="mb-3 mt-1 text-xs leading-5 text-slate-600">以下内容保留在问询会话中，供人工核对；当前不会自动写入已确认画像。</p><dl className="m-0 grid gap-3 sm:grid-cols-2">{fields.map(([label, value]) => <div key={label}><dt className="text-xs font-medium text-slate-600">{label}</dt><dd className="m-0 mt-1 whitespace-pre-wrap text-sm text-slate-800">{value}</dd></div>)}</dl></section> : null }
-function Field({ label, required, children }: { label: string; required?: boolean; children: React.ReactNode }) { return <label className="block"><span className="mb-1.5 block text-xs font-semibold text-slate-600">{label}{required ? ' *' : ''}</span>{children}</label> }
-function Alert({ children }: { children: React.ReactNode }) { return <div className="mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700" role="alert">{children}</div> }
-function messageFrom(cause: unknown) { return cause instanceof ApiClientError ? cause.message : cause instanceof Error ? cause.message : '操作失败，请稍后重试。' }
+function DraftProfileReview({ draft, onEditSource }: { draft: IntakeDraft; onEditSource: (source: IntakeProfileDraftFieldMetadata) => void }) {
+  const metadata = new Map(draft.field_metadata.map((item) => [item.field, item]))
+  const fields: Array<{ field: keyof IntakeDraftProfile; label: string }> = [
+    { field: 'physical_description', label: '体貌描述' },
+    { field: 'clothing_description', label: '衣着与随身物品' },
+    { field: 'health_notes', label: '健康注意事项' },
+    { field: 'mobility_notes', label: '行动与移动' },
+    { field: 'transportation_ability', label: '出行能力' },
+    { field: 'frequent_locations', label: '常去地点' },
+    { field: 'last_seen_information', label: '最后出现信息' },
+    { field: 'behavior_habits', label: '行为习惯' },
+    { field: 'suspicious_motive', label: '可疑动机' },
+  ]
+
+  return (
+    <section className="mt-5" aria-labelledby="draft-profile-title">
+      <h3 id="draft-profile-title" className="m-0 text-base font-bold text-slate-950">问询整理出的画像草稿</h3>
+      <div className="mt-3 grid gap-3 md:grid-cols-2">
+        {fields.map(({ field, label }) => {
+          const value = draft.profile[field]
+          const source = metadata.get(field)
+          return (
+            <article key={field} className="rounded-md border border-slate-200 bg-white p-4">
+              <div className="flex flex-wrap items-start justify-between gap-2">
+                <h4 className="m-0 text-sm font-bold text-slate-950">{label}</h4>
+                <Chip size="sm" variant="soft"><Chip.Label>草稿</Chip.Label></Chip>
+              </div>
+              <p className="mb-3 mt-3 min-h-12 whitespace-pre-wrap text-sm leading-6 text-slate-700">{value ?? '尚未提供'}</p>
+              {source ? (
+                <div className="border-t border-slate-100 pt-3 text-xs leading-5 text-slate-600">
+                  <span className="block">来源：{source.source === 'family_provided' ? '家属提供' : '待核实提取'} · {questionLabels[source.source_field] ?? source.source_field}</span>
+                  <span className="block">生成于：{formatDate(source.generated_at)} · 状态：需人工确认</span>
+                  <Button className="mt-2" size="sm" variant="ghost" onPress={() => onEditSource(source)}><FilePenLine size={14} aria-hidden="true" />返回修改</Button>
+                </div>
+              ) : (
+                <p className="m-0 border-t border-slate-100 pt-3 text-xs text-slate-500">暂无可核对的来源记录</p>
+              )}
+            </article>
+          )
+        })}
+      </div>
+    </section>
+  )
+}
+
+function ProfileForm({ profile, onChange }: { profile: ConfirmedIntakeProfile; onChange: (next: ConfirmedIntakeProfile) => void }) {
+  return (
+    <div className="mt-4 grid gap-3 sm:grid-cols-2">
+      <Field label="姓名或称呼" required><Input value={profile.display_name} maxLength={120} onChange={(event) => onChange({ ...profile, display_name: event.target.value })} fullWidth /></Field>
+      <Field label="最后出现地点" required><Input value={profile.last_seen_location} onChange={(event) => onChange({ ...profile, last_seen_location: event.target.value })} fullWidth /></Field>
+      <Field label="年龄"><Input type="number" min={0} max={130} value={profile.age ?? ''} onChange={(event) => onChange({ ...profile, age: event.target.value ? Number(event.target.value) : null })} fullWidth /></Field>
+      <Field label="性别"><Input value={profile.gender ?? ''} onChange={(event) => onChange({ ...profile, gender: nullable(event.target.value) })} fullWidth /></Field>
+      <Field label="最后出现时间"><Input type="datetime-local" value={toDateTimeLocal(profile.last_seen_at)} onChange={(event) => onChange({ ...profile, last_seen_at: event.target.value ? new Date(event.target.value).toISOString() : null })} fullWidth /></Field>
+      <div className="hidden sm:block" aria-hidden="true" />
+      <Field label="体貌描述"><TextArea value={profile.physical_description ?? ''} onChange={(event) => onChange({ ...profile, physical_description: nullable(event.target.value) })} rows={3} fullWidth /></Field>
+      <Field label="衣着描述"><TextArea value={profile.clothing_description ?? ''} onChange={(event) => onChange({ ...profile, clothing_description: nullable(event.target.value) })} rows={3} fullWidth /></Field>
+      <div className="sm:col-span-2"><Field label="健康注意事项"><TextArea value={profile.health_notes ?? ''} onChange={(event) => onChange({ ...profile, health_notes: nullable(event.target.value) })} rows={3} fullWidth /></Field></div>
+    </div>
+  )
+}
+
+function AssessmentList({ items }: { items: IntakeAssessment[] }) {
+  if (items.length === 0) return null
+  return (
+    <section className="mt-4 space-y-2" aria-label="规则核对结果">
+      {items.map((item, index) => (
+        <div key={`${item.field_path}-${item.conflict_type}-${index}`} className={`rounded-md border px-3 py-3 text-sm ${assessmentClass(item.severity)}`}>
+          <div className="flex items-start gap-2"><AlertTriangle className="mt-0.5 shrink-0" size={16} aria-hidden="true" /><div><strong>{assessmentLabel(item.severity)}</strong><span className="ml-2">{item.evidence_summary}</span><p className="mb-0 mt-1 text-xs leading-5">{item.suggested_action}</p></div></div>
+        </div>
+      ))}
+    </section>
+  )
+}
+
+function Field({ label, hint, required, children }: { label: string; hint?: string; required?: boolean; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span className="mb-1.5 block text-sm font-semibold text-slate-800">{label}{required ? <span aria-hidden="true"> *</span> : null}</span>
+      {hint && <span className="mb-2 flex items-start gap-1 text-xs leading-5 text-slate-500"><CircleHelp className="mt-0.5 shrink-0" size={14} aria-hidden="true" />{hint}</span>}
+      {children}
+    </label>
+  )
+}
+
+function Alert({ children }: { children: React.ReactNode }) {
+  return <div className="mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-3 text-sm leading-6 text-red-800" role="alert">{children}</div>
+}
+
+function uniqueSourceOptions(draft: IntakeDraft | null) {
+  if (!draft) return []
+  const seen = new Set<string>()
+  return draft.field_metadata.filter((item) => {
+    if (seen.has(item.source_field)) return false
+    seen.add(item.source_field)
+    return true
+  })
+}
+
+function profileFromDraft(draft: IntakeDraft): ConfirmedIntakeProfile {
+  return {
+    ...blankProfile,
+    physical_description: draft.profile.physical_description,
+    clothing_description: draft.profile.clothing_description,
+    health_notes: draft.profile.health_notes,
+    last_seen_location: draft.profile.last_seen_information ?? '',
+  }
+}
+
+function normalizedProfile(profile: ConfirmedIntakeProfile): ConfirmedIntakeProfile {
+  return {
+    ...profile,
+    display_name: profile.display_name.trim(),
+    last_seen_location: profile.last_seen_location.trim(),
+    gender: nullable(profile.gender ?? ''),
+    physical_description: nullable(profile.physical_description ?? ''),
+    clothing_description: nullable(profile.clothing_description ?? ''),
+    health_notes: nullable(profile.health_notes ?? ''),
+  }
+}
+
+function toStoredSession(session: IntakeSession): StoredIntakeSession {
+  return {
+    id: session.id,
+    status: session.status,
+    missing_fields: session.missing_fields,
+    phase: session.phase,
+    completed_phase_one_fields: session.completed_phase_one_fields,
+    missing_phase_one_fields: session.missing_phase_one_fields,
+    phase_transition_ready: session.phase_transition_ready,
+    next_question: session.next_question,
+    guidance_mode: session.guidance_mode,
+    privacy_notice: session.privacy_notice,
+  }
+}
+
+function readStoredState(storageKey: string): StoredIntakeState | null {
+  try {
+    const value = window.sessionStorage.getItem(storageKey)
+    if (!value) return null
+    const parsed = JSON.parse(value) as Partial<StoredIntakeState>
+    if (!parsed.session?.id || !parsed.session.next_question && parsed.session.status !== 'ready_for_confirmation') return null
+    return { session: parsed.session as StoredIntakeSession, answer: typeof parsed.answer === 'string' ? parsed.answer : '' }
+  } catch {
+    return null
+  }
+}
+
+function clearStoredState(storageKey: string) {
+  if (typeof window !== 'undefined') window.sessionStorage.removeItem(storageKey)
+}
+
+function questionLabel(field: string) {
+  return questionLabels[field] ?? field
+}
+
+function assessmentLabel(severity: IntakeAssessment['severity']) {
+  return severity === 'blocking' ? '需要先处理' : severity === 'warning' ? '请注意' : '提示'
+}
+
+function assessmentClass(severity: IntakeAssessment['severity']) {
+  return severity === 'blocking'
+    ? 'border-red-200 bg-red-50 text-red-800'
+    : severity === 'warning'
+      ? 'border-amber-200 bg-amber-50 text-amber-900'
+      : 'border-blue-200 bg-blue-50 text-blue-900'
+}
+
+function nullable(value: string): string | null {
+  const trimmed = value.trim()
+  return trimmed || null
+}
+
+function formatDate(value: string) {
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : new Intl.DateTimeFormat('zh-CN', { dateStyle: 'medium', timeStyle: 'short' }).format(date)
+}
+
+function toDateTimeLocal(value: string | null) {
+  if (!value) return ''
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+  const offset = date.getTimezoneOffset() * 60_000
+  return new Date(date.getTime() - offset).toISOString().slice(0, 16)
+}
+
+function messageFrom(cause: unknown) {
+  return cause instanceof ApiClientError
+    ? cause.message
+    : cause instanceof Error
+      ? cause.message
+      : '操作失败，请稍后重试。'
+}


### PR DESCRIPTION
Closes #73 and #74. Adds current-tab intake draft recovery, phased question progress, field-level draft provenance, answer replacement, explicit confirmation, and frontend regression tests. #75 already has its family place and attachment entry points on main, so it is intentionally not duplicated here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 问询与确认流程支持草稿与未提交答案本地持久化：页面恢复后自动还原，离开时可触发离开提示。
  - 支持“修订并刷新草稿”：展示字段来源/生成时间，可标记未知并更新相关字段。
  - 确认流程改为双步交互（二次确认弹层+阻断性校验，如姓名/称呼、最后出现地点），成功后清理本地缓存；新增“重新获取草稿”与冲突/不可用时的回退提示。
- **测试**
  - 新增单测覆盖草稿恢复校验、修订替换参数、字段溯源展示及二次确认触发/接口调用行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->