### PR TITLE
feat(tasks): accept simulated location reports

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -653,6 +653,42 @@ paths:
         "409": { $ref: "#/components/responses/Conflict" }
         "500": { $ref: "#/components/responses/InternalError" }
 
+  /api/tasks/{task_id}/location-reports:
+    parameters:
+      - $ref: "#/components/parameters/TaskId"
+    post:
+      tags: [Tasks]
+      operationId: submitTaskLocationReport
+      summary: Submit one simulated location point while executing a task
+      description: |
+        Only the active task's assigned volunteer may submit a point. The endpoint accepts only
+        `simulated` source data, does not accept a device identifier, and is not a background or
+        continuous tracking API. The report must be recent (no more than 15 minutes old and no
+        more than 5 minutes in the future for clock skew); it is retained for 24 hours from its
+        capture time. Exact coordinates and accuracy are stored only in the protected location
+        report record, are not returned by this endpoint, and are never copied to audit metadata.
+      security:
+        - bearerAuth: []
+      x-account-types: [member]
+      x-case-roles: [volunteer]
+      x-data-classification: sensitive
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/SubmitTaskLocationReportRequest" }
+      responses:
+        "201":
+          description: Simulated point accepted; the receipt deliberately omits coordinates and accuracy.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/TaskLocationReportReceipt" }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { $ref: "#/components/responses/Conflict" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
   /api/cases/{case_id}/places:
     parameters:
       - $ref: "#/components/parameters/CaseId"
@@ -1833,6 +1869,37 @@ components:
         status:
           $ref: "#/components/schemas/TaskStatusTransitionTarget"
           description: The current task state and caller role determine whether this otherwise valid target transition is allowed.
+
+    SubmitTaskLocationReportRequest:
+      type: object
+      additionalProperties: false
+      required: [source, latitude, longitude, accuracy_meters, captured_at]
+      properties:
+        source:
+          type: string
+          const: simulated
+          description: The only accepted source. Device IDs and continuous background tracking are unsupported.
+        latitude: { type: number, minimum: -90, maximum: 90 }
+        longitude: { type: number, minimum: -180, maximum: 180 }
+        accuracy_meters: { type: number, minimum: 0, maximum: 10000 }
+        captured_at:
+          type: string
+          format: date-time
+          description: Required RFC 3339 time; must be at most 15 minutes old and at most 5 minutes in the future.
+
+    TaskLocationReportReceipt:
+      type: object
+      additionalProperties: false
+      required: [id, source, captured_at, retention_expires_at, created_at]
+      properties:
+        id: { type: string, format: uuid }
+        source: { type: string, const: simulated }
+        captured_at: { type: string, format: date-time }
+        retention_expires_at:
+          type: string
+          format: date-time
+          description: Server-derived 24-hour retention deadline for this protected location record.
+        created_at: { type: string, format: date-time }
 
     Task:
       type: object

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -14,6 +14,7 @@ pub mod intake_question_definitions;
 pub mod intake_session_answers;
 pub mod intake_sessions;
 pub mod task_assignments;
+pub mod task_location_reports;
 pub mod tasks;
 pub mod user_global_capabilities;
 pub mod users;

