### PR TITLE
feat(tasks): add task lifecycle APIs and simulated location schema

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1072,6 +1072,11 @@ components:
       type: string
       enum: [pending_claim, assigned, accepted, active, blocked, completed, cancelled]
 
+    TaskStatusTransitionTarget:
+      type: string
+      description: `pending_claim` and `assigned` are stored task states, not valid PATCH targets.
+      enum: [accepted, active, blocked, completed, cancelled]
+
     TaskRiskLevel:
       type: string
       enum: [low, medium, high, critical]
@@ -1800,8 +1805,16 @@ components:
         title: { type: string, minLength: 1, maxLength: 200 }
         objective: { type: string, minLength: 1, maxLength: 4000 }
         area_text: { type: string, minLength: 1, maxLength: 500 }
-        latitude: { type: [number, "null"], minimum: -90, maximum: 90 }
-        longitude: { type: [number, "null"], minimum: -180, maximum: 180 }
+        latitude:
+          type: [number, "null"]
+          minimum: -90
+          maximum: 90
+          description: Must be provided with longitude, or both coordinates must be omitted or null.
+        longitude:
+          type: [number, "null"]
+          minimum: -180
+          maximum: 180
+          description: Must be provided with latitude, or both coordinates must be omitted or null.
         due_at:
           type: string
           format: date-time
@@ -1817,7 +1830,9 @@ components:
       additionalProperties: false
       required: [status]
       properties:
-        status: { $ref: "#/components/schemas/TaskStatus" }
+        status:
+          $ref: "#/components/schemas/TaskStatusTransitionTarget"
+          description: The current task state and caller role determine whether this otherwise valid target transition is allowed.
 
     Task:
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -42,6 +42,8 @@ tags:
     description: 案件、老人资料、案件成员和案件内线索；必须先通过案件成员关系授权
   - name: Clues
     description: 线索人工审核
+  - name: Tasks
+    description: Case-internal rescue task creation, assignment, and execution status.
   - name: Intake sessions
     description: 家属创建的未确认走失信息问询会话
 security:
@@ -521,6 +523,136 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /api/cases/{case_id}/tasks:
+    parameters:
+      - $ref: "#/components/parameters/CaseId"
+    get:
+      tags: [Tasks]
+      operationId: listCaseTasks
+      summary: List tasks visible to the current case member
+      description: |
+        Commanders receive all case tasks. Volunteers receive only tasks assigned to themselves;
+        assignment identity is redacted. Family members receive an empty page. The server applies
+        role filtering before stable `due_at`, then `id` ordering and pagination. Non-members
+        receive 404.
+      security:
+        - bearerAuth: []
+      x-account-types: [member]
+      x-case-roles: [family, commander, volunteer]
+      x-data-classification: case-restricted
+      parameters:
+        - name: page
+          in: query
+          schema: { type: integer, minimum: 1, default: 1 }
+        - name: page_size
+          in: query
+          schema: { type: integer, minimum: 1, maximum: 100, default: 25 }
+      responses:
+        "200":
+          description: Role-filtered, stably ordered task page
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/TaskListPage" }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "500": { $ref: "#/components/responses/InternalError" }
+    post:
+      tags: [Tasks]
+      operationId: createCaseTask
+      summary: Manually create and assign a rescue task
+      description: |
+        Only a commander of an open case can create this endpoint's initially `assigned` task.
+        The source clue must be confirmed and belong to the same case; the recipient must be an
+        active case member with the volunteer role. Creation, assignment, and `task.created` /
+        `task.assigned` audit events commit in one transaction. No automatic assignment or
+        high-risk-action authorization is performed.
+      security:
+        - bearerAuth: []
+      x-account-types: [member]
+      x-case-roles: [commander]
+      x-data-classification: case-restricted
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/CreateTaskRequest" }
+      responses:
+        "201":
+          description: Assigned task created
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Task" }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { $ref: "#/components/responses/Conflict" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
+  /api/tasks/mine:
+    get:
+      tags: [Tasks]
+      operationId: listMyTasks
+      summary: List the current volunteer's assigned task queue
+      description: |
+        This endpoint accepts only accounts with the volunteer capability and returns `200 []`
+        when none of their active volunteer case memberships has an assignment. It never accepts
+        a case ID and returns no health details, family contact details, full clues, or any other
+        volunteer's identity or location history.
+      security:
+        - bearerAuth: []
+      x-account-types: [member]
+      x-global-capabilities: [volunteer]
+      x-data-classification: case-restricted
+      responses:
+        "200":
+          description: The caller's tasks, ordered by due time then task ID
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "#/components/schemas/Task" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
+  /api/tasks/{task_id}/status:
+    parameters:
+      - $ref: "#/components/parameters/TaskId"
+    patch:
+      tags: [Tasks]
+      operationId: updateTaskStatus
+      summary: Advance an assigned task or cancel an unfinished task
+      description: |
+        The assigned volunteer may advance only `assigned -> accepted -> active -> completed`,
+        with `active <-> blocked` available for safety escalation. A case commander may only set
+        an unfinished task to `cancelled`. Completed and cancelled tasks are terminal. Every
+        successful state change writes a `task.status_changed` audit event containing the prior
+        and next status, actor, and timestamp.
+      security:
+        - bearerAuth: []
+      x-account-types: [member]
+      x-case-roles: [commander, volunteer]
+      x-data-classification: case-restricted
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/UpdateTaskStatusRequest" }
+      responses:
+        "200":
+          description: Updated task after an allowed transition
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Task" }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { $ref: "#/components/responses/Conflict" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
   /api/cases/{case_id}/places:
     parameters:
       - $ref: "#/components/parameters/CaseId"
@@ -752,6 +884,14 @@ components:
       schema:
         type: string
         format: uuid
+    TaskId:
+      name: task_id
+      in: path
+      required: true
+      description: Case task UUID. Non-members and non-assigned volunteers receive not found.
+      schema:
+        type: string
+        format: uuid
     IntakeSessionId:
       name: session_id
       in: path
@@ -927,6 +1067,14 @@ components:
     CaseStatus:
       type: string
       enum: [active, resolved, closed]
+
+    TaskStatus:
+      type: string
+      enum: [pending_claim, assigned, accepted, active, blocked, completed, cancelled]
+
+    TaskRiskLevel:
+      type: string
+      enum: [low, medium, high, critical]
 
     ClueStatus:
       type: string
@@ -1635,6 +1783,90 @@ components:
           type: integer
           minimum: 0
           description: Only clues visible to the authenticated user are counted.
+
+    CreateTaskRequest:
+      type: object
+      additionalProperties: false
+      required: [source_clue_id, volunteer_user_id, title, objective, area_text, due_at, background, risk_level, risk_notes, safety_briefing, expected_feedback]
+      properties:
+        source_clue_id:
+          type: string
+          format: uuid
+          description: A confirmed clue in the same case; required as the task's reviewed source evidence.
+        volunteer_user_id:
+          type: string
+          format: uuid
+          description: An active volunteer member of the same case; the server does not auto-select one.
+        title: { type: string, minLength: 1, maxLength: 200 }
+        objective: { type: string, minLength: 1, maxLength: 4000 }
+        area_text: { type: string, minLength: 1, maxLength: 500 }
+        latitude: { type: [number, "null"], minimum: -90, maximum: 90 }
+        longitude: { type: [number, "null"], minimum: -180, maximum: 180 }
+        due_at:
+          type: string
+          format: date-time
+          description: Required future RFC 3339 timestamp; the server normalizes it to UTC.
+        background: { type: string, minLength: 1, maxLength: 10000 }
+        risk_level: { $ref: "#/components/schemas/TaskRiskLevel" }
+        risk_notes: { type: string, minLength: 1, maxLength: 4000 }
+        safety_briefing: { type: string, minLength: 1, maxLength: 4000 }
+        expected_feedback: { type: string, minLength: 1, maxLength: 4000 }
+
+    UpdateTaskStatusRequest:
+      type: object
+      additionalProperties: false
+      required: [status]
+      properties:
+        status: { $ref: "#/components/schemas/TaskStatus" }
+
+    Task:
+      type: object
+      additionalProperties: false
+      required: [id, case_id, source_clue_id, title, objective, area_text, latitude, longitude, due_at, background, risk_level, risk_notes, safety_briefing, expected_feedback, status, result_summary, assigned_volunteer_user_id, assigned_at, created_at, updated_at]
+      properties:
+        id: { type: string, format: uuid }
+        case_id: { type: string, format: uuid }
+        source_clue_id:
+          type: [string, "null"]
+          format: uuid
+          description: Returned to commanders only; it is null in volunteer responses.
+        title: { type: string, maxLength: 200 }
+        objective: { type: string, maxLength: 4000 }
+        area_text: { type: string, maxLength: 500 }
+        latitude: { type: [number, "null"] }
+        longitude: { type: [number, "null"] }
+        due_at: { type: string, format: date-time }
+        background:
+          type: [string, "null"]
+          description: Internal task context returned to commanders only; it is null in volunteer responses.
+        risk_level: { $ref: "#/components/schemas/TaskRiskLevel" }
+        risk_notes: { type: string }
+        safety_briefing: { type: string }
+        expected_feedback: { type: string }
+        status: { $ref: "#/components/schemas/TaskStatus" }
+        result_summary: { type: [string, "null"] }
+        assigned_volunteer_user_id:
+          type: [string, "null"]
+          format: uuid
+          description: Returned to commanders only; it is null in volunteer responses.
+        assigned_at: { type: [string, "null"], format: date-time }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+
+    TaskListPage:
+      type: object
+      additionalProperties: false
+      required: [items, page, page_size, total]
+      properties:
+        items:
+          type: array
+          items: { $ref: "#/components/schemas/Task" }
+        page: { type: integer, minimum: 1 }
+        page_size: { type: integer, minimum: 1, maximum: 100 }
+        total:
+          type: integer
+          minimum: 0
+          description: Only tasks visible to the authenticated case role are counted.
 
     CreateCasePlaceRequest:
       type: object

