### PR TITLE
feat(clues): add scoped timeline API

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -24,6 +24,7 @@
 | `POST` | `/api/cases` | `201` | 创建案件和老人画像 |
 | `GET` | `/api/cases/{case_id}` | `200` | 查询案件、老人画像和线索 |
 | `PATCH` | `/api/cases/{case_id}/status` | `200` | 人工更新案件状态 |
+| `GET` | `/api/cases/{case_id}/clues` | `200` | 获取角色裁剪、可分页的线索时间轴 |
 | `POST` | `/api/cases/{case_id}/clues` | `201` | 提交待审核线索 |
 | `POST` | `/api/cases/{case_id}/places` | `201` | 家属或指挥提交常去/关键地点，始终待人工审核 |
 | `GET` | `/api/cases/{case_id}/resource-configuration` | `200` | 获取当前案件可用的地点类型和图片限制 |
@@ -114,6 +115,8 @@ duplicate
 ```
 
 AI 或其他自动化能力未来只能生成草稿或待审核输入，不得绕过人工审核直接创建 `confirmed` 线索。
+
+线索时间轴使用 `page`（默认 `1`）、`page_size`（默认 `25`，最大 `100`）、`status`、`sort`（`created_at` 或 `occurred_at`）和 `order`（`asc` 或 `desc`）查询参数。所有参数均为白名单；响应中的 `total` 只统计当前认证用户可见的线索。指挥可见全量，家属可见已确认或本人提交的线索，志愿者仅可见已确认线索；无案件成员关系一律返回 `404`。
 
 ## 6. 请求示例
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -438,6 +438,45 @@ paths:
   /api/cases/{case_id}/clues:
     parameters:
       - $ref: "#/components/parameters/CaseId"
+    get:
+      tags: [Cases]
+      operationId: listCaseClues
+      summary: 获取角色裁剪的线索时间轴
+      description: |
+        commander 可以查看全部线索；family 只能查看已确认线索和本人提交的线索；
+        volunteer 只能查看已确认线索。分页总数只计算当前角色可见的线索。无案件成员关系返回 404。
+      security:
+        - bearerAuth: []
+      x-account-types: [member]
+      x-case-roles: [family, commander, volunteer]
+      x-data-classification: case-restricted
+      parameters:
+        - name: page
+          in: query
+          schema: { type: integer, minimum: 1, default: 1 }
+        - name: page_size
+          in: query
+          schema: { type: integer, minimum: 1, maximum: 100, default: 25 }
+        - name: status
+          in: query
+          schema: { $ref: "#/components/schemas/ClueStatus" }
+        - name: sort
+          in: query
+          schema: { type: string, enum: [created_at, occurred_at], default: created_at }
+        - name: order
+          in: query
+          schema: { type: string, enum: [asc, desc], default: desc }
+      responses:
+        "200":
+          description: 角色裁剪后的稳定排序线索页
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ClueTimelinePage"
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "500": { $ref: "#/components/responses/InternalError" }
     post:
       tags: [Cases]
       operationId: createClue
@@ -1482,6 +1521,21 @@ components:
         is_own_submission:
           type: boolean
           description: 当前认证用户是否为该线索的提交者。
+
+    ClueTimelinePage:
+      type: object
+      additionalProperties: false
+      required: [items, page, page_size, total]
+      properties:
+        items:
+          type: array
+          items: { $ref: "#/components/schemas/Clue" }
+        page: { type: integer, minimum: 1 }
+        page_size: { type: integer, minimum: 1, maximum: 100 }
+        total:
+          type: integer
+          minimum: 0
+          description: Only clues visible to the authenticated user are counted.
 
     CreateCasePlaceRequest:
       type: object

--- a/src/models.rs
+++ b/src/models.rs
@@ -389,6 +389,16 @@ pub struct CreateClueRequest {
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct ClueTimelineQuery {
+    pub page: Option<u64>,
+    pub page_size: Option<u64>,
+    pub status: Option<String>,
+    pub sort: Option<String>,
+    pub order: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CreateCasePlaceRequest {
     pub name: String,
     pub place_type: String,
@@ -492,6 +502,14 @@ pub struct ClueResponse {
     pub updated_at: String,
     pub reviewed_at: Option<String>,
     pub is_own_submission: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ClueTimelineResponse {
+    pub items: Vec<ClueResponse>,
+    pub page: u64,
+    pub page_size: u64,
+    pub total: u64,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/routes/cases.rs
+++ b/src/routes/cases.rs
@@ -20,6 +20,7 @@ pub fn configure(config: &mut web::ServiceConfig) {
             .route("", web::post().to(create_case))
             .route("/{case_id}", web::get().to(get_case))
             .route("/{case_id}/status", web::patch().to(update_case_status))
+            .route("/{case_id}/clues", web::get().to(list_clues))
             .route("/{case_id}/clues", web::post().to(create_clue))
             .route("/{case_id}/places", web::post().to(create_place))
             .route(
@@ -200,6 +201,16 @@ async fn create_clue(
 ) -> Result<HttpResponse, ApiError> {
     let clue = case_service::create_clue(&state.db, &auth, &case_id, request.into_inner()).await?;
     Ok(HttpResponse::Created().json(clue))
+}
+
+async fn list_clues(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    case_id: web::Path<String>,
+    query: web::Query<crate::models::ClueTimelineQuery>,
+) -> Result<HttpResponse, ApiError> {
+    let clues = case_service::list_clues(&state.db, &auth, &case_id, query.into_inner()).await?;
+    Ok(HttpResponse::Ok().json(clues))
 }
 
 async fn add_case_member(

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -4,13 +4,41 @@ mod clues;
 mod health;
 mod intake_sessions;
 
-use actix_web::web;
+use actix_web::{HttpResponse, web};
+
+use serde_json::json;
 
 use crate::auth::ApiSessionAuthentication;
 
 pub fn configure(config: &mut web::ServiceConfig) {
+    let json_config = web::JsonConfig::default().error_handler(|error, _request| {
+        actix_web::error::InternalError::from_response(
+            error,
+            HttpResponse::BadRequest().json(json!({
+                "error": {
+                    "code": "validation_error",
+                    "message": "request body is invalid"
+                }
+            })),
+        )
+        .into()
+    });
+    let query_config = web::QueryConfig::default().error_handler(|error, _request| {
+        actix_web::error::InternalError::from_response(
+            error,
+            HttpResponse::BadRequest().json(json!({
+                "error": {
+                    "code": "validation_error",
+                    "message": "query parameters are invalid"
+                }
+            })),
+        )
+        .into()
+    });
     config.service(
         web::scope("/api")
+            .app_data(json_config)
+            .app_data(query_config)
             .wrap(ApiSessionAuthentication)
             .service(health::get_health)
             .configure(auth::configure)

--- a/src/services/case_service.rs
+++ b/src/services/case_service.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use chrono::{SecondsFormat, Utc};
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseConnection, EntityTrait,
-    IntoActiveModel, QueryFilter, QueryOrder, Set, TransactionTrait,
+    IntoActiveModel, Order, QueryFilter, QueryOrder, Set, TransactionTrait,
 };
 use serde_json::json;
 use uuid::Uuid;
@@ -16,8 +16,8 @@ use crate::{
     error::ApiError,
     models::{
         AddCaseMemberRequest, AuthenticatedUser, CaseDetail, CaseListItem, CaseMemberResponse,
-        ClueResponse, CreateCaseRequest, CreateClueRequest, ElderProfileResponse,
-        ReviewClueRequest, UpdateCaseStatusRequest,
+        ClueResponse, ClueTimelineQuery, ClueTimelineResponse, CreateCaseRequest,
+        CreateClueRequest, ElderProfileResponse, ReviewClueRequest, UpdateCaseStatusRequest,
     },
     roles::{AccountType, CaseRole, GlobalCapability},
 };
@@ -30,6 +30,15 @@ const CLUE_REVIEW_STATUSES: &[&str] = &[
     "expired",
     "duplicate",
 ];
+const CLUE_STATUSES: &[&str] = &[
+    "pending_review",
+    "needs_verification",
+    "confirmed",
+    "rejected",
+    "expired",
+    "duplicate",
+];
+const MAX_CLUE_TIMELINE_PAGE_SIZE: u64 = 100;
 
 pub async fn list_cases(
     db: &DatabaseConnection,
@@ -254,6 +263,59 @@ pub async fn create_clue(
     Ok(ClueResponse::new(clue_model, Some(attribution), &auth.id))
 }
 
+pub async fn list_clues(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    case_id: &str,
+    query: ClueTimelineQuery,
+) -> Result<ClueTimelineResponse, ApiError> {
+    let query = ValidatedClueTimelineQuery::try_from(query)?;
+    let membership = membership_for_case(db, &auth.id, case_id).await?;
+    let case_role = case_role_from_database(&membership.role)?;
+    let mut clue_query = clues::Entity::find().filter(clues::Column::CaseId.eq(case_id));
+
+    if let Some(status) = &query.status {
+        clue_query = clue_query.filter(clues::Column::Status.eq(status));
+    }
+
+    clue_query = match query.sort.as_str() {
+        "created_at" => clue_query.order_by(clues::Column::CreatedAt, query.order.clone()),
+        "occurred_at" => clue_query
+            .order_by(clues::Column::OccurredAt, query.order.clone())
+            .order_by(clues::Column::CreatedAt, query.order.clone()),
+        _ => return Err(ApiError::Internal),
+    }
+    .order_by(clues::Column::Id, query.order.clone());
+
+    let clue_models = clue_query.all(db).await?;
+    let clue_ids: Vec<_> = clue_models.iter().map(|clue| clue.id.clone()).collect();
+    let attributions = clue_attributions_for_clues(db, clue_ids).await?;
+    let visible_clues: Vec<_> = clue_models
+        .into_iter()
+        .filter_map(|clue| {
+            let clue_id = clue.id.clone();
+            visible_clue_response(clue, attributions.get(&clue_id).cloned(), auth, case_role)
+        })
+        .collect();
+    let total = u64::try_from(visible_clues.len()).map_err(|_| ApiError::Internal)?;
+    let start = query.offset()?;
+    let end = start
+        .saturating_add(query.page_size_usize())
+        .min(visible_clues.len());
+    let items = visible_clues
+        .into_iter()
+        .skip(start)
+        .take(end.saturating_sub(start))
+        .collect();
+
+    Ok(ClueTimelineResponse {
+        items,
+        page: query.page,
+        page_size: query.page_size,
+        total,
+    })
+}
+
 pub async fn review_clue(
     db: &DatabaseConnection,
     auth: &AuthenticatedUser,
@@ -319,6 +381,80 @@ pub async fn review_clue(
 
     transaction.commit().await?;
     Ok(ClueResponse::new(updated, Some(attribution), &auth.id))
+}
+
+struct ValidatedClueTimelineQuery {
+    page: u64,
+    page_size: u64,
+    status: Option<String>,
+    sort: String,
+    order: Order,
+}
+
+impl ValidatedClueTimelineQuery {
+    fn offset(&self) -> Result<usize, ApiError> {
+        let page_offset = self
+            .page
+            .checked_sub(1)
+            .and_then(|page| page.checked_mul(self.page_size))
+            .ok_or_else(|| ApiError::Validation("page is too large".to_owned()))?;
+        usize::try_from(page_offset)
+            .map_err(|_| ApiError::Validation("page is too large".to_owned()))
+    }
+
+    fn page_size_usize(&self) -> usize {
+        self.page_size as usize
+    }
+}
+
+impl TryFrom<ClueTimelineQuery> for ValidatedClueTimelineQuery {
+    type Error = ApiError;
+
+    fn try_from(value: ClueTimelineQuery) -> Result<Self, Self::Error> {
+        let page = value.page.unwrap_or(1);
+        if page == 0 {
+            return Err(ApiError::Validation("page must be at least 1".to_owned()));
+        }
+        let page_size = value.page_size.unwrap_or(25);
+        if page_size == 0 || page_size > MAX_CLUE_TIMELINE_PAGE_SIZE {
+            return Err(ApiError::Validation(format!(
+                "page_size must be between 1 and {MAX_CLUE_TIMELINE_PAGE_SIZE}"
+            )));
+        }
+        let status = value.status.map(|status| status.trim().to_lowercase());
+        if status
+            .as_deref()
+            .is_some_and(|status| !CLUE_STATUSES.contains(&status))
+        {
+            return Err(ApiError::Validation("status is unsupported".to_owned()));
+        }
+        let sort = value
+            .sort
+            .unwrap_or_else(|| "created_at".to_owned())
+            .trim()
+            .to_lowercase();
+        if !matches!(sort.as_str(), "created_at" | "occurred_at") {
+            return Err(ApiError::Validation("sort is unsupported".to_owned()));
+        }
+        let order = match value
+            .order
+            .unwrap_or_else(|| "desc".to_owned())
+            .trim()
+            .to_lowercase()
+            .as_str()
+        {
+            "asc" => Order::Asc,
+            "desc" => Order::Desc,
+            _ => return Err(ApiError::Validation("order is unsupported".to_owned())),
+        };
+        Ok(Self {
+            page,
+            page_size,
+            status,
+            sort,
+            order,
+        })
+    }
 }
 
 pub async fn add_case_member(
@@ -437,32 +573,13 @@ async fn load_case_detail(
         .all(db)
         .await?;
     let clue_ids: Vec<_> = clue_models.iter().map(|clue| clue.id.clone()).collect();
-    let attributions: HashMap<_, _> = if clue_ids.is_empty() {
-        HashMap::new()
-    } else {
-        clue_attributions::Entity::find()
-            .filter(clue_attributions::Column::ClueId.is_in(clue_ids))
-            .all(db)
-            .await?
-            .into_iter()
-            .map(|attribution| (attribution.clue_id.clone(), attribution))
-            .collect()
-    };
+    let attributions = clue_attributions_for_clues(db, clue_ids).await?;
 
     let visible_clues = clue_models
         .into_iter()
         .filter_map(|clue| {
-            let attribution = attributions.get(&clue.id).cloned();
-            let own = attribution
-                .as_ref()
-                .and_then(|value| value.submitted_by_user_id.as_deref())
-                == Some(auth.id.as_str());
-            let visible = match case_role {
-                CaseRole::Commander => true,
-                CaseRole::Family => clue.status == "confirmed" || own,
-                CaseRole::Volunteer => clue.status == "confirmed",
-            };
-            visible.then(|| ClueResponse::new(clue, attribution, &auth.id))
+            let clue_id = clue.id.clone();
+            visible_clue_response(clue, attributions.get(&clue_id).cloned(), auth, case_role)
         })
         .collect();
 
@@ -494,6 +611,40 @@ async fn load_case_detail(
         attachments,
         case_role,
     ))
+}
+
+async fn clue_attributions_for_clues<C: ConnectionTrait>(
+    db: &C,
+    clue_ids: Vec<String>,
+) -> Result<HashMap<String, clue_attributions::Model>, ApiError> {
+    if clue_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    Ok(clue_attributions::Entity::find()
+        .filter(clue_attributions::Column::ClueId.is_in(clue_ids))
+        .all(db)
+        .await?
+        .into_iter()
+        .map(|attribution| (attribution.clue_id.clone(), attribution))
+        .collect())
+}
+
+fn visible_clue_response(
+    clue: clues::Model,
+    attribution: Option<clue_attributions::Model>,
+    auth: &AuthenticatedUser,
+    case_role: CaseRole,
+) -> Option<ClueResponse> {
+    let own = attribution
+        .as_ref()
+        .and_then(|value| value.submitted_by_user_id.as_deref())
+        == Some(auth.id.as_str());
+    let visible = match case_role {
+        CaseRole::Commander => true,
+        CaseRole::Family => clue.status == "confirmed" || own,
+        CaseRole::Volunteer => clue.status == "confirmed",
+    };
+    visible.then(|| ClueResponse::new(clue, attribution, &auth.id))
 }
 
 async fn membership_for_case<C: ConnectionTrait>(

--- a/tests/api/authentication_guards.rs
+++ b/tests/api/authentication_guards.rs
@@ -43,6 +43,7 @@ async fn every_protected_endpoint_rejects_missing_and_invalid_bearer_tokens() {
     assert_unauthorized!(app, get, "/api/cases/not-used");
     assert_unauthorized!(app, patch, "/api/cases/not-used/status");
     assert_unauthorized!(app, post, "/api/cases/not-used/members");
+    assert_unauthorized!(app, get, "/api/cases/not-used/clues");
     assert_unauthorized!(app, post, "/api/cases/not-used/clues");
     assert_unauthorized!(app, post, "/api/cases/not-used/places");
     assert_unauthorized!(app, get, "/api/cases/not-used/resource-configuration");

--- a/tests/api/case_clues_get.rs
+++ b/tests/api/case_clues_get.rs
@@ -1,0 +1,135 @@
+use actix_web::{
+    http::{StatusCode, header},
+    test,
+};
+use serde_json::Value;
+
+use crate::support::{COMMANDER, FAMILY, LEARNER, TestContext, VOLUNTEER, assert_error};
+
+#[actix_web::test]
+async fn get_case_clues_applies_role_cuts_pagination_and_status_filters() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    context
+        .add_member(&case_id, COMMANDER, VOLUNTEER, "volunteer")
+        .await;
+
+    let confirmed_clue = context.create_clue(&case_id, FAMILY).await;
+    let commander = context.authenticated(COMMANDER).await;
+    angui::services::case_service::review_clue(
+        &context.database,
+        &commander,
+        &confirmed_clue,
+        angui::models::ReviewClueRequest {
+            status: "confirmed".to_owned(),
+        },
+    )
+    .await
+    .expect("fixture clue should be confirmed");
+    context.create_clue(&case_id, COMMANDER).await;
+    context.create_clue(&case_id, FAMILY).await;
+
+    let family_token = context.token(FAMILY).await;
+    let volunteer_token = context.token(VOLUNTEER).await;
+    let commander_token = context.token(COMMANDER).await;
+    let learner_token = context.token(LEARNER).await;
+    let app = crate::init_api_app!(&context);
+
+    let family = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/cases/{case_id}/clues"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {family_token}")))
+            .to_request(),
+    )
+    .await;
+    let family_body: Value = test::read_body_json(family).await;
+    assert_eq!(family_body["total"], 2);
+    assert!(
+        family_body["items"]
+            .as_array()
+            .expect("items should be an array")
+            .iter()
+            .all(|clue| clue["status"] == "confirmed" || clue["is_own_submission"] == true)
+    );
+
+    let volunteer = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/cases/{case_id}/clues"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {volunteer_token}")))
+            .to_request(),
+    )
+    .await;
+    let volunteer_body: Value = test::read_body_json(volunteer).await;
+    assert_eq!(volunteer_body["total"], 1);
+    assert_eq!(volunteer_body["items"][0]["status"], "confirmed");
+
+    let paged = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!(
+                "/api/cases/{case_id}/clues?page=1&page_size=2&sort=created_at&order=asc"
+            ))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .to_request(),
+    )
+    .await;
+    let paged_body: Value = test::read_body_json(paged).await;
+    assert_eq!(paged_body["total"], 3);
+    assert_eq!(paged_body["items"].as_array().map(Vec::len), Some(2));
+    assert_eq!(paged_body["page"], 1);
+    assert_eq!(paged_body["page_size"], 2);
+
+    let filtered = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/cases/{case_id}/clues?status=confirmed"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .to_request(),
+    )
+    .await;
+    let filtered_body: Value = test::read_body_json(filtered).await;
+    assert_eq!(filtered_body["total"], 1);
+    assert_eq!(filtered_body["items"][0]["id"], confirmed_clue);
+
+    let unavailable = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/cases/{case_id}/clues"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {learner_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_error(unavailable, StatusCode::NOT_FOUND, "not_found").await;
+}
+
+#[actix_web::test]
+async fn get_case_clues_rejects_invalid_whitelisted_query_values() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    let token = context.token(FAMILY).await;
+    let app = crate::init_api_app!(&context);
+
+    for query in [
+        "page=0",
+        "page_size=101",
+        "status=unreviewed",
+        "sort=status",
+        "order=sideways",
+        "unexpected=value",
+    ] {
+        let response = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/api/cases/{case_id}/clues?{query}"))
+                .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+                .to_request(),
+        )
+        .await;
+        assert_error(response, StatusCode::BAD_REQUEST, "validation_error").await;
+    }
+}

--- a/tests/api/case_clues_post.rs
+++ b/tests/api/case_clues_post.rs
@@ -2,6 +2,7 @@ use actix_web::{
     http::{StatusCode, header},
     test,
 };
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use serde_json::Value;
 
 use crate::support::{COMMANDER, FAMILY, TestContext, VOLUNTEER, assert_error, create_clue_json};
@@ -26,6 +27,25 @@ async fn post_case_clues_creates_pending_review_clues_for_case_members() {
     assert_eq!(body["case_id"], case_id);
     assert_eq!(body["status"], "pending_review");
     assert_eq!(body["is_own_submission"], true);
+    assert!(body["reviewed_at"].is_null());
+
+    let audit = angui::entities::audit_events::Entity::find()
+        .filter(angui::entities::audit_events::Column::EntityId.eq(body["id"].as_str()))
+        .one(&context.database)
+        .await
+        .expect("audit lookup should succeed")
+        .expect("clue submission should be audited");
+    let metadata = audit
+        .metadata_json
+        .expect("audit metadata should be present");
+    assert!(metadata.contains("pending_review"));
+    assert!(
+        !metadata.contains(
+            create_clue_json()["content"]
+                .as_str()
+                .expect("content is text")
+        )
+    );
 }
 
 #[actix_web::test]
@@ -59,4 +79,36 @@ async fn post_case_clues_hides_non_member_cases_and_rejects_closed_cases() {
     )
     .await;
     assert_error(closed, StatusCode::CONFLICT, "conflict").await;
+}
+
+#[actix_web::test]
+async fn post_case_clues_rejects_client_controlled_status_and_unknown_fields() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    let token = context.token(FAMILY).await;
+    let app = crate::init_api_app!(&context);
+
+    for payload in [
+        serde_json::json!({
+            "source": "family",
+            "content": "untrusted status",
+            "status": "confirmed"
+        }),
+        serde_json::json!({
+            "source": "family",
+            "content": "unknown field",
+            "reviewed_by_user_id": "forged"
+        }),
+    ] {
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri(&format!("/api/cases/{case_id}/clues"))
+                .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+                .set_json(payload)
+                .to_request(),
+        )
+        .await;
+        assert_error(response, StatusCode::BAD_REQUEST, "validation_error").await;
+    }
 }

--- a/tests/api/clue_review_patch.rs
+++ b/tests/api/clue_review_patch.rs
@@ -2,9 +2,10 @@ use actix_web::{
     http::{StatusCode, header},
     test,
 };
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use serde_json::Value;
 
-use crate::support::{COMMANDER, FAMILY, TestContext, assert_error};
+use crate::support::{COMMANDER, FAMILY, TestContext, VOLUNTEER, assert_error};
 
 #[actix_web::test]
 async fn patch_clue_review_requires_the_case_commander_and_publishes_review_status() {
@@ -40,6 +41,19 @@ async fn patch_clue_review_requires_the_case_commander_and_publishes_review_stat
     let body: Value = test::read_body_json(confirmed).await;
     assert_eq!(body["status"], "confirmed");
     assert!(body["reviewed_at"].is_string());
+
+    let audit = angui::entities::audit_events::Entity::find()
+        .filter(angui::entities::audit_events::Column::EntityId.eq(&clue_id))
+        .filter(angui::entities::audit_events::Column::Action.eq("clue.reviewed"))
+        .one(&context.database)
+        .await
+        .expect("audit lookup should succeed")
+        .expect("clue review should be audited");
+    let metadata = audit
+        .metadata_json
+        .expect("audit metadata should be present");
+    assert!(metadata.contains("confirmed"));
+    assert!(!metadata.contains("测试线索"));
 }
 
 #[actix_web::test]
@@ -62,4 +76,64 @@ async fn patch_clue_review_rejects_pending_review_as_a_review_target() {
     )
     .await;
     assert_error(response, StatusCode::BAD_REQUEST, "validation_error").await;
+}
+
+#[actix_web::test]
+async fn patch_clue_review_rejects_volunteers_and_records_each_review_transition() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    context
+        .add_member(&case_id, COMMANDER, VOLUNTEER, "volunteer")
+        .await;
+    let clue_id = context.create_clue(&case_id, FAMILY).await;
+    let volunteer_token = context.token(VOLUNTEER).await;
+    let commander_token = context.token(COMMANDER).await;
+    let app = crate::init_api_app!(&context);
+
+    let forbidden = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&format!("/api/clues/{clue_id}/review"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {volunteer_token}")))
+            .set_json(serde_json::json!({ "status": "confirmed" }))
+            .to_request(),
+    )
+    .await;
+    assert_error(forbidden, StatusCode::FORBIDDEN, "forbidden").await;
+
+    for status in ["needs_verification", "duplicate"] {
+        let response = test::call_service(
+            &app,
+            test::TestRequest::patch()
+                .uri(&format!("/api/clues/{clue_id}/review"))
+                .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+                .set_json(serde_json::json!({ "status": status }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    let audits = angui::entities::audit_events::Entity::find()
+        .filter(angui::entities::audit_events::Column::EntityId.eq(&clue_id))
+        .filter(angui::entities::audit_events::Column::Action.eq("clue.reviewed"))
+        .all(&context.database)
+        .await
+        .expect("audit lookup should succeed");
+    assert_eq!(audits.len(), 2);
+    assert!(audits.iter().any(|audit| {
+        audit
+            .metadata_json
+            .as_deref()
+            .is_some_and(|metadata| metadata.contains("needs_verification"))
+    }));
+    assert!(audits.iter().any(|audit| {
+        audit
+            .metadata_json
+            .as_deref()
+            .is_some_and(|metadata| metadata.contains("duplicate"))
+    }));
 }

--- a/tests/api/mod.rs
+++ b/tests/api/mod.rs
@@ -2,6 +2,7 @@ mod auth_login_post;
 mod auth_logout_post;
 mod auth_me_get;
 mod authentication_guards;
+mod case_clues_get;
 mod case_clues_post;
 mod case_detail_get;
 mod case_members_post;

--- a/tests/api/openapi_intake_contract.rs
+++ b/tests/api/openapi_intake_contract.rs
@@ -140,3 +140,36 @@ fn intake_openapi_contract_covers_draft_provenance_assessments_and_confirmation(
         &["#/components/schemas/CaseStatus"],
     );
 }
+
+#[test]
+fn clue_timeline_openapi_contract_covers_pagination_and_visibility() {
+    let (_, operation) = OPENAPI
+        .split_once("  /api/cases/{case_id}/clues:\n")
+        .expect("OpenAPI clue path must exist");
+    let get_operation = operation
+        .split_once("    get:\n")
+        .and_then(|(_, after_get)| after_get.split_once("    post:\n").map(|(get, _)| get))
+        .expect("OpenAPI clue path must declare GET before POST");
+    for expected in [
+        "operationId: listCaseClues",
+        "name: page",
+        "name: page_size",
+        "name: status",
+        "name: sort",
+        "name: order",
+        "#/components/schemas/ClueTimelinePage",
+    ] {
+        assert!(
+            get_operation.contains(expected),
+            "OpenAPI clue timeline operation must declare {expected:?}"
+        );
+    }
+    assert_schema_contains(
+        "ClueTimelinePage",
+        &[
+            "required: [items, page, page_size, total]",
+            "items:",
+            "total:",
+        ],
+    );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增案件线索时间轴查询接口 `GET /api/cases/{case_id}/clues`，支持分页（`page/page_size`）、状态筛选、排序（`sort/ order`）。
  * 结果按当前认证用户的角色与“是否本人提交”进行可见性裁剪，分页返回 `items/page/page_size/total`。
  * 无案件成员的情况下返回 `404`。
* **错误修复**
  * 非法查询参数触发 `400`，并返回结构化 `validation_error`（如分页/枚举白名单不通过）。
* **文档**
  * 更新 OpenAPI/接口文档契约，补充 `ClueTimelinePage` 等响应结构。
* **测试**
  * 新增并增强接口契约、鉴权、参数校验与角色可见性/分页行为的自动化测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->