### PR TITLE
feat(command): restrict and verify commander workspace

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -11,7 +11,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: preview-pr-${{ github.event.workflow_run.pull_requests[0].number || github.run_id }}
+  group: >-
+    ${{ github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.pull_requests[0].number != null &&
+        format('preview-pr-{0}', github.event.workflow_run.pull_requests[0].number) ||
+        format('preview-run-{0}', github.run_id) }}
   cancel-in-progress: true
 
 jobs:
@@ -19,6 +24,7 @@ jobs:
     if: >-
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.pull_requests[0].number != null &&
       github.event.workflow_run.head_repository.full_name == github.repository &&
       vars.PREVIEW_DEPLOY_ENABLED == 'true'
     runs-on: angui-preview

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -68,13 +68,13 @@ describe('application role routing', () => {
   })
 
   it.each([
-    ['/command', ['commander'], '指挥端'],
-    ['/volunteer', ['volunteer'], '志愿者端'],
-    ['/family', [], '家属端'],
-  ] as const)('allows an operational account with %s capability to open the %s route', async (path, capabilities, workspace) => {
+    ['/command', ['commander']],
+    ['/volunteer', ['volunteer']],
+    ['/family', []],
+  ] as const)('allows an operational account with %s capability to open the workspace route', async (path, capabilities) => {
     setAuth('member', capabilities)
     renderApp(path)
-    expect(await screen.findByRole('link', { name: workspace })).toBeInTheDocument()
+    expect(await screen.findByRole('region', { name: '案件列表' })).toBeInTheDocument()
   })
 
   it.each([

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -3,11 +3,13 @@ import { MemoryRouter } from 'react-router'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import App from './App'
 import type { AuthContextValue } from './auth/auth-context'
+import type { GlobalCapability } from './api/auth'
 
 const mocked = vi.hoisted(() => ({
   auth: null as AuthContextValue | null,
   listCases: vi.fn().mockResolvedValue([]),
   getCase: vi.fn(),
+  getCaseResourceConfiguration: vi.fn(),
 }))
 
 vi.mock('./auth/useAuth', () => ({ useAuth: () => mocked.auth }))
@@ -19,14 +21,18 @@ vi.mock('./api/cases', () => ({
   addCaseMember: vi.fn(),
   reviewClue: vi.fn(),
   updateCaseStatus: vi.fn(),
+  getCaseResourceConfiguration: (...args: unknown[]) => mocked.getCaseResourceConfiguration(...args),
 }))
 vi.mock('./components/ServiceStatus', () => ({ ServiceStatus: () => <span>服务状态</span> }))
 
-function setAuth(accountType: NonNullable<AuthContextValue['user']>['account_type'] | null) {
+function setAuth(
+  accountType: NonNullable<AuthContextValue['user']>['account_type'] | null,
+  globalCapabilities: readonly GlobalCapability[] = [],
+) {
   mocked.auth = {
     token: accountType ? 'test-session' : null,
     user: accountType
-      ? { id: `${accountType}-1`, email: `${accountType}@demo.invalid`, display_name: '模拟用户', account_type: accountType, global_capabilities: [] }
+      ? { id: `${accountType}-1`, email: `${accountType}@demo.invalid`, display_name: '模拟用户', account_type: accountType, global_capabilities: [...globalCapabilities] }
       : null,
     isLoading: false,
     isLoggingOut: false,
@@ -52,26 +58,33 @@ describe('application role routing', () => {
     expect(screen.getByText('账号登录')).toBeInTheDocument()
   })
 
-  it.each(['member'] as const)(
-    'shows all case workspaces to the operational %s account',
-    async (role) => {
-    setAuth(role)
+  it('shows workspaces that match the operational account capabilities', async () => {
+    setAuth('member', ['commander', 'volunteer'])
     renderApp()
     await waitFor(() => expect(screen.getByText('行动总览')).toBeInTheDocument())
     for (const workspace of ['家属端', '指挥端', '志愿者端']) {
       expect(screen.getByRole('link', { name: workspace })).toBeInTheDocument()
     }
-    },
-  )
+  })
 
   it.each([
-    ['member', '/command', '指挥端'],
-    ['member', '/volunteer', '志愿者端'],
-    ['member', '/family', '家属端'],
-  ] as const)('allows a %s account to open the %s route when its case membership grants access', async (role, path, workspace) => {
-    setAuth(role)
+    ['/command', ['commander'], '指挥端'],
+    ['/volunteer', ['volunteer'], '志愿者端'],
+    ['/family', [], '家属端'],
+  ] as const)('allows an operational account with %s capability to open the %s route', async (path, capabilities, workspace) => {
+    setAuth('member', capabilities)
     renderApp(path)
     expect(await screen.findByRole('link', { name: workspace })).toBeInTheDocument()
+  })
+
+  it.each([
+    ['family account', [], '/command'],
+    ['volunteer account', ['volunteer'], '/command'],
+  ] as const)('redirects a %s away from the command workspace', async (_description, capabilities, path) => {
+    setAuth('member', capabilities)
+    renderApp(path)
+    expect(await screen.findByText('行动总览')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: '指挥端' })).not.toBeInTheDocument()
   })
 
   it.each(['learner'] as const)('does not imply case access for %s accounts', async (role) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,9 +7,15 @@ import { CaseWorkspacePage } from './pages/CaseWorkspacePage'
 import { DashboardPage } from './pages/DashboardPage'
 import { LoginPage } from './pages/LoginPage'
 
-function CaseRoleRoute({ children }: { children: ReactNode }) {
+function CaseRoleRoute({
+  capability,
+  children,
+}: {
+  capability?: 'commander' | 'volunteer'
+  children: ReactNode
+}) {
   const { user } = useAuth()
-  return user?.account_type === 'member'
+  return user?.account_type === 'member' && (!capability || user.global_capabilities.includes(capability))
     ? children
     : <Navigate to="/" replace />
 }
@@ -44,7 +50,7 @@ function App() {
         <Route
           path="command"
           element={
-            <CaseRoleRoute>
+            <CaseRoleRoute capability="commander">
               <CaseWorkspacePage mode="commander" />
             </CaseRoleRoute>
           }
@@ -52,7 +58,7 @@ function App() {
         <Route
           path="volunteer"
           element={
-            <CaseRoleRoute>
+            <CaseRoleRoute capability="volunteer">
               <CaseWorkspacePage mode="volunteer" />
             </CaseRoleRoute>
           }

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -12,28 +12,24 @@ import { useAuth } from '../auth/useAuth'
 import type { AccountType, GlobalCapability } from '../api/auth'
 import { ServiceStatus } from './ServiceStatus'
 
-type LegacyRole = 'family' | 'commander' | 'volunteer' | 'learner' | 'admin'
-
 interface NavigationItem {
   to: string
   label: string
   icon: typeof LayoutDashboard
   end?: boolean
-  roles: LegacyRole[]
+  capability?: 'commander' | 'volunteer'
 }
 
 const navigation: NavigationItem[] = [
-  { to: '/', label: '总览', icon: LayoutDashboard, end: true, roles: ['family', 'commander', 'volunteer', 'learner', 'admin'] },
-  { to: '/family', label: '家属端', icon: HeartHandshake, roles: ['family', 'commander', 'volunteer'] },
-  { to: '/command', label: '指挥端', icon: RadioTower, roles: ['family', 'commander', 'volunteer'] },
-  { to: '/volunteer', label: '志愿者端', icon: Navigation, roles: ['family', 'commander', 'volunteer'] },
+  { to: '/', label: '总览', icon: LayoutDashboard, end: true },
+  { to: '/family', label: '家属端', icon: HeartHandshake },
+  { to: '/command', label: '指挥端', icon: RadioTower, capability: 'commander' },
+  { to: '/volunteer', label: '志愿者端', icon: Navigation, capability: 'volunteer' },
 ]
 
-const roleLabels: Record<LegacyRole, string> = {
-  family: '家属',
+const roleLabels: Record<GlobalCapability, string> = {
   commander: '指挥',
   volunteer: '志愿者',
-  learner: '新人',
   admin: '管理员',
 }
 
@@ -44,7 +40,10 @@ function identityLabel(accountType: AccountType, capabilities: GlobalCapability[
 
 export function AppShell() {
   const { user, logout, isLoggingOut } = useAuth()
-  const visibleNavigation = navigation.filter((item) => user && (item.to === '/' || user.account_type === 'member'))
+  const visibleNavigation = navigation.filter((item) => user && (
+    item.to === '/'
+    || (user.account_type === 'member' && (!item.capability || user.global_capabilities.includes(item.capability)))
+  ))
 
   return (
     <div className="min-h-screen bg-canvas text-slate-700 lg:grid lg:grid-cols-[224px_minmax(0,1fr)]">

--- a/frontend/src/pages/CaseWorkspacePage.test.tsx
+++ b/frontend/src/pages/CaseWorkspacePage.test.tsx
@@ -1,12 +1,13 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
-import type { CaseDetail } from '../api/cases'
+import type { CaseDetail, CaseRole, CaseStatus } from '../api/cases'
 import { CaseWorkspacePage } from './CaseWorkspacePage'
 
 const mocked = vi.hoisted(() => ({
   getCase: vi.fn(),
   getCaseResourceConfiguration: vi.fn(),
   listCases: vi.fn(),
+  addCaseMember: vi.fn(),
 }))
 
 vi.mock('../auth/useAuth', () => ({
@@ -16,7 +17,7 @@ vi.mock('../api/cases', () => ({
   getCase: (...args: unknown[]) => mocked.getCase(...args),
   getCaseResourceConfiguration: (...args: unknown[]) => mocked.getCaseResourceConfiguration(...args),
   listCases: (...args: unknown[]) => mocked.listCases(...args),
-  addCaseMember: vi.fn(),
+  addCaseMember: (...args: unknown[]) => mocked.addCaseMember(...args),
   createCase: vi.fn(),
   createClue: vi.fn(),
   reviewClue: vi.fn(),
@@ -35,12 +36,17 @@ function deferred<T>() {
   return { promise, resolve, reject }
 }
 
-function detail(id: string, displayName: string): CaseDetail {
+function detail(
+  id: string,
+  displayName: string,
+  accessRole: CaseRole = 'family',
+  status: CaseStatus = 'active',
+): CaseDetail {
   return {
     id,
     case_code: `AG-${id}`,
-    status: 'active',
-    access_role: 'family',
+    status,
+    access_role: accessRole,
     elder_profile: {
       id: `profile-${id}`,
       display_name: displayName,
@@ -101,5 +107,57 @@ describe('CaseWorkspacePage', () => {
     })
     expect(screen.getByRole('heading', { name: '最新案件详情' })).toBeInTheDocument()
     expect(screen.queryByText('过期请求')).not.toBeInTheDocument()
+  })
+
+  it('lets an authorized commander invite the demo volunteer to an active case', async () => {
+    mocked.listCases.mockResolvedValue([
+      {
+        id: 'case-command', case_code: 'AG-COMMAND', status: 'active', access_role: 'commander', display_name: '指挥案件',
+        last_seen_at: null, last_seen_location: null, created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z',
+      },
+    ])
+    mocked.getCase.mockResolvedValue(detail('case-command', '指挥案件', 'commander'))
+    mocked.getCaseResourceConfiguration.mockResolvedValue({
+      attachment_max_image_bytes: 5 * 1024 * 1024,
+      attachment_max_per_case: 12,
+      case_place_types: ['frequent'],
+    })
+    mocked.addCaseMember.mockResolvedValue({})
+
+    render(<CaseWorkspacePage mode="commander" />)
+
+    await screen.findByRole('heading', { name: '指挥案件' })
+    fireEvent.change(screen.getByPlaceholderText('成员邮箱'), { target: { value: 'volunteer@demo.invalid' } })
+    fireEvent.click(screen.getByRole('button', { name: '添加案件成员' }))
+
+    await waitFor(() => expect(mocked.addCaseMember).toHaveBeenCalledWith(
+      'test-session',
+      'case-command',
+      'volunteer@demo.invalid',
+      'volunteer',
+    ))
+  })
+
+  it('does not expose closed-case controls that create supplementary information', async () => {
+    mocked.listCases.mockResolvedValue([
+      {
+        id: 'case-closed', case_code: 'AG-CLOSED', status: 'closed', access_role: 'commander', display_name: '已关闭案件',
+        last_seen_at: null, last_seen_location: null, created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z',
+      },
+    ])
+    mocked.getCase.mockResolvedValue(detail('case-closed', '已关闭案件', 'commander', 'closed'))
+    mocked.getCaseResourceConfiguration.mockResolvedValue({
+      attachment_max_image_bytes: 5 * 1024 * 1024,
+      attachment_max_per_case: 12,
+      case_place_types: ['frequent'],
+    })
+
+    render(<CaseWorkspacePage mode="commander" />)
+
+    await screen.findByRole('heading', { name: '已关闭案件' })
+    expect(screen.queryByRole('button', { name: '提交线索' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '提交地点' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '上传图片' })).not.toBeInTheDocument()
+    expect(screen.getAllByRole('combobox')[0]).toBeDisabled()
   })
 })

--- a/frontend/src/pages/CaseWorkspacePage.test.tsx
+++ b/frontend/src/pages/CaseWorkspacePage.test.tsx
@@ -158,6 +158,6 @@ describe('CaseWorkspacePage', () => {
     expect(screen.queryByRole('button', { name: '提交线索' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: '提交地点' })).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: '上传图片' })).not.toBeInTheDocument()
-    expect(screen.getAllByRole('combobox')[0]).toBeDisabled()
+    expect(screen.getByRole('combobox', { name: '案件状态' })).toBeDisabled()
   })
 })

--- a/frontend/src/pages/CaseWorkspacePage.tsx
+++ b/frontend/src/pages/CaseWorkspacePage.tsx
@@ -339,9 +339,9 @@ function CaseDetailView({
               void run('status', () => updateCaseStatus(token, detail.id, nextStatus), '案件状态已更新')
             }}
           >
-            <h3 className="m-0 text-sm font-bold text-slate-950">案件状态</h3>
+            <h3 id="case-status-title" className="m-0 text-sm font-bold text-slate-950">案件状态</h3>
             <div className="mt-3 flex gap-2">
-              <select className="min-h-10 flex-1 rounded-md border border-slate-300 bg-white px-3 text-sm" value={nextStatus} onChange={(event) => setNextStatus(event.target.value as CaseStatus)} disabled={detail.status === 'closed'}>
+              <select aria-labelledby="case-status-title" className="min-h-10 flex-1 rounded-md border border-slate-300 bg-white px-3 text-sm" value={nextStatus} onChange={(event) => setNextStatus(event.target.value as CaseStatus)} disabled={detail.status === 'closed'}>
                 {statusOptions.map((status) => <option key={status} value={status}>{statusLabels[status]}</option>)}
               </select>
               <Button type="submit" size="sm" variant="secondary" isDisabled={busy === 'status' || nextStatus === detail.status}>保存</Button>


### PR DESCRIPTION
## Summary
- restricts command navigation and direct routing to accounts with the commander capability
- preserves case-level membership filtering from the API and verifies commander volunteer invitations
- verifies closed cases do not expose supplementary-information controls
- adds route and workspace acceptance coverage for #12

Closes #12

## Validation
- npm test -- --run
- npm run lint
- npm run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 基于用户全局能力（指挥端/志愿者端）细化工作区与路由访问控制，并同步更新导航展示逻辑。
  - 在进行中的案件中，支持指挥官通过邀请流程添加志愿者加入案件。
- **问题修复/改进**
  - 案件关闭后，相关提交线索、地点与图片上传等入口不再可见/可用，且无权限入口的跳转表现更一致。
  - 状态选择区域增强可访问性关联（表单标题与下拉框的语义绑定）。
- **测试**
  - 扩展并补齐能力驱动的路由/导航断言，完善邀请与按钮禁用等用例模拟与校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->