--- a/migration/sql/mysql/down/0020_drop_tasks_and_location_reports.sql
+++ b/migration/sql/mysql/down/0020_drop_tasks_and_location_reports.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS task_location_reports;
+-- statement-break
+DROP TABLE IF EXISTS task_assignments;
+-- statement-break
+DROP TABLE IF EXISTS tasks;

--- a/migration/sql/mysql/up/0020_create_tasks_and_location_reports.sql
+++ b/migration/sql/mysql/up/0020_create_tasks_and_location_reports.sql
@@ -1,0 +1,76 @@
+CREATE TABLE tasks (
+    id VARCHAR(36) PRIMARY KEY,
+    case_id VARCHAR(36) NOT NULL,
+    source_clue_id VARCHAR(36),
+    title VARCHAR(200) NOT NULL,
+    objective TEXT NOT NULL,
+    area_text VARCHAR(500) NOT NULL,
+    latitude DOUBLE,
+    longitude DOUBLE,
+    due_at VARCHAR(40) NOT NULL,
+    background TEXT NOT NULL,
+    risk_level VARCHAR(16) NOT NULL,
+    risk_notes TEXT NOT NULL,
+    safety_briefing TEXT NOT NULL,
+    expected_feedback TEXT NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    result_summary TEXT,
+    created_by_user_id VARCHAR(36) NOT NULL,
+    created_at VARCHAR(40) NOT NULL,
+    updated_at VARCHAR(40) NOT NULL,
+    CONSTRAINT chk_tasks_risk_level CHECK (risk_level IN ('low', 'medium', 'high', 'critical')),
+    CONSTRAINT chk_tasks_status CHECK (status IN ('pending_claim', 'assigned', 'accepted', 'active', 'blocked', 'completed', 'cancelled')),
+    CONSTRAINT chk_tasks_coordinates CHECK (
+        (latitude IS NULL AND longitude IS NULL)
+        OR (
+            latitude IS NOT NULL
+            AND longitude IS NOT NULL
+            AND latitude BETWEEN -90 AND 90
+            AND longitude BETWEEN -180 AND 180
+        )
+    ),
+    CONSTRAINT fk_tasks_case FOREIGN KEY (case_id) REFERENCES cases(id) ON DELETE CASCADE,
+    CONSTRAINT fk_tasks_source_clue FOREIGN KEY (source_clue_id) REFERENCES clues(id) ON DELETE SET NULL,
+    CONSTRAINT fk_tasks_creator FOREIGN KEY (created_by_user_id) REFERENCES users(id) ON DELETE RESTRICT
+) ENGINE=InnoDB;
+-- statement-break
+CREATE INDEX idx_tasks_case_status_due_at ON tasks(case_id, status, due_at);
+-- statement-break
+CREATE INDEX idx_tasks_source_clue_id ON tasks(source_clue_id);
+-- statement-break
+CREATE TABLE task_assignments (
+    task_id VARCHAR(36) PRIMARY KEY,
+    volunteer_user_id VARCHAR(36) NOT NULL,
+    assigned_by_user_id VARCHAR(36) NOT NULL,
+    assigned_at VARCHAR(40) NOT NULL,
+    updated_at VARCHAR(40) NOT NULL,
+    UNIQUE (task_id, volunteer_user_id),
+    CONSTRAINT fk_task_assignments_task FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+    CONSTRAINT fk_task_assignments_volunteer FOREIGN KEY (volunteer_user_id) REFERENCES users(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_task_assignments_assigner FOREIGN KEY (assigned_by_user_id) REFERENCES users(id) ON DELETE RESTRICT
+) ENGINE=InnoDB;
+-- statement-break
+CREATE INDEX idx_task_assignments_volunteer_assigned_at ON task_assignments(volunteer_user_id, assigned_at);
+-- statement-break
+CREATE TABLE task_location_reports (
+    id VARCHAR(36) PRIMARY KEY,
+    task_id VARCHAR(36) NOT NULL,
+    volunteer_user_id VARCHAR(36) NOT NULL,
+    source VARCHAR(16) NOT NULL,
+    latitude DOUBLE NOT NULL,
+    longitude DOUBLE NOT NULL,
+    accuracy_meters DOUBLE NOT NULL,
+    captured_at VARCHAR(40) NOT NULL,
+    retention_expires_at VARCHAR(40) NOT NULL,
+    created_at VARCHAR(40) NOT NULL,
+    CONSTRAINT chk_task_location_reports_source CHECK (source = 'simulated'),
+    CONSTRAINT chk_task_location_reports_latitude CHECK (latitude BETWEEN -90 AND 90),
+    CONSTRAINT chk_task_location_reports_longitude CHECK (longitude BETWEEN -180 AND 180),
+    CONSTRAINT chk_task_location_reports_accuracy CHECK (accuracy_meters >= 0 AND accuracy_meters <= 10000),
+    CONSTRAINT fk_task_location_reports_task FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+    CONSTRAINT fk_task_location_reports_assignment FOREIGN KEY (task_id, volunteer_user_id) REFERENCES task_assignments(task_id, volunteer_user_id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+-- statement-break
+CREATE INDEX idx_task_location_reports_task_captured_at ON task_location_reports(task_id, captured_at);
+-- statement-break
+CREATE INDEX idx_task_location_reports_retention_expires_at ON task_location_reports(retention_expires_at);

--- a/migration/sql/postgres/down/0020_drop_tasks_and_location_reports.sql
+++ b/migration/sql/postgres/down/0020_drop_tasks_and_location_reports.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS task_location_reports;
+-- statement-break
+DROP TABLE IF EXISTS task_assignments;
+-- statement-break
+DROP TABLE IF EXISTS tasks;

--- a/migration/sql/postgres/up/0020_create_tasks_and_location_reports.sql
+++ b/migration/sql/postgres/up/0020_create_tasks_and_location_reports.sql
@@ -1,0 +1,70 @@
+CREATE TABLE tasks (
+    id VARCHAR(36) PRIMARY KEY,
+    case_id VARCHAR(36) NOT NULL,
+    source_clue_id VARCHAR(36),
+    title VARCHAR(200) NOT NULL,
+    objective TEXT NOT NULL,
+    area_text VARCHAR(500) NOT NULL,
+    latitude DOUBLE PRECISION,
+    longitude DOUBLE PRECISION,
+    due_at VARCHAR(40) NOT NULL,
+    background TEXT NOT NULL,
+    risk_level VARCHAR(16) NOT NULL CHECK (risk_level IN ('low', 'medium', 'high', 'critical')),
+    risk_notes TEXT NOT NULL,
+    safety_briefing TEXT NOT NULL,
+    expected_feedback TEXT NOT NULL,
+    status VARCHAR(32) NOT NULL CHECK (status IN ('pending_claim', 'assigned', 'accepted', 'active', 'blocked', 'completed', 'cancelled')),
+    result_summary TEXT,
+    created_by_user_id VARCHAR(36) NOT NULL,
+    created_at VARCHAR(40) NOT NULL,
+    updated_at VARCHAR(40) NOT NULL,
+    CHECK (
+        (latitude IS NULL AND longitude IS NULL)
+        OR (
+            latitude IS NOT NULL
+            AND longitude IS NOT NULL
+            AND latitude BETWEEN -90 AND 90
+            AND longitude BETWEEN -180 AND 180
+        )
+    ),
+    CONSTRAINT fk_tasks_case FOREIGN KEY (case_id) REFERENCES cases(id) ON DELETE CASCADE,
+    CONSTRAINT fk_tasks_source_clue FOREIGN KEY (source_clue_id) REFERENCES clues(id) ON DELETE SET NULL,
+    CONSTRAINT fk_tasks_creator FOREIGN KEY (created_by_user_id) REFERENCES users(id) ON DELETE RESTRICT
+);
+-- statement-break
+CREATE INDEX idx_tasks_case_status_due_at ON tasks(case_id, status, due_at);
+-- statement-break
+CREATE INDEX idx_tasks_source_clue_id ON tasks(source_clue_id);
+-- statement-break
+CREATE TABLE task_assignments (
+    task_id VARCHAR(36) PRIMARY KEY,
+    volunteer_user_id VARCHAR(36) NOT NULL,
+    assigned_by_user_id VARCHAR(36) NOT NULL,
+    assigned_at VARCHAR(40) NOT NULL,
+    updated_at VARCHAR(40) NOT NULL,
+    UNIQUE (task_id, volunteer_user_id),
+    CONSTRAINT fk_task_assignments_task FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+    CONSTRAINT fk_task_assignments_volunteer FOREIGN KEY (volunteer_user_id) REFERENCES users(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_task_assignments_assigner FOREIGN KEY (assigned_by_user_id) REFERENCES users(id) ON DELETE RESTRICT
+);
+-- statement-break
+CREATE INDEX idx_task_assignments_volunteer_assigned_at ON task_assignments(volunteer_user_id, assigned_at);
+-- statement-break
+CREATE TABLE task_location_reports (
+    id VARCHAR(36) PRIMARY KEY,
+    task_id VARCHAR(36) NOT NULL,
+    volunteer_user_id VARCHAR(36) NOT NULL,
+    source VARCHAR(16) NOT NULL CHECK (source = 'simulated'),
+    latitude DOUBLE PRECISION NOT NULL CHECK (latitude BETWEEN -90 AND 90),
+    longitude DOUBLE PRECISION NOT NULL CHECK (longitude BETWEEN -180 AND 180),
+    accuracy_meters DOUBLE PRECISION NOT NULL CHECK (accuracy_meters >= 0 AND accuracy_meters <= 10000),
+    captured_at VARCHAR(40) NOT NULL,
+    retention_expires_at VARCHAR(40) NOT NULL,
+    created_at VARCHAR(40) NOT NULL,
+    CONSTRAINT fk_task_location_reports_task FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+    CONSTRAINT fk_task_location_reports_assignment FOREIGN KEY (task_id, volunteer_user_id) REFERENCES task_assignments(task_id, volunteer_user_id) ON DELETE CASCADE
+);
+-- statement-break
+CREATE INDEX idx_task_location_reports_task_captured_at ON task_location_reports(task_id, captured_at);
+-- statement-break
+CREATE INDEX idx_task_location_reports_retention_expires_at ON task_location_reports(retention_expires_at);

--- a/migration/sql/sqlite/down/0020_drop_tasks_and_location_reports.sql
+++ b/migration/sql/sqlite/down/0020_drop_tasks_and_location_reports.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS task_location_reports;
+-- statement-break
+DROP TABLE IF EXISTS task_assignments;
+-- statement-break
+DROP TABLE IF EXISTS tasks;

--- a/migration/sql/sqlite/up/0020_create_tasks_and_location_reports.sql
+++ b/migration/sql/sqlite/up/0020_create_tasks_and_location_reports.sql
@@ -1,0 +1,70 @@
+CREATE TABLE tasks (
+    id TEXT PRIMARY KEY NOT NULL,
+    case_id TEXT NOT NULL,
+    source_clue_id TEXT,
+    title TEXT NOT NULL,
+    objective TEXT NOT NULL,
+    area_text TEXT NOT NULL,
+    latitude REAL,
+    longitude REAL,
+    due_at TEXT NOT NULL,
+    background TEXT NOT NULL,
+    risk_level TEXT NOT NULL CHECK (risk_level IN ('low', 'medium', 'high', 'critical')),
+    risk_notes TEXT NOT NULL,
+    safety_briefing TEXT NOT NULL,
+    expected_feedback TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('pending_claim', 'assigned', 'accepted', 'active', 'blocked', 'completed', 'cancelled')),
+    result_summary TEXT,
+    created_by_user_id TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    CHECK (
+        (latitude IS NULL AND longitude IS NULL)
+        OR (
+            latitude IS NOT NULL
+            AND longitude IS NOT NULL
+            AND latitude BETWEEN -90 AND 90
+            AND longitude BETWEEN -180 AND 180
+        )
+    ),
+    FOREIGN KEY (case_id) REFERENCES cases(id) ON DELETE CASCADE,
+    FOREIGN KEY (source_clue_id) REFERENCES clues(id) ON DELETE SET NULL,
+    FOREIGN KEY (created_by_user_id) REFERENCES users(id) ON DELETE RESTRICT
+);
+-- statement-break
+CREATE INDEX idx_tasks_case_status_due_at ON tasks(case_id, status, due_at);
+-- statement-break
+CREATE INDEX idx_tasks_source_clue_id ON tasks(source_clue_id);
+-- statement-break
+CREATE TABLE task_assignments (
+    task_id TEXT PRIMARY KEY NOT NULL,
+    volunteer_user_id TEXT NOT NULL,
+    assigned_by_user_id TEXT NOT NULL,
+    assigned_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE (task_id, volunteer_user_id),
+    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+    FOREIGN KEY (volunteer_user_id) REFERENCES users(id) ON DELETE RESTRICT,
+    FOREIGN KEY (assigned_by_user_id) REFERENCES users(id) ON DELETE RESTRICT
+);
+-- statement-break
+CREATE INDEX idx_task_assignments_volunteer_assigned_at ON task_assignments(volunteer_user_id, assigned_at);
+-- statement-break
+CREATE TABLE task_location_reports (
+    id TEXT PRIMARY KEY NOT NULL,
+    task_id TEXT NOT NULL,
+    volunteer_user_id TEXT NOT NULL,
+    source TEXT NOT NULL CHECK (source = 'simulated'),
+    latitude REAL NOT NULL CHECK (latitude BETWEEN -90 AND 90),
+    longitude REAL NOT NULL CHECK (longitude BETWEEN -180 AND 180),
+    accuracy_meters REAL NOT NULL CHECK (accuracy_meters >= 0 AND accuracy_meters <= 10000),
+    captured_at TEXT NOT NULL,
+    retention_expires_at TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+    FOREIGN KEY (task_id, volunteer_user_id) REFERENCES task_assignments(task_id, volunteer_user_id) ON DELETE CASCADE
+);
+-- statement-break
+CREATE INDEX idx_task_location_reports_task_captured_at ON task_location_reports(task_id, captured_at);
+-- statement-break
+CREATE INDEX idx_task_location_reports_retention_expires_at ON task_location_reports(retention_expires_at);

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -19,6 +19,7 @@ mod m0016_add_intake_assessments;
 mod m0017_add_two_phase_intake_questions;
 mod m0018_create_case_places_and_attachments;
 mod m0019_expand_clue_lifecycle;
+mod m0020_create_tasks_and_location_reports;
 
 use sea_orm_migration::sea_orm::{DbBackend, Statement};
 
@@ -47,6 +48,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0017_add_two_phase_intake_questions::Migration),
             Box::new(m0018_create_case_places_and_attachments::Migration),
             Box::new(m0019_expand_clue_lifecycle::Migration),
+            Box::new(m0020_create_tasks_and_location_reports::Migration),
         ]
     }
 }