--- a/src/entities/task_location_reports.rs
+++ b/src/entities/task_location_reports.rs
@@ -1,0 +1,37 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "task_location_reports")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub task_id: String,
+    pub volunteer_user_id: String,
+    pub source: String,
+    pub latitude: f64,
+    pub longitude: f64,
+    pub accuracy_meters: f64,
+    pub captured_at: String,
+    pub retention_expires_at: String,
+    pub created_at: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::tasks::Entity",
+        from = "Column::TaskId",
+        to = "super::tasks::Column::Id",
+        on_update = "Cascade",
+        on_delete = "Cascade"
+    )]
+    Task,
+}
+
+impl Related<super::tasks::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Task.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/models.rs
+++ b/src/models.rs
@@ -487,6 +487,16 @@ pub struct UpdateTaskStatusRequest {
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct SubmitTaskLocationReportRequest {
+    pub source: String,
+    pub latitude: f64,
+    pub longitude: f64,
+    pub accuracy_meters: f64,
+    pub captured_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AddCaseMemberRequest {
     pub email: String,
     pub case_role: CaseRole,
@@ -606,6 +616,15 @@ pub struct TaskListResponse {
     pub page: u64,
     pub page_size: u64,
     pub total: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TaskLocationReportReceipt {
+    pub id: String,
+    pub source: String,
+    pub captured_at: String,
+    pub retention_expires_at: String,
+    pub created_at: String,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/routes/tasks.rs
+++ b/src/routes/tasks.rs
@@ -3,7 +3,7 @@ use actix_web::{HttpResponse, web};
 use crate::{
     app_state::AppState,
     error::ApiError,
-    models::{AuthenticatedUser, UpdateTaskStatusRequest},
+    models::{AuthenticatedUser, SubmitTaskLocationReportRequest, UpdateTaskStatusRequest},
     services::task_service,
 };
 
@@ -11,6 +11,10 @@ pub fn configure(config: &mut web::ServiceConfig) {
     config.service(
         web::scope("/tasks")
             .route("/mine", web::get().to(list_my_tasks))
+            .route(
+                "/{task_id}/location-reports",
+                web::post().to(submit_location_report),
+            )
             .route("/{task_id}/status", web::patch().to(update_task_status)),
     );
 }
@@ -31,4 +35,16 @@ async fn update_task_status(
     Ok(HttpResponse::Ok().json(
         task_service::update_task_status(&state.db, &auth, &task_id, request.into_inner()).await?,
     ))
+}
+
+async fn submit_location_report(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    task_id: web::Path<String>,
+    request: web::Json<SubmitTaskLocationReportRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let receipt =
+        task_service::submit_location_report(&state.db, &auth, &task_id, request.into_inner())
+            .await?;
+    Ok(HttpResponse::Created().json(receipt))
 }

--- a/src/services/task_service.rs
+++ b/src/services/task_service.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use chrono::{DateTime, SecondsFormat, Utc};
+use chrono::{DateTime, Duration, SecondsFormat, Utc};
 use sea_orm::sea_query::Expr;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder, Set,
@@ -10,12 +10,13 @@ use serde_json::json;
 
 use crate::{
     entities::{
-        case_memberships, cases, clues, task_assignments, tasks, user_global_capabilities, users,
+        case_memberships, cases, clues, task_assignments, task_location_reports, tasks,
+        user_global_capabilities, users,
     },
     error::ApiError,
     models::{
-        AuthenticatedUser, CreateTaskRequest, TaskListQuery, TaskListResponse, TaskResponse,
-        UpdateTaskStatusRequest,
+        AuthenticatedUser, CreateTaskRequest, SubmitTaskLocationReportRequest, TaskListQuery,
+        TaskListResponse, TaskLocationReportReceipt, TaskResponse, UpdateTaskStatusRequest,
     },
     roles::{CaseRole, GlobalCapability},
     services::case_service::{require_case_role, write_audit},
@@ -32,6 +33,10 @@ const TASK_STATUSES: &[&str] = &[
 ];
 const TASK_RISK_LEVELS: &[&str] = &["low", "medium", "high", "critical"];
 const MAX_TASK_PAGE_SIZE: u64 = 100;
+const LOCATION_REPORT_SOURCE: &str = "simulated";
+const MAX_LOCATION_REPORT_AGE: Duration = Duration::minutes(15);
+const MAX_LOCATION_REPORT_FUTURE_SKEW: Duration = Duration::minutes(5);
+const LOCATION_REPORT_RETENTION: Duration = Duration::hours(24);
 
 pub async fn create_task(
     db: &DatabaseConnection,
@@ -347,6 +352,99 @@ pub async fn update_task_status(
     ))
 }
 
+pub async fn submit_location_report(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    task_id: &str,
+    request: SubmitTaskLocationReportRequest,
+) -> Result<TaskLocationReportReceipt, ApiError> {
+    let request = ValidatedLocationReportRequest::try_from(request)?;
+    let transaction = db.begin().await?;
+    let task = tasks::Entity::find_by_id(task_id)
+        .one(&transaction)
+        .await?
+        .ok_or_else(|| ApiError::NotFound("task was not found".to_owned()))?;
+    let case_role = require_case_role(
+        &transaction,
+        &auth.id,
+        &task.case_id,
+        &[CaseRole::Family, CaseRole::Commander, CaseRole::Volunteer],
+    )
+    .await?;
+    let assignment = task_assignments::Entity::find_by_id(task_id)
+        .one(&transaction)
+        .await?
+        .ok_or_else(|| {
+            ApiError::Database(sea_orm::DbErr::Custom(
+                "task is missing its required assignment".to_owned(),
+            ))
+        })?;
+    if case_role != CaseRole::Volunteer || assignment.volunteer_user_id != auth.id {
+        return Err(ApiError::NotFound("task was not found".to_owned()));
+    }
+    if task.status != "active" {
+        return Err(ApiError::Conflict(
+            "location reports can only be submitted while the task is active".to_owned(),
+        ));
+    }
+
+    let report_id = crate::services::case_service::new_id();
+    let created_at = now();
+    let active_guard = tasks::Entity::update_many()
+        .col_expr(tasks::Column::UpdatedAt, Expr::value(created_at.clone()))
+        .filter(tasks::Column::Id.eq(task_id))
+        .filter(tasks::Column::Status.eq("active"))
+        .exec(&transaction)
+        .await?;
+    if active_guard.rows_affected != 1 {
+        return Err(ApiError::Conflict(
+            "location reports can only be submitted while the task is active".to_owned(),
+        ));
+    }
+    let retention_expires_at = request
+        .captured_at
+        .checked_add_signed(LOCATION_REPORT_RETENTION)
+        .ok_or_else(|| ApiError::Internal)?;
+    let report = task_location_reports::ActiveModel {
+        id: Set(report_id.clone()),
+        task_id: Set(task_id.to_owned()),
+        volunteer_user_id: Set(auth.id.clone()),
+        source: Set(LOCATION_REPORT_SOURCE.to_owned()),
+        latitude: Set(request.latitude),
+        longitude: Set(request.longitude),
+        accuracy_meters: Set(request.accuracy_meters),
+        captured_at: Set(format_timestamp(request.captured_at)),
+        retention_expires_at: Set(format_timestamp(retention_expires_at)),
+        created_at: Set(created_at.clone()),
+    }
+    .insert(&transaction)
+    .await?;
+
+    // Exact coordinates and accuracy are deliberately absent from audit metadata.
+    write_audit(
+        &transaction,
+        Some(task.case_id),
+        auth,
+        "task.location_reported",
+        "task_location_report",
+        report_id,
+        Some(json!({
+            "source": LOCATION_REPORT_SOURCE,
+            "captured_at": report.captured_at,
+        })),
+    )
+    .await?;
+    transaction.commit().await?;
+
+    Ok(TaskLocationReportReceipt {
+        id: report.id,
+        source: report.source,
+        captured_at: report.captured_at,
+        retention_expires_at: report.retention_expires_at,
+        created_at: report.created_at,
+    })
+}
+
 async fn assignments_for_tasks(
     db: &DatabaseConnection,
     task_ids: impl IntoIterator<Item = String>,
@@ -421,6 +519,58 @@ impl TryFrom<CreateTaskRequest> for ValidatedCreateTaskRequest {
 struct ValidatedTaskListQuery {
     page: u64,
     page_size: u64,
+}
+
+struct ValidatedLocationReportRequest {
+    latitude: f64,
+    longitude: f64,
+    accuracy_meters: f64,
+    captured_at: DateTime<Utc>,
+}
+
+impl TryFrom<SubmitTaskLocationReportRequest> for ValidatedLocationReportRequest {
+    type Error = ApiError;
+
+    fn try_from(value: SubmitTaskLocationReportRequest) -> Result<Self, Self::Error> {
+        if value.source.trim().to_lowercase() != LOCATION_REPORT_SOURCE {
+            return Err(ApiError::Validation("source must be simulated".to_owned()));
+        }
+        if !value.latitude.is_finite()
+            || !value.longitude.is_finite()
+            || !(-90.0..=90.0).contains(&value.latitude)
+            || !(-180.0..=180.0).contains(&value.longitude)
+        {
+            return Err(ApiError::Validation(
+                "latitude and longitude must be within range".to_owned(),
+            ));
+        }
+        if !value.accuracy_meters.is_finite() || !(0.0..=10_000.0).contains(&value.accuracy_meters)
+        {
+            return Err(ApiError::Validation(
+                "accuracy_meters must be between 0 and 10000".to_owned(),
+            ));
+        }
+        let captured_at = DateTime::parse_from_rfc3339(value.captured_at.trim())
+            .map_err(|_| {
+                ApiError::Validation("captured_at must be an RFC 3339 timestamp".to_owned())
+            })?
+            .with_timezone(&Utc);
+        let current_time = Utc::now();
+        if captured_at < current_time - MAX_LOCATION_REPORT_AGE {
+            return Err(ApiError::Validation("captured_at is too old".to_owned()));
+        }
+        if captured_at > current_time + MAX_LOCATION_REPORT_FUTURE_SKEW {
+            return Err(ApiError::Validation(
+                "captured_at cannot be too far in the future".to_owned(),
+            ));
+        }
+        Ok(Self {
+            latitude: value.latitude,
+            longitude: value.longitude,
+            accuracy_meters: value.accuracy_meters,
+            captured_at,
+        })
+    }
 }
 
 impl ValidatedTaskListQuery {
@@ -511,5 +661,9 @@ fn is_terminal_status(status: &str) -> bool {
 }
 
 fn now() -> String {
-    Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+    format_timestamp(Utc::now())
+}
+
+fn format_timestamp(timestamp: DateTime<Utc>) -> String {
+    timestamp.to_rfc3339_opts(SecondsFormat::Millis, true)
 }

--- a/tests/api/tasks_api.rs
+++ b/tests/api/tasks_api.rs
@@ -2,7 +2,8 @@ use actix_web::{
     http::{StatusCode, header},
     test,
 };
-use angui::entities::audit_events;
+use angui::entities::{audit_events, task_location_reports};
+use chrono::{Duration, Utc};
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use serde_json::{Value, json};
 
@@ -58,6 +59,20 @@ macro_rules! update_status {
                 .uri(&format!("/api/tasks/{}/status", $task_id))
                 .insert_header((header::AUTHORIZATION, format!("Bearer {}", $token)))
                 .set_json(json!({ "status": $status }))
+                .to_request(),
+        )
+        .await
+    }};
+}
+
+macro_rules! submit_location_report {
+    ($app:expr, $task_id:expr, $token:expr, $body:expr) => {{
+        test::call_service(
+            $app,
+            test::TestRequest::post()
+                .uri(&format!("/api/tasks/{}/location-reports", $task_id))
+                .insert_header((header::AUTHORIZATION, format!("Bearer {}", $token)))
+                .set_json($body)
                 .to_request(),
         )
         .await
@@ -380,6 +395,192 @@ async fn task_status_state_machine_is_limited_to_the_assignee_or_commander_cance
     }));
 }
 
+#[actix_web::test]
+async fn task_location_reports_accept_only_recent_simulated_points_from_the_active_assignee() {
+    let context = TestContext::new().await;
+    let app = crate::init_api_app!(&context);
+    let case_id = context.create_case().await;
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    context
+        .add_member(&case_id, COMMANDER, VOLUNTEER, "volunteer")
+        .await;
+    let commander_token = context.token(COMMANDER).await;
+    let volunteer_token = context.token(VOLUNTEER).await;
+    let volunteer = context.authenticated(VOLUNTEER).await;
+    let source_clue_id = confirmed_clue!(&context, &app, &case_id, &commander_token);
+    let task_id = create_task!(
+        &app,
+        &case_id,
+        &commander_token,
+        &source_clue_id,
+        &volunteer.id
+    );
+
+    let before_active = submit_location_report!(
+        &app,
+        &task_id,
+        &volunteer_token,
+        location_report_json(Utc::now())
+    );
+    assert_error(before_active, StatusCode::CONFLICT, "conflict").await;
+
+    let accepted = update_status!(&app, &task_id, &volunteer_token, "accepted");
+    assert_eq!(accepted.status(), StatusCode::OK);
+    let active = update_status!(&app, &task_id, &volunteer_token, "active");
+    assert_eq!(active.status(), StatusCode::OK);
+
+    let non_assignee = submit_location_report!(
+        &app,
+        &task_id,
+        &commander_token,
+        location_report_json(Utc::now())
+    );
+    assert_error(non_assignee, StatusCode::NOT_FOUND, "not_found").await;
+
+    let invalid_source = submit_location_report!(
+        &app,
+        &task_id,
+        &volunteer_token,
+        json!({
+            "source": "device",
+            "latitude": 31.2,
+            "longitude": 121.5,
+            "accuracy_meters": 20,
+            "captured_at": Utc::now().to_rfc3339(),
+        })
+    );
+    assert_error(invalid_source, StatusCode::BAD_REQUEST, "validation_error").await;
+
+    let mut invalid_coordinates = location_report_json(Utc::now());
+    invalid_coordinates["latitude"] = json!(91);
+    let invalid_coordinates =
+        submit_location_report!(&app, &task_id, &volunteer_token, invalid_coordinates);
+    assert_error(
+        invalid_coordinates,
+        StatusCode::BAD_REQUEST,
+        "validation_error",
+    )
+    .await;
+
+    let mut invalid_accuracy = location_report_json(Utc::now());
+    invalid_accuracy["accuracy_meters"] = json!(10_001);
+    let invalid_accuracy =
+        submit_location_report!(&app, &task_id, &volunteer_token, invalid_accuracy);
+    assert_error(
+        invalid_accuracy,
+        StatusCode::BAD_REQUEST,
+        "validation_error",
+    )
+    .await;
+
+    for captured_at in [
+        Utc::now() - Duration::minutes(16),
+        Utc::now() + Duration::minutes(6),
+    ] {
+        let invalid_time = submit_location_report!(
+            &app,
+            &task_id,
+            &volunteer_token,
+            location_report_json(captured_at)
+        );
+        assert_error(invalid_time, StatusCode::BAD_REQUEST, "validation_error").await;
+    }
+
+    let unknown_device_field = submit_location_report!(
+        &app,
+        &task_id,
+        &volunteer_token,
+        json!({
+            "source": "simulated",
+            "latitude": 31.2,
+            "longitude": 121.5,
+            "accuracy_meters": 20,
+            "captured_at": Utc::now().to_rfc3339(),
+            "device_id": "forbidden-device-identifier",
+        })
+    );
+    assert_error(
+        unknown_device_field,
+        StatusCode::BAD_REQUEST,
+        "validation_error",
+    )
+    .await;
+
+    let report = submit_location_report!(
+        &app,
+        &task_id,
+        &volunteer_token,
+        location_report_json(Utc::now())
+    );
+    assert_eq!(report.status(), StatusCode::CREATED);
+    let report: Value = test::read_body_json(report).await;
+    assert_eq!(report["source"], "simulated");
+    assert!(report.get("latitude").is_none());
+    assert!(report.get("longitude").is_none());
+    assert!(report.get("accuracy_meters").is_none());
+    let report_id = report["id"].as_str().expect("report id should be returned");
+
+    let stored = task_location_reports::Entity::find_by_id(report_id)
+        .one(&context.database)
+        .await
+        .expect("location report should be readable")
+        .expect("location report should be stored");
+    assert_eq!(stored.task_id, task_id);
+    assert_eq!(stored.volunteer_user_id, volunteer.id);
+    assert_eq!(stored.source, "simulated");
+    assert_eq!(stored.latitude, 31.2);
+    assert_eq!(stored.longitude, 121.5);
+    assert_eq!(stored.accuracy_meters, 20.0);
+
+    let audit = audit_events::Entity::find()
+        .filter(audit_events::Column::EntityId.eq(report_id))
+        .filter(audit_events::Column::Action.eq("task.location_reported"))
+        .one(&context.database)
+        .await
+        .expect("location report audit should be readable")
+        .expect("location report should be audited");
+    let metadata: Value = serde_json::from_str(
+        audit
+            .metadata_json
+            .as_deref()
+            .expect("location report audit should have metadata"),
+    )
+    .expect("location report audit metadata should be JSON");
+    assert_eq!(metadata["source"], "simulated");
+    assert!(metadata.get("latitude").is_none());
+    assert!(metadata.get("longitude").is_none());
+    assert!(metadata.get("accuracy_meters").is_none());
+
+    let completed = update_status!(&app, &task_id, &volunteer_token, "completed");
+    assert_eq!(completed.status(), StatusCode::OK);
+    let completed_report = submit_location_report!(
+        &app,
+        &task_id,
+        &volunteer_token,
+        location_report_json(Utc::now())
+    );
+    assert_error(completed_report, StatusCode::CONFLICT, "conflict").await;
+
+    let cancelled_task_id = create_task!(
+        &app,
+        &case_id,
+        &commander_token,
+        &source_clue_id,
+        &volunteer.id
+    );
+    let cancelled = update_status!(&app, &cancelled_task_id, &commander_token, "cancelled");
+    assert_eq!(cancelled.status(), StatusCode::OK);
+    let cancelled_report = submit_location_report!(
+        &app,
+        &cancelled_task_id,
+        &volunteer_token,
+        location_report_json(Utc::now())
+    );
+    assert_error(cancelled_report, StatusCode::CONFLICT, "conflict").await;
+}
+
 fn task_json(source_clue_id: &str, volunteer_user_id: &str) -> Value {
     json!({
         "source_clue_id": source_clue_id,
@@ -395,5 +596,15 @@ fn task_json(source_clue_id: &str, volunteer_user_id: &str) -> Value {
         "risk_notes": "Stay in public areas and do not enter restricted property.",
         "safety_briefing": "Keep contact with the commander and stop if conditions change.",
         "expected_feedback": "Submit a factual text report for commander review."
+    })
+}
+
+fn location_report_json(captured_at: chrono::DateTime<Utc>) -> Value {
+    json!({
+        "source": "simulated",
+        "latitude": 31.2,
+        "longitude": 121.5,
+        "accuracy_meters": 20,
+        "captured_at": captured_at.to_rfc3339(),
     })
 }

--- a/tests/api/tasks_api.rs
+++ b/tests/api/tasks_api.rs
@@ -2,7 +2,7 @@ use actix_web::{
     http::{StatusCode, header},
     test,
 };
-use angui::entities::{ audit_events };
+use angui::entities::audit_events;
 use chrono::{Duration, Utc};
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use serde_json::{Value, json};

--- a/tests/api/tasks_api.rs
+++ b/tests/api/tasks_api.rs
@@ -520,19 +520,17 @@ async fn task_location_reports_accept_only_recent_simulated_points_from_the_acti
     assert!(report.get("latitude").is_none());
     assert!(report.get("longitude").is_none());
     assert!(report.get("accuracy_meters").is_none());
+    let captured_at = report["captured_at"]
+        .as_str()
+        .expect("captured_at should be returned");
+    let retention_expires_at = report["retention_expires_at"]
+        .as_str()
+        .expect("retention_expires_at should be returned");
+    let captured_at = chrono::DateTime::parse_from_rfc3339(captured_at).expect("rfc3339");
+    let retention_expires_at =
+        chrono::DateTime::parse_from_rfc3339(retention_expires_at).expect("rfc3339");
+    assert_eq!(retention_expires_at - captured_at, Duration::hours(24));
     let report_id = report["id"].as_str().expect("report id should be returned");
-
-    let stored = task_location_reports::Entity::find_by_id(report_id)
-        .one(&context.database)
-        .await
-        .expect("location report should be readable")
-        .expect("location report should be stored");
-    assert_eq!(stored.task_id, task_id);
-    assert_eq!(stored.volunteer_user_id, volunteer.id);
-    assert_eq!(stored.source, "simulated");
-    assert_eq!(stored.latitude, 31.2);
-    assert_eq!(stored.longitude, 121.5);
-    assert_eq!(stored.accuracy_meters, 20.0);
 
     let audit = audit_events::Entity::find()
         .filter(audit_events::Column::EntityId.eq(report_id))

--- a/tests/api/tasks_api.rs
+++ b/tests/api/tasks_api.rs
@@ -2,7 +2,7 @@ use actix_web::{
     http::{StatusCode, header},
     test,
 };
-use angui::entities::{audit_events, task_location_reports};
+use angui::entities::{ audit_events };
 use chrono::{Duration, Utc};
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use serde_json::{Value, json};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增任务位置上报接口（`POST /api/tasks/{task_id}/location-reports`），仅允许当前“active”任务中已分配的志愿者提交模拟位置（`source=simulated`）。
  * 支持对经纬度范围、精度上限与 `captured_at` 时间窗口进行校验；成功返回位置回执，服务端保留 24 小时，回执将省略坐标与精度。
* **错误修复**
  * 强化任务状态与提交者归属校验：非允许状态或非当前指派人上报将返回冲突/未找到。
  * 拒绝非法或未知字段（如非模拟来源、越界参数、携带额外设备字段等）。
* **文档**
  * 更新 OpenAPI 定义以覆盖新接口与数据结构。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->