@@ -318,7 +320,7 @@ mod tests {
             .await
             .expect("clue with a distinct report time should be stored");
 
-        assert!(Migrator::down(&database, Some(1)).await.is_err());
+        assert!(Migrator::down(&database, Some(2)).await.is_err());
         assert!(database
             .query_one(Statement::from_string(
                 sea_orm_migration::sea_orm::DbBackend::Sqlite,
@@ -327,6 +329,85 @@ mod tests {
             .await
             .expect("report-time query should succeed")
             .is_some());
+    }
+
+    #[tokio::test]
+    async fn sqlite_task_migration_enforces_assignment_location_and_rollback_integrity() {
+        let database = Database::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite connection should succeed");
+        Migrator::up(&database, None)
+            .await
+            .expect("all migrations should succeed");
+        database
+            .execute_unprepared(
+                "INSERT INTO users (id, email, display_name, account_type, password_hash, status, created_at, updated_at) VALUES ('task-commander', 'task-commander@demo.invalid', 'Task commander', 'member', 'hash', 'active', '2026-07-26T00:00:00.000Z', '2026-07-26T00:00:00.000Z'), ('task-volunteer', 'task-volunteer@demo.invalid', 'Task volunteer', 'member', 'hash', 'active', '2026-07-26T00:00:00.000Z', '2026-07-26T00:00:00.000Z'); INSERT INTO cases (id, case_code, status, created_at, updated_at) VALUES ('task-case', 'AG-00000020', 'active', '2026-07-26T00:00:00.000Z', '2026-07-26T00:00:00.000Z')",
+            )
+            .await
+            .expect("task fixtures should be stored");
+
+        assert!(
+            database
+                .execute_unprepared(&task_insert_sql("invalid-task", "missing-case"))
+                .await
+                .is_err()
+        );
+        assert!(database
+            .execute_unprepared(
+                "INSERT INTO tasks (id, case_id, source_clue_id, title, objective, area_text, latitude, longitude, due_at, background, risk_level, risk_notes, safety_briefing, expected_feedback, status, result_summary, created_by_user_id, created_at, updated_at) VALUES ('incomplete-coordinate-task', 'task-case', NULL, 'Verify north gate', 'Check the reported route', 'North gate to market', 31.2, NULL, '2026-07-27T12:00:00.000Z', 'A reviewed report needs field verification.', 'medium', 'Stay in public areas.', 'Keep contact and stop if conditions change.', 'Submit a text report for commander review.', 'assigned', NULL, 'task-commander', '2026-07-26T00:00:00.000Z', '2026-07-26T00:00:00.000Z')",
+            )
+            .await
+            .is_err());
+
+        database
+            .execute_unprepared(&task_insert_sql("task-1", "task-case"))
+            .await
+            .expect("task should reference its case");
+        assert!(database
+            .execute_unprepared(
+                "INSERT INTO task_assignments (task_id, volunteer_user_id, assigned_by_user_id, assigned_at, updated_at) VALUES ('task-1', 'missing-volunteer', 'task-commander', '2026-07-26T00:00:00.000Z', '2026-07-26T00:00:00.000Z')",
+            )
+            .await
+            .is_err());
+        database
+            .execute_unprepared(
+                "INSERT INTO task_assignments (task_id, volunteer_user_id, assigned_by_user_id, assigned_at, updated_at) VALUES ('task-1', 'task-volunteer', 'task-commander', '2026-07-26T00:00:00.000Z', '2026-07-26T00:00:00.000Z')",
+            )
+            .await
+            .expect("task should have one assigned volunteer");
+
+        assert!(database
+            .execute_unprepared(
+                "INSERT INTO task_location_reports (id, task_id, volunteer_user_id, source, latitude, longitude, accuracy_meters, captured_at, retention_expires_at, created_at) VALUES ('invalid-source', 'task-1', 'task-volunteer', 'device', 31.2, 121.5, 20, '2026-07-26T00:10:00.000Z', '2026-07-27T00:10:00.000Z', '2026-07-26T00:10:00.000Z')",
+            )
+            .await
+            .is_err());
+        assert!(database
+            .execute_unprepared(
+                "INSERT INTO task_location_reports (id, task_id, volunteer_user_id, source, latitude, longitude, accuracy_meters, captured_at, retention_expires_at, created_at) VALUES ('invalid-coordinate', 'task-1', 'task-volunteer', 'simulated', 91, 121.5, 20, '2026-07-26T00:10:00.000Z', '2026-07-27T00:10:00.000Z', '2026-07-26T00:10:00.000Z')",
+            )
+            .await
+            .is_err());
+        database
+            .execute_unprepared(
+                "INSERT INTO task_location_reports (id, task_id, volunteer_user_id, source, latitude, longitude, accuracy_meters, captured_at, retention_expires_at, created_at) VALUES ('task-location-1', 'task-1', 'task-volunteer', 'simulated', 31.2, 121.5, 20, '2026-07-26T00:10:00.000Z', '2026-07-27T00:10:00.000Z', '2026-07-26T00:10:00.000Z')",
+            )
+            .await
+            .expect("simulated task location should reference the assignment");
+
+        assert!(Migrator::down(&database, Some(1)).await.is_err());
+        database
+            .execute_unprepared("DELETE FROM tasks WHERE id = 'task-1'")
+            .await
+            .expect("task cleanup should succeed");
+        assert!(database
+            .query_one(Statement::from_string(
+                sea_orm_migration::sea_orm::DbBackend::Sqlite,
+                "SELECT 1 FROM task_assignments WHERE task_id = 'task-1' UNION ALL SELECT 1 FROM task_location_reports WHERE task_id = 'task-1'",
+            ))
+            .await
+            .expect("cascade query should succeed")
+            .is_none());
     }
 
     #[tokio::test]
@@ -439,6 +520,12 @@ mod tests {
             ))
             .await
             .expect("test member and intake session should be stored");
+    }
+
+    fn task_insert_sql(id: &str, case_id: &str) -> String {
+        format!(
+            "INSERT INTO tasks (id, case_id, source_clue_id, title, objective, area_text, latitude, longitude, due_at, background, risk_level, risk_notes, safety_briefing, expected_feedback, status, result_summary, created_by_user_id, created_at, updated_at) VALUES ('{id}', '{case_id}', NULL, 'Verify north gate', 'Check the reported route', 'North gate to market', 31.2, 121.5, '2026-07-27T12:00:00.000Z', 'A reviewed report needs field verification.', 'medium', 'Stay in public areas.', 'Keep contact and stop if conditions change.', 'Submit a text report for commander review.', 'assigned', NULL, 'task-commander', '2026-07-26T00:00:00.000Z', '2026-07-26T00:00:00.000Z')"
+        )
     }
 
     #[tokio::test]

--- a/migration/src/m0020_create_tasks_and_location_reports.rs
+++ b/migration/src/m0020_create_tasks_and_location_reports.rs
@@ -1,0 +1,55 @@
+use sea_orm_migration::prelude::*;
+
+use crate::{ensure_rollback_is_safe, execute_script, sql_for_backend};
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m0020_create_tasks_and_location_reports"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        execute_script(
+            manager,
+            sql_for_backend(
+                manager,
+                include_str!("../sql/sqlite/up/0020_create_tasks_and_location_reports.sql"),
+                include_str!("../sql/postgres/up/0020_create_tasks_and_location_reports.sql"),
+                include_str!("../sql/mysql/up/0020_create_tasks_and_location_reports.sql"),
+            ),
+        )
+        .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        ensure_rollback_is_safe(
+            manager,
+            &[
+                (
+                    "task location reports exist",
+                    "SELECT 1 FROM task_location_reports LIMIT 1",
+                ),
+                (
+                    "task assignments exist",
+                    "SELECT 1 FROM task_assignments LIMIT 1",
+                ),
+                ("tasks exist", "SELECT 1 FROM tasks LIMIT 1"),
+            ],
+        )
+        .await?;
+        execute_script(
+            manager,
+            sql_for_backend(
+                manager,
+                include_str!("../sql/sqlite/down/0020_drop_tasks_and_location_reports.sql"),
+                include_str!("../sql/postgres/down/0020_drop_tasks_and_location_reports.sql"),
+                include_str!("../sql/mysql/down/0020_drop_tasks_and_location_reports.sql"),
+            ),
+        )
+        .await
+    }
+}

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -13,5 +13,7 @@ pub mod intake_answer_revisions;
 pub mod intake_question_definitions;
 pub mod intake_session_answers;
 pub mod intake_sessions;
+pub mod task_assignments;
+pub mod tasks;
 pub mod user_global_capabilities;
 pub mod users;

--- a/src/entities/task_assignments.rs
+++ b/src/entities/task_assignments.rs
@@ -1,0 +1,32 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "task_assignments")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub task_id: String,
+    pub volunteer_user_id: String,
+    pub assigned_by_user_id: String,
+    pub assigned_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::tasks::Entity",
+        from = "Column::TaskId",
+        to = "super::tasks::Column::Id",
+        on_update = "Cascade",
+        on_delete = "Cascade"
+    )]
+    Task,
+}
+
+impl Related<super::tasks::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Task.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/entities/tasks.rs
+++ b/src/entities/tasks.rs
@@ -1,0 +1,62 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "tasks")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub case_id: String,
+    pub source_clue_id: Option<String>,
+    pub title: String,
+    pub objective: String,
+    pub area_text: String,
+    pub latitude: Option<f64>,
+    pub longitude: Option<f64>,
+    pub due_at: String,
+    pub background: String,
+    pub risk_level: String,
+    pub risk_notes: String,
+    pub safety_briefing: String,
+    pub expected_feedback: String,
+    pub status: String,
+    pub result_summary: Option<String>,
+    pub created_by_user_id: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::cases::Entity",
+        from = "Column::CaseId",
+        to = "super::cases::Column::Id",
+        on_update = "Cascade",
+        on_delete = "Cascade"
+    )]
+    Case,
+    #[sea_orm(
+        belongs_to = "super::clues::Entity",
+        from = "Column::SourceClueId",
+        to = "super::clues::Column::Id",
+        on_update = "Cascade",
+        on_delete = "SetNull"
+    )]
+    SourceClue,
+    #[sea_orm(
+        belongs_to = "super::users::Entity",
+        from = "Column::CreatedByUserId",
+        to = "super::users::Column::Id",
+        on_update = "Cascade",
+        on_delete = "Restrict"
+    )]
+    Creator,
+}
+
+impl Related<super::cases::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Case.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/models.rs
+++ b/src/models.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     entities::{
         cases, clue_attributions, clues, elder_profiles, intake_session_answers, intake_sessions,
+        task_assignments, tasks,
     },
     roles::{AccountType, CaseRole, GlobalCapability},
 };
@@ -455,6 +456,37 @@ pub struct ReviewClueRequest {
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct CreateTaskRequest {
+    pub source_clue_id: String,
+    pub volunteer_user_id: String,
+    pub title: String,
+    pub objective: String,
+    pub area_text: String,
+    pub latitude: Option<f64>,
+    pub longitude: Option<f64>,
+    pub due_at: String,
+    pub background: String,
+    pub risk_level: String,
+    pub risk_notes: String,
+    pub safety_briefing: String,
+    pub expected_feedback: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TaskListQuery {
+    pub page: Option<u64>,
+    pub page_size: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UpdateTaskStatusRequest {
+    pub status: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AddCaseMemberRequest {
     pub email: String,
     pub case_role: CaseRole,
@@ -539,6 +571,38 @@ pub struct ClueResponse {
 #[derive(Debug, Serialize)]
 pub struct ClueTimelineResponse {
     pub items: Vec<ClueResponse>,
+    pub page: u64,
+    pub page_size: u64,
+    pub total: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TaskResponse {
+    pub id: String,
+    pub case_id: String,
+    pub source_clue_id: Option<String>,
+    pub title: String,
+    pub objective: String,
+    pub area_text: String,
+    pub latitude: Option<f64>,
+    pub longitude: Option<f64>,
+    pub due_at: String,
+    pub background: Option<String>,
+    pub risk_level: String,
+    pub risk_notes: String,
+    pub safety_briefing: String,
+    pub expected_feedback: String,
+    pub status: String,
+    pub result_summary: Option<String>,
+    pub assigned_volunteer_user_id: Option<String>,
+    pub assigned_at: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TaskListResponse {
+    pub items: Vec<TaskResponse>,
     pub page: u64,
     pub page_size: u64,
     pub total: u64,
@@ -632,6 +696,43 @@ impl ClueResponse {
             is_own_submission: attribution
                 .and_then(|attribution| attribution.submitted_by_user_id)
                 .is_some_and(|user_id| user_id == viewer_user_id),
+        }
+    }
+}
+
+impl TaskResponse {
+    pub fn new(
+        model: tasks::Model,
+        assignment: Option<task_assignments::Model>,
+        include_assignee: bool,
+    ) -> Self {
+        Self {
+            id: model.id,
+            case_id: model.case_id,
+            source_clue_id: include_assignee.then_some(model.source_clue_id).flatten(),
+            title: model.title,
+            objective: model.objective,
+            area_text: model.area_text,
+            latitude: model.latitude,
+            longitude: model.longitude,
+            due_at: model.due_at,
+            background: include_assignee.then_some(model.background),
+            risk_level: model.risk_level,
+            risk_notes: model.risk_notes,
+            safety_briefing: model.safety_briefing,
+            expected_feedback: model.expected_feedback,
+            status: model.status,
+            result_summary: model.result_summary,
+            assigned_volunteer_user_id: include_assignee
+                .then(|| {
+                    assignment
+                        .as_ref()
+                        .map(|value| value.volunteer_user_id.clone())
+                })
+                .flatten(),
+            assigned_at: assignment.map(|value| value.assigned_at),
+            created_at: model.created_at,
+            updated_at: model.updated_at,
         }
     }
 }

--- a/src/routes/cases.rs
+++ b/src/routes/cases.rs
@@ -7,7 +7,8 @@ use crate::{
     error::ApiError,
     models::{
         AddCaseMemberRequest, AuthenticatedUser, CaseResourceConfigurationResponse,
-        CreateCasePlaceRequest, CreateCaseRequest, CreateClueRequest, UpdateCaseStatusRequest,
+        CreateCasePlaceRequest, CreateCaseRequest, CreateClueRequest, CreateTaskRequest,
+        TaskListQuery, UpdateCaseStatusRequest,
     },
     roles::CaseRole,
     services::case_service,
@@ -22,6 +23,8 @@ pub fn configure(config: &mut web::ServiceConfig) {
             .route("/{case_id}/status", web::patch().to(update_case_status))
             .route("/{case_id}/clues", web::get().to(list_clues))
             .route("/{case_id}/clues", web::post().to(create_clue))
+            .route("/{case_id}/tasks", web::get().to(list_tasks))
+            .route("/{case_id}/tasks", web::post().to(create_task))
             .route("/{case_id}/places", web::post().to(create_place))
             .route(
                 "/{case_id}/resource-configuration",
@@ -211,6 +214,34 @@ async fn list_clues(
 ) -> Result<HttpResponse, ApiError> {
     let clues = case_service::list_clues(&state.db, &auth, &case_id, query.into_inner()).await?;
     Ok(HttpResponse::Ok().json(clues))
+}
+
+async fn create_task(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    case_id: web::Path<String>,
+    request: web::Json<CreateTaskRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let task = crate::services::task_service::create_task(
+        &state.db,
+        &auth,
+        &case_id,
+        request.into_inner(),
+    )
+    .await?;
+    Ok(HttpResponse::Created().json(task))
+}
+
+async fn list_tasks(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    case_id: web::Path<String>,
+    query: web::Query<TaskListQuery>,
+) -> Result<HttpResponse, ApiError> {
+    Ok(HttpResponse::Ok().json(
+        crate::services::task_service::list_tasks(&state.db, &auth, &case_id, query.into_inner())
+            .await?,
+    ))
 }
 
 async fn add_case_member(

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -3,6 +3,7 @@ mod cases;
 mod clues;
 mod health;
 mod intake_sessions;
+mod tasks;
 
 use actix_web::{HttpResponse, web};
 
@@ -44,6 +45,7 @@ pub fn configure(config: &mut web::ServiceConfig) {
             .configure(auth::configure)
             .configure(cases::configure)
             .configure(intake_sessions::configure)
-            .configure(clues::configure),
+            .configure(clues::configure)
+            .configure(tasks::configure),
     );
 }

--- a/src/routes/tasks.rs
+++ b/src/routes/tasks.rs
@@ -1,0 +1,34 @@
+use actix_web::{HttpResponse, web};
+
+use crate::{
+    app_state::AppState,
+    error::ApiError,
+    models::{AuthenticatedUser, UpdateTaskStatusRequest},
+    services::task_service,
+};
+
+pub fn configure(config: &mut web::ServiceConfig) {
+    config.service(
+        web::scope("/tasks")
+            .route("/mine", web::get().to(list_my_tasks))
+            .route("/{task_id}/status", web::patch().to(update_task_status)),
+    );
+}
+
+async fn list_my_tasks(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+) -> Result<HttpResponse, ApiError> {
+    Ok(HttpResponse::Ok().json(task_service::list_my_tasks(&state.db, &auth).await?))
+}
+
+async fn update_task_status(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    task_id: web::Path<String>,
+    request: web::Json<UpdateTaskStatusRequest>,
+) -> Result<HttpResponse, ApiError> {
+    Ok(HttpResponse::Ok().json(
+        task_service::update_task_status(&state.db, &auth, &task_id, request.into_inner()).await?,
+    ))
+}

--- a/src/services/case_service.rs
+++ b/src/services/case_service.rs
@@ -1125,7 +1125,7 @@ fn trim_optional(value: Option<String>) -> Option<String> {
     })
 }
 
-fn new_id() -> String {
+pub(crate) fn new_id() -> String {
     Uuid::new_v4().to_string()
 }
 

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -2,3 +2,4 @@ pub mod auth_service;
 pub mod case_resource_service;
 pub mod case_service;
 pub mod intake_session_service;
+pub mod task_service;

--- a/src/services/task_service.rs
+++ b/src/services/task_service.rs
@@ -1,0 +1,502 @@
+use std::collections::{HashMap, HashSet};
+
+use chrono::{DateTime, SecondsFormat, Utc};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, IntoActiveModel, QueryFilter,
+    QueryOrder, Set, TransactionTrait,
+};
+use serde_json::json;
+
+use crate::{
+    entities::{
+        case_memberships, cases, clues, task_assignments, tasks, user_global_capabilities, users,
+    },
+    error::ApiError,
+    models::{
+        AuthenticatedUser, CreateTaskRequest, TaskListQuery, TaskListResponse, TaskResponse,
+        UpdateTaskStatusRequest,
+    },
+    roles::{CaseRole, GlobalCapability},
+    services::case_service::{require_case_role, write_audit},
+};
+
+const TASK_STATUSES: &[&str] = &[
+    "pending_claim",
+    "assigned",
+    "accepted",
+    "active",
+    "blocked",
+    "completed",
+    "cancelled",
+];
+const TASK_RISK_LEVELS: &[&str] = &["low", "medium", "high", "critical"];
+const MAX_TASK_PAGE_SIZE: u64 = 100;
+
+pub async fn create_task(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    case_id: &str,
+    request: CreateTaskRequest,
+) -> Result<TaskResponse, ApiError> {
+    let request = ValidatedCreateTaskRequest::try_from(request)?;
+    let transaction = db.begin().await?;
+    require_case_role(&transaction, &auth.id, case_id, &[CaseRole::Commander]).await?;
+
+    let case = cases::Entity::find_by_id(case_id)
+        .one(&transaction)
+        .await?
+        .ok_or_else(|| ApiError::NotFound("case was not found".to_owned()))?;
+    if case.status == "closed" {
+        return Err(ApiError::Conflict(
+            "tasks cannot be created for a closed case".to_owned(),
+        ));
+    }
+
+    let source_clue = clues::Entity::find_by_id(&request.source_clue_id)
+        .one(&transaction)
+        .await?
+        .filter(|clue| clue.case_id == case_id && clue.status == "confirmed")
+        .ok_or_else(|| {
+            ApiError::Validation(
+                "source_clue_id must reference a confirmed clue in this case".to_owned(),
+            )
+        })?;
+
+    let volunteer_membership = case_memberships::Entity::find()
+        .filter(case_memberships::Column::CaseId.eq(case_id))
+        .filter(case_memberships::Column::UserId.eq(&request.volunteer_user_id))
+        .filter(case_memberships::Column::Role.eq(CaseRole::Volunteer.to_string()))
+        .one(&transaction)
+        .await?;
+    let volunteer_is_active = users::Entity::find_by_id(&request.volunteer_user_id)
+        .filter(users::Column::Status.eq("active"))
+        .one(&transaction)
+        .await?
+        .is_some();
+    let volunteer_is_authorized = user_global_capabilities::Entity::find()
+        .filter(user_global_capabilities::Column::UserId.eq(&request.volunteer_user_id))
+        .filter(user_global_capabilities::Column::Capability.eq("volunteer"))
+        .one(&transaction)
+        .await?
+        .is_some();
+    if volunteer_membership.is_none() || !volunteer_is_active || !volunteer_is_authorized {
+        return Err(ApiError::Validation(
+            "volunteer_user_id must reference an active volunteer in this case".to_owned(),
+        ));
+    }
+
+    let timestamp = now();
+    let task_id = crate::services::case_service::new_id();
+    let task = tasks::ActiveModel {
+        id: Set(task_id.clone()),
+        case_id: Set(case_id.to_owned()),
+        source_clue_id: Set(Some(source_clue.id)),
+        title: Set(request.title),
+        objective: Set(request.objective),
+        area_text: Set(request.area_text),
+        latitude: Set(request.latitude),
+        longitude: Set(request.longitude),
+        due_at: Set(request.due_at),
+        background: Set(request.background),
+        risk_level: Set(request.risk_level),
+        risk_notes: Set(request.risk_notes),
+        safety_briefing: Set(request.safety_briefing),
+        expected_feedback: Set(request.expected_feedback),
+        status: Set("assigned".to_owned()),
+        result_summary: Set(None),
+        created_by_user_id: Set(auth.id.clone()),
+        created_at: Set(timestamp.clone()),
+        updated_at: Set(timestamp.clone()),
+    }
+    .insert(&transaction)
+    .await?;
+    let assignment = task_assignments::ActiveModel {
+        task_id: Set(task_id.clone()),
+        volunteer_user_id: Set(request.volunteer_user_id.clone()),
+        assigned_by_user_id: Set(auth.id.clone()),
+        assigned_at: Set(timestamp.clone()),
+        updated_at: Set(timestamp),
+    }
+    .insert(&transaction)
+    .await?;
+
+    write_audit(
+        &transaction,
+        Some(case_id.to_owned()),
+        auth,
+        "task.created",
+        "task",
+        task_id.clone(),
+        Some(json!({
+            "status": "assigned",
+            "source_clue_id": task.source_clue_id,
+            "risk_level": task.risk_level,
+        })),
+    )
+    .await?;
+    write_audit(
+        &transaction,
+        Some(case_id.to_owned()),
+        auth,
+        "task.assigned",
+        "task",
+        task_id,
+        Some(json!({ "volunteer_user_id": assignment.volunteer_user_id })),
+    )
+    .await?;
+
+    transaction.commit().await?;
+    Ok(TaskResponse::new(task, Some(assignment), true))
+}
+
+pub async fn list_tasks(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    case_id: &str,
+    query: TaskListQuery,
+) -> Result<TaskListResponse, ApiError> {
+    let query = ValidatedTaskListQuery::try_from(query)?;
+    let case_role = require_case_role(
+        db,
+        &auth.id,
+        case_id,
+        &[CaseRole::Family, CaseRole::Commander, CaseRole::Volunteer],
+    )
+    .await?;
+    if case_role == CaseRole::Family {
+        return Ok(TaskListResponse {
+            items: Vec::new(),
+            page: query.page,
+            page_size: query.page_size,
+            total: 0,
+        });
+    }
+
+    let task_models = tasks::Entity::find()
+        .filter(tasks::Column::CaseId.eq(case_id))
+        .order_by_asc(tasks::Column::DueAt)
+        .order_by_asc(tasks::Column::Id)
+        .all(db)
+        .await?;
+    let assignments =
+        assignments_for_tasks(db, task_models.iter().map(|task| task.id.clone())).await?;
+    let visible_tasks = task_models
+        .into_iter()
+        .filter(|task| {
+            case_role == CaseRole::Commander
+                || assignments
+                    .get(&task.id)
+                    .is_some_and(|assignment| assignment.volunteer_user_id == auth.id)
+        })
+        .collect::<Vec<_>>();
+    let total = u64::try_from(visible_tasks.len()).map_err(|_| ApiError::Internal)?;
+    let start = query.offset()?;
+    let items = visible_tasks
+        .into_iter()
+        .skip(start)
+        .take(query.page_size_usize())
+        .map(|task| {
+            let assignment = assignments.get(&task.id).cloned();
+            TaskResponse::new(task, assignment, case_role == CaseRole::Commander)
+        })
+        .collect();
+
+    Ok(TaskListResponse {
+        items,
+        page: query.page,
+        page_size: query.page_size,
+        total,
+    })
+}
+
+pub async fn list_my_tasks(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+) -> Result<Vec<TaskResponse>, ApiError> {
+    if !auth
+        .global_capabilities
+        .contains(&GlobalCapability::Volunteer)
+    {
+        return Err(ApiError::Forbidden(
+            "only volunteer accounts can access the personal task queue".to_owned(),
+        ));
+    }
+
+    let volunteer_case_ids = case_memberships::Entity::find()
+        .filter(case_memberships::Column::UserId.eq(&auth.id))
+        .filter(case_memberships::Column::Role.eq(CaseRole::Volunteer.to_string()))
+        .all(db)
+        .await?
+        .into_iter()
+        .map(|membership| membership.case_id)
+        .collect::<HashSet<_>>();
+    if volunteer_case_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let assignments = task_assignments::Entity::find()
+        .filter(task_assignments::Column::VolunteerUserId.eq(&auth.id))
+        .all(db)
+        .await?;
+    if assignments.is_empty() {
+        return Ok(Vec::new());
+    }
+    let assignments = assignments
+        .into_iter()
+        .map(|assignment| (assignment.task_id.clone(), assignment))
+        .collect::<HashMap<_, _>>();
+    let task_models = tasks::Entity::find()
+        .filter(tasks::Column::Id.is_in(assignments.keys().cloned()))
+        .order_by_asc(tasks::Column::DueAt)
+        .order_by_asc(tasks::Column::Id)
+        .all(db)
+        .await?;
+
+    Ok(task_models
+        .into_iter()
+        .filter(|task| volunteer_case_ids.contains(&task.case_id))
+        .map(|task| {
+            let assignment = assignments.get(&task.id).cloned();
+            TaskResponse::new(task, assignment, false)
+        })
+        .collect())
+}
+
+pub async fn update_task_status(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    task_id: &str,
+    request: UpdateTaskStatusRequest,
+) -> Result<TaskResponse, ApiError> {
+    let next_status = request.status.trim().to_lowercase();
+    if !TASK_STATUSES.contains(&next_status.as_str()) {
+        return Err(ApiError::Validation("status is unsupported".to_owned()));
+    }
+    let transaction = db.begin().await?;
+    let task = tasks::Entity::find_by_id(task_id)
+        .one(&transaction)
+        .await?
+        .ok_or_else(|| ApiError::NotFound("task was not found".to_owned()))?;
+    let case_role = require_case_role(
+        &transaction,
+        &auth.id,
+        &task.case_id,
+        &[CaseRole::Family, CaseRole::Commander, CaseRole::Volunteer],
+    )
+    .await?;
+    let assignment = task_assignments::Entity::find_by_id(task_id)
+        .one(&transaction)
+        .await?
+        .ok_or_else(|| {
+            ApiError::Database(sea_orm::DbErr::Custom(
+                "task is missing its required assignment".to_owned(),
+            ))
+        })?;
+
+    if case_role == CaseRole::Commander {
+        if next_status != "cancelled" || is_terminal_status(&task.status) {
+            return Err(ApiError::Conflict(
+                "commanders can only cancel unfinished tasks".to_owned(),
+            ));
+        }
+    } else {
+        if case_role != CaseRole::Volunteer || assignment.volunteer_user_id != auth.id {
+            return Err(ApiError::NotFound("task was not found".to_owned()));
+        }
+        if !volunteer_transition_allowed(&task.status, &next_status) {
+            return Err(ApiError::Conflict(format!(
+                "task status cannot change from {:?} to {:?}",
+                task.status, next_status
+            )));
+        }
+    }
+
+    let previous_status = task.status.clone();
+    let mut active = task.into_active_model();
+    active.status = Set(next_status.clone());
+    active.updated_at = Set(now());
+    let updated = active.update(&transaction).await?;
+    write_audit(
+        &transaction,
+        Some(updated.case_id.clone()),
+        auth,
+        "task.status_changed",
+        "task",
+        updated.id.clone(),
+        Some(json!({ "from": previous_status, "to": next_status })),
+    )
+    .await?;
+    transaction.commit().await?;
+
+    Ok(TaskResponse::new(
+        updated,
+        Some(assignment),
+        case_role == CaseRole::Commander,
+    ))
+}
+
+async fn assignments_for_tasks(
+    db: &DatabaseConnection,
+    task_ids: impl IntoIterator<Item = String>,
+) -> Result<HashMap<String, task_assignments::Model>, ApiError> {
+    let task_ids = task_ids.into_iter().collect::<Vec<_>>();
+    if task_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    Ok(task_assignments::Entity::find()
+        .filter(task_assignments::Column::TaskId.is_in(task_ids))
+        .all(db)
+        .await?
+        .into_iter()
+        .map(|assignment| (assignment.task_id.clone(), assignment))
+        .collect())
+}
+
+struct ValidatedCreateTaskRequest {
+    source_clue_id: String,
+    volunteer_user_id: String,
+    title: String,
+    objective: String,
+    area_text: String,
+    latitude: Option<f64>,
+    longitude: Option<f64>,
+    due_at: String,
+    background: String,
+    risk_level: String,
+    risk_notes: String,
+    safety_briefing: String,
+    expected_feedback: String,
+}
+
+impl TryFrom<CreateTaskRequest> for ValidatedCreateTaskRequest {
+    type Error = ApiError;
+
+    fn try_from(value: CreateTaskRequest) -> Result<Self, Self::Error> {
+        let source_clue_id = required_field("source_clue_id", value.source_clue_id, 36)?;
+        let volunteer_user_id = required_field("volunteer_user_id", value.volunteer_user_id, 36)?;
+        let title = required_field("title", value.title, 200)?;
+        let objective = required_field("objective", value.objective, 4_000)?;
+        let area_text = required_field("area_text", value.area_text, 500)?;
+        validate_coordinates(value.latitude, value.longitude)?;
+        let due_at = parse_due_at(&value.due_at)?;
+        let background = required_field("background", value.background, 10_000)?;
+        let risk_level = value.risk_level.trim().to_lowercase();
+        if !TASK_RISK_LEVELS.contains(&risk_level.as_str()) {
+            return Err(ApiError::Validation("risk_level is unsupported".to_owned()));
+        }
+        let risk_notes = required_field("risk_notes", value.risk_notes, 4_000)?;
+        let safety_briefing = required_field("safety_briefing", value.safety_briefing, 4_000)?;
+        let expected_feedback =
+            required_field("expected_feedback", value.expected_feedback, 4_000)?;
+        Ok(Self {
+            source_clue_id,
+            volunteer_user_id,
+            title,
+            objective,
+            area_text,
+            latitude: value.latitude,
+            longitude: value.longitude,
+            due_at,
+            background,
+            risk_level,
+            risk_notes,
+            safety_briefing,
+            expected_feedback,
+        })
+    }
+}
+
+struct ValidatedTaskListQuery {
+    page: u64,
+    page_size: u64,
+}
+
+impl ValidatedTaskListQuery {
+    fn offset(&self) -> Result<usize, ApiError> {
+        let offset = self
+            .page
+            .checked_sub(1)
+            .and_then(|page| page.checked_mul(self.page_size))
+            .ok_or_else(|| ApiError::Validation("page is too large".to_owned()))?;
+        usize::try_from(offset).map_err(|_| ApiError::Validation("page is too large".to_owned()))
+    }
+
+    fn page_size_usize(&self) -> usize {
+        self.page_size as usize
+    }
+}
+
+impl TryFrom<TaskListQuery> for ValidatedTaskListQuery {
+    type Error = ApiError;
+
+    fn try_from(value: TaskListQuery) -> Result<Self, Self::Error> {
+        let page = value.page.unwrap_or(1);
+        let page_size = value.page_size.unwrap_or(25);
+        if page == 0 {
+            return Err(ApiError::Validation("page must be at least 1".to_owned()));
+        }
+        if page_size == 0 || page_size > MAX_TASK_PAGE_SIZE {
+            return Err(ApiError::Validation(format!(
+                "page_size must be between 1 and {MAX_TASK_PAGE_SIZE}"
+            )));
+        }
+        Ok(Self { page, page_size })
+    }
+}
+
+fn required_field(label: &str, value: String, maximum: usize) -> Result<String, ApiError> {
+    let value = value.trim();
+    if value.is_empty() || value.chars().count() > maximum {
+        return Err(ApiError::Validation(format!(
+            "{label} must contain between 1 and {maximum} characters"
+        )));
+    }
+    Ok(value.to_owned())
+}
+
+fn validate_coordinates(latitude: Option<f64>, longitude: Option<f64>) -> Result<(), ApiError> {
+    match (latitude, longitude) {
+        (None, None) => Ok(()),
+        (Some(latitude), Some(longitude))
+            if latitude.is_finite()
+                && longitude.is_finite()
+                && (-90.0..=90.0).contains(&latitude)
+                && (-180.0..=180.0).contains(&longitude) =>
+        {
+            Ok(())
+        }
+        _ => Err(ApiError::Validation(
+            "latitude and longitude must be provided together and be within range".to_owned(),
+        )),
+    }
+}
+
+fn parse_due_at(value: &str) -> Result<String, ApiError> {
+    let due_at = DateTime::parse_from_rfc3339(value.trim())
+        .map_err(|_| ApiError::Validation("due_at must be an RFC 3339 timestamp".to_owned()))?
+        .with_timezone(&Utc);
+    if due_at <= Utc::now() {
+        return Err(ApiError::Validation(
+            "due_at must be in the future".to_owned(),
+        ));
+    }
+    Ok(due_at.to_rfc3339_opts(SecondsFormat::Millis, true))
+}
+
+fn volunteer_transition_allowed(current: &str, next: &str) -> bool {
+    matches!(
+        (current, next),
+        ("assigned", "accepted")
+            | ("accepted", "active")
+            | ("active", "blocked")
+            | ("blocked", "active")
+            | ("active", "completed")
+    )
+}
+
+fn is_terminal_status(status: &str) -> bool {
+    matches!(status, "completed" | "cancelled")
+}
+
+fn now() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}

--- a/src/services/task_service.rs
+++ b/src/services/task_service.rs
@@ -1,9 +1,10 @@
 use std::collections::{HashMap, HashSet};
 
 use chrono::{DateTime, SecondsFormat, Utc};
+use sea_orm::sea_query::Expr;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, IntoActiveModel, QueryFilter,
-    QueryOrder, Set, TransactionTrait,
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder, Set,
+    TransactionTrait,
 };
 use serde_json::json;
 
@@ -311,10 +312,22 @@ pub async fn update_task_status(
     }
 
     let previous_status = task.status.clone();
-    let mut active = task.into_active_model();
-    active.status = Set(next_status.clone());
-    active.updated_at = Set(now());
-    let updated = active.update(&transaction).await?;
+    let update_result = tasks::Entity::update_many()
+        .col_expr(tasks::Column::Status, Expr::value(next_status.clone()))
+        .col_expr(tasks::Column::UpdatedAt, Expr::value(now()))
+        .filter(tasks::Column::Id.eq(task_id))
+        .filter(tasks::Column::Status.eq(&previous_status))
+        .exec(&transaction)
+        .await?;
+    if update_result.rows_affected != 1 {
+        return Err(ApiError::Conflict(
+            "task status changed before this transition could be applied".to_owned(),
+        ));
+    }
+    let updated = tasks::Entity::find_by_id(task_id)
+        .one(&transaction)
+        .await?
+        .ok_or_else(|| ApiError::Internal)?;
     write_audit(
         &transaction,
         Some(updated.case_id.clone()),

--- a/src/services/task_service.rs
+++ b/src/services/task_service.rs
@@ -305,7 +305,7 @@ pub async fn update_task_status(
         }
         if !volunteer_transition_allowed(&task.status, &next_status) {
             return Err(ApiError::Conflict(format!(
-                "task status cannot change from {:?} to {:?}",
+                "task status cannot change from {} to {}",
                 task.status, next_status
             )));
         }

--- a/tests/api/mod.rs
+++ b/tests/api/mod.rs
@@ -17,3 +17,4 @@ mod intake_session_confirm_post;
 mod intake_session_profile_draft_get;
 mod intake_sessions_create_post;
 mod openapi_intake_contract;
+mod tasks_api;

--- a/tests/api/tasks_api.rs
+++ b/tests/api/tasks_api.rs
@@ -1,0 +1,393 @@
+use actix_web::{
+    http::{StatusCode, header},
+    test,
+};
+use angui::entities::audit_events;
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use serde_json::{Value, json};
+
+use crate::support::{ADMIN, COMMANDER, FAMILY, TestContext, VOLUNTEER, assert_error};
+
+macro_rules! confirmed_clue {
+    ($context:expr, $app:expr, $case_id:expr, $commander_token:expr) => {{
+        let clue_id = $context.create_clue($case_id, FAMILY).await;
+        let reviewed = test::call_service(
+            $app,
+            test::TestRequest::patch()
+                .uri(&format!("/api/clues/{clue_id}/review"))
+                .insert_header((
+                    header::AUTHORIZATION,
+                    format!("Bearer {}", $commander_token),
+                ))
+                .set_json(json!({ "status": "confirmed", "reason": "source verified" }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(reviewed.status(), StatusCode::OK);
+        clue_id
+    }};
+}
+
+macro_rules! create_task {
+    ($app:expr, $case_id:expr, $commander_token:expr, $source_clue_id:expr, $volunteer_user_id:expr) => {{
+        let response = test::call_service(
+            $app,
+            test::TestRequest::post()
+                .uri(&format!("/api/cases/{}/tasks", $case_id))
+                .insert_header((
+                    header::AUTHORIZATION,
+                    format!("Bearer {}", $commander_token),
+                ))
+                .set_json(task_json($source_clue_id, $volunteer_user_id))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::CREATED);
+        test::read_body_json::<Value, _>(response).await["id"]
+            .as_str()
+            .expect("task id should be returned")
+            .to_owned()
+    }};
+}
+
+macro_rules! update_status {
+    ($app:expr, $task_id:expr, $token:expr, $status:expr) => {{
+        test::call_service(
+            $app,
+            test::TestRequest::patch()
+                .uri(&format!("/api/tasks/{}/status", $task_id))
+                .insert_header((header::AUTHORIZATION, format!("Bearer {}", $token)))
+                .set_json(json!({ "status": $status }))
+                .to_request(),
+        )
+        .await
+    }};
+}
+
+#[actix_web::test]
+async fn post_case_tasks_requires_a_commander_confirmed_source_and_active_case_volunteer() {
+    let context = TestContext::new().await;
+    let app = crate::init_api_app!(&context);
+    let case_id = context.create_case().await;
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    context
+        .add_member(&case_id, COMMANDER, VOLUNTEER, "volunteer")
+        .await;
+    let commander_token = context.token(COMMANDER).await;
+    let family_token = context.token(FAMILY).await;
+    let volunteer_token = context.token(VOLUNTEER).await;
+    let admin_token = context.token(ADMIN).await;
+    let volunteer = context.authenticated(VOLUNTEER).await;
+    let source_clue_id = confirmed_clue!(&context, &app, &case_id, &commander_token);
+
+    for (token, expected_status, expected_code) in [
+        (&family_token, StatusCode::FORBIDDEN, "forbidden"),
+        (&volunteer_token, StatusCode::FORBIDDEN, "forbidden"),
+        (&admin_token, StatusCode::NOT_FOUND, "not_found"),
+    ] {
+        let response = test::call_service(
+            &app,
+            test::TestRequest::post()
+                .uri(&format!("/api/cases/{case_id}/tasks"))
+                .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+                .set_json(task_json(&source_clue_id, &volunteer.id))
+                .to_request(),
+        )
+        .await;
+        assert_error(response, expected_status, expected_code).await;
+    }
+
+    let mut invalid_coordinates = task_json(&source_clue_id, &volunteer.id);
+    invalid_coordinates["latitude"] = json!(91);
+    let invalid_coordinates = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/tasks"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(invalid_coordinates)
+            .to_request(),
+    )
+    .await;
+    assert_error(
+        invalid_coordinates,
+        StatusCode::BAD_REQUEST,
+        "validation_error",
+    )
+    .await;
+
+    let created = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/tasks"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(task_json(&source_clue_id, &volunteer.id))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(created.status(), StatusCode::CREATED);
+    let created: Value = test::read_body_json(created).await;
+    assert_eq!(created["status"], "assigned");
+    assert_eq!(created["source_clue_id"], source_clue_id);
+    assert_eq!(created["assigned_volunteer_user_id"], volunteer.id);
+    let task_id = created["id"].as_str().expect("task id should be returned");
+
+    let audits = audit_events::Entity::find()
+        .filter(audit_events::Column::EntityId.eq(task_id))
+        .all(&context.database)
+        .await
+        .expect("task audits should be readable");
+    assert_eq!(audits.len(), 2);
+    assert!(audits.iter().any(|audit| audit.action == "task.created"));
+    assert!(audits.iter().any(|audit| audit.action == "task.assigned"));
+
+    let unconfirmed_clue_id = context.create_clue(&case_id, FAMILY).await;
+    let unconfirmed = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/tasks"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(task_json(&unconfirmed_clue_id, &volunteer.id))
+            .to_request(),
+    )
+    .await;
+    assert_error(unconfirmed, StatusCode::BAD_REQUEST, "validation_error").await;
+
+    let no_volunteer = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/tasks"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(task_json(
+                &source_clue_id,
+                &context.authenticated(COMMANDER).await.id,
+            ))
+            .to_request(),
+    )
+    .await;
+    assert_error(no_volunteer, StatusCode::BAD_REQUEST, "validation_error").await;
+
+    context.close_case(&case_id).await;
+    let closed_case = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/tasks"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(task_json(&source_clue_id, &volunteer.id))
+            .to_request(),
+    )
+    .await;
+    assert_error(closed_case, StatusCode::CONFLICT, "conflict").await;
+}
+
+#[actix_web::test]
+async fn task_lists_are_server_filtered_by_case_role_and_personal_queue_requires_volunteer() {
+    let context = TestContext::new().await;
+    let empty_app = crate::init_api_app!(&context);
+    let empty_volunteer_token = context.token(VOLUNTEER).await;
+    let empty_queue = test::call_service(
+        &empty_app,
+        test::TestRequest::get()
+            .uri("/api/tasks/mine")
+            .insert_header((
+                header::AUTHORIZATION,
+                format!("Bearer {empty_volunteer_token}"),
+            ))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(empty_queue.status(), StatusCode::OK);
+    assert_eq!(
+        test::read_body_json::<Value, _>(empty_queue).await,
+        json!([])
+    );
+
+    let app = crate::init_api_app!(&context);
+    let case_id = context.create_case().await;
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    context
+        .add_member(&case_id, COMMANDER, VOLUNTEER, "volunteer")
+        .await;
+    let commander_token = context.token(COMMANDER).await;
+    let volunteer_token = context.token(VOLUNTEER).await;
+    let family_token = context.token(FAMILY).await;
+    let admin_token = context.token(ADMIN).await;
+    let volunteer = context.authenticated(VOLUNTEER).await;
+    let source_clue_id = confirmed_clue!(&context, &app, &case_id, &commander_token);
+    let created = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/tasks"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(task_json(&source_clue_id, &volunteer.id))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(created.status(), StatusCode::CREATED);
+
+    let commander_tasks = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/cases/{case_id}/tasks?page=1&page_size=1"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(commander_tasks.status(), StatusCode::OK);
+    let commander_tasks: Value = test::read_body_json(commander_tasks).await;
+    assert_eq!(commander_tasks["total"], 1);
+    assert_eq!(
+        commander_tasks["items"][0]["assigned_volunteer_user_id"],
+        volunteer.id
+    );
+
+    let volunteer_tasks = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/cases/{case_id}/tasks"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {volunteer_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(volunteer_tasks.status(), StatusCode::OK);
+    let volunteer_tasks: Value = test::read_body_json(volunteer_tasks).await;
+    assert_eq!(volunteer_tasks["total"], 1);
+    assert_eq!(
+        volunteer_tasks["items"][0]["assigned_volunteer_user_id"],
+        Value::Null
+    );
+    assert_eq!(volunteer_tasks["items"][0]["source_clue_id"], Value::Null);
+    assert_eq!(volunteer_tasks["items"][0]["background"], Value::Null);
+
+    let family_tasks = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/cases/{case_id}/tasks"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {family_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(family_tasks.status(), StatusCode::OK);
+    let family_tasks: Value = test::read_body_json(family_tasks).await;
+    assert_eq!(family_tasks["items"], json!([]));
+
+    let personal_queue = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/api/tasks/mine")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {volunteer_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(personal_queue.status(), StatusCode::OK);
+    let personal_queue: Value = test::read_body_json(personal_queue).await;
+    assert_eq!(personal_queue.as_array().map(Vec::len), Some(1));
+    assert_eq!(personal_queue[0]["assigned_volunteer_user_id"], Value::Null);
+    assert_eq!(personal_queue[0]["source_clue_id"], Value::Null);
+    assert_eq!(personal_queue[0]["background"], Value::Null);
+
+    for token in [&family_token, &commander_token, &admin_token] {
+        let queue = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri("/api/tasks/mine")
+                .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+                .to_request(),
+        )
+        .await;
+        assert_error(queue, StatusCode::FORBIDDEN, "forbidden").await;
+    }
+
+    let unrelated = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/cases/{case_id}/tasks"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {admin_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_error(unrelated, StatusCode::NOT_FOUND, "not_found").await;
+}
+
+#[actix_web::test]
+async fn task_status_state_machine_is_limited_to_the_assignee_or_commander_cancellation_and_audited()
+ {
+    let context = TestContext::new().await;
+    let app = crate::init_api_app!(&context);
+    let case_id = context.create_case().await;
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    context
+        .add_member(&case_id, COMMANDER, VOLUNTEER, "volunteer")
+        .await;
+    let commander_token = context.token(COMMANDER).await;
+    let volunteer_token = context.token(VOLUNTEER).await;
+    let volunteer = context.authenticated(VOLUNTEER).await;
+    let source_clue_id = confirmed_clue!(&context, &app, &case_id, &commander_token);
+    let task_id = create_task!(
+        &app,
+        &case_id,
+        &commander_token,
+        &source_clue_id,
+        &volunteer.id
+    );
+
+    let illegal = update_status!(&app, &task_id, &volunteer_token, "completed");
+    assert_error(illegal, StatusCode::CONFLICT, "conflict").await;
+    for status in ["accepted", "active", "blocked", "active", "completed"] {
+        let response = update_status!(&app, &task_id, &volunteer_token, status);
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value = test::read_body_json(response).await;
+        assert_eq!(body["status"], status);
+    }
+    let completed_cancel = update_status!(&app, &task_id, &commander_token, "cancelled");
+    assert_error(completed_cancel, StatusCode::CONFLICT, "conflict").await;
+
+    let cancellable_task_id = create_task!(
+        &app,
+        &case_id,
+        &commander_token,
+        &source_clue_id,
+        &volunteer.id
+    );
+    let cancelled = update_status!(&app, &cancellable_task_id, &commander_token, "cancelled");
+    assert_eq!(cancelled.status(), StatusCode::OK);
+    let cancelled: Value = test::read_body_json(cancelled).await;
+    assert_eq!(cancelled["status"], "cancelled");
+
+    let audits = audit_events::Entity::find()
+        .filter(audit_events::Column::EntityId.eq(&task_id))
+        .filter(audit_events::Column::Action.eq("task.status_changed"))
+        .all(&context.database)
+        .await
+        .expect("state transition audits should be readable");
+    assert_eq!(audits.len(), 5);
+    assert!(audits.iter().all(|audit| {
+        audit.metadata_json.as_deref().is_some_and(|metadata| {
+            let metadata: Value = serde_json::from_str(metadata).expect("audit metadata is JSON");
+            metadata["from"].is_string() && metadata["to"].is_string()
+        })
+    }));
+}
+
+fn task_json(source_clue_id: &str, volunteer_user_id: &str) -> Value {
+    json!({
+        "source_clue_id": source_clue_id,
+        "volunteer_user_id": volunteer_user_id,
+        "title": "Verify north gate",
+        "objective": "Check the reported route and submit observations.",
+        "area_text": "North gate to market",
+        "latitude": 31.2,
+        "longitude": 121.5,
+        "due_at": "2099-07-27T12:00:00Z",
+        "background": "A commander-reviewed report needs field verification.",
+        "risk_level": "medium",
+        "risk_notes": "Stay in public areas and do not enter restricted property.",
+        "safety_briefing": "Keep contact with the commander and stop if conditions change.",
+        "expected_feedback": "Submit a factual text report for commander review."
+    })
+}

--- a/tests/api/tasks_api.rs
+++ b/tests/api/tasks_api.rs
@@ -337,7 +337,13 @@ async fn task_status_state_machine_is_limited_to_the_assignee_or_commander_cance
     );
 
     let illegal = update_status!(&app, &task_id, &volunteer_token, "completed");
-    assert_error(illegal, StatusCode::CONFLICT, "conflict").await;
+    assert_eq!(illegal.status(), StatusCode::CONFLICT);
+    let illegal: Value = test::read_body_json(illegal).await;
+    assert_eq!(illegal["error"]["code"], "conflict");
+    assert_eq!(
+        illegal["error"]["message"],
+        "task status cannot change from assigned to completed"
+    );
     for status in ["accepted", "active", "blocked", "active", "completed"] {
         let response = update_status!(&app, &task_id, &volunteer_token, status);
         assert_eq!(response.status(), StatusCode::OK);


### PR DESCRIPTION
## Summary

- add cross-database task, assignment, and simulated location-report migrations with safe rollback protection
- add commander task creation and assignment, role-filtered case task lists, and volunteer personal task queues
- enforce task state transitions with audit events and redact internal task context from volunteer responses
- document the API contract and add integration coverage for validation, authorization, privacy, state transitions, and audit trails

## Issues

Closes #17
Closes #18
Closes #19
Closes #20
Closes #21

## Validation

- cargo fmt --all --check
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo test --workspace --all-features --locked
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增任务管理能力：支持在案件中查看任务列表与创建并分配初始任务（含分页与按角色可见性过滤）。
  * 志愿者可查询个人任务队列。
  * 支持推进/取消任务状态，校验权限与任务归属关系。
  * 任务包含风险等级、截止时间、位置与来源线索等信息，并返回相应结果摘要。
* **文档**
  * 更新 OpenAPI：新增 Tasks 分组、相关接口（案件任务列表/创建、个人队列、任务状态更新）及请求/响应与分页结构，并补充任务状态与风险等级枚举。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->