### PR TITLE
feat(tasks): purge expired location reports periodically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 sha2 = "0.10.9"
 thiserror = "2.0.18"
-tokio = { version = "1.52.0", features = ["macros", "rt-multi-thread", "sync"] }
+tokio = { version = "1.52.0", features = ["macros", "rt-multi-thread", "sync", "time"] }
 uuid = { version = "1.19.0", features = ["serde", "v4"] }
 
 [dev-dependencies]

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -685,6 +685,7 @@ paths:
               schema: { $ref: "#/components/schemas/TaskLocationReportReceipt" }
         "400": { $ref: "#/components/responses/ValidationError" }
         "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/NotFound" }
         "409": { $ref: "#/components/responses/Conflict" }
         "500": { $ref: "#/components/responses/InternalError" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use actix_cors::Cors;
 use actix_web::{App, HttpServer, http, middleware::Logger, web};
 use angui::{
     ai_gateway::AiGateway, amap_service::AmapService, app_state::AppState, config::Settings,
-    rate_limit::LoginRateLimiter, routes,
+    rate_limit::LoginRateLimiter, routes, services::task_service,
 };
 use sea_orm::Database;
 
@@ -37,6 +37,7 @@ async fn main() -> io::Result<()> {
         ai_gateway,
         login_limiter: LoginRateLimiter::default(),
     });
+    task_service::start_location_report_retention_purger(state.db.clone());
 
     HttpServer::new(move || {
         let cors = Cors::default()

--- a/src/services/task_service.rs
+++ b/src/services/task_service.rs
@@ -1,4 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    time::Duration as StdDuration,
+};
 
 use chrono::{DateTime, Duration, SecondsFormat, Utc};
 use sea_orm::sea_query::Expr;
@@ -37,6 +40,27 @@ const LOCATION_REPORT_SOURCE: &str = "simulated";
 const MAX_LOCATION_REPORT_AGE: Duration = Duration::minutes(15);
 const MAX_LOCATION_REPORT_FUTURE_SKEW: Duration = Duration::minutes(5);
 const LOCATION_REPORT_RETENTION: Duration = Duration::hours(24);
+const LOCATION_REPORT_PURGE_INTERVAL: StdDuration = StdDuration::from_secs(60);
+
+pub fn start_location_report_retention_purger(db: DatabaseConnection) {
+    actix_web::rt::spawn(async move {
+        let mut interval = tokio::time::interval(LOCATION_REPORT_PURGE_INTERVAL);
+        loop {
+            interval.tick().await;
+            if let Err(error) = purge_expired_location_reports(&db).await {
+                eprintln!("failed to purge expired task location reports: {error}");
+            }
+        }
+    });
+}
+
+pub async fn purge_expired_location_reports(db: &DatabaseConnection) -> Result<u64, ApiError> {
+    let deleted = task_location_reports::Entity::delete_many()
+        .filter(task_location_reports::Column::RetentionExpiresAt.lte(now()))
+        .exec(db)
+        .await?;
+    Ok(deleted.rows_affected)
+}
 
 pub async fn create_task(
     db: &DatabaseConnection,

--- a/tests/api/tasks_api.rs
+++ b/tests/api/tasks_api.rs
@@ -2,9 +2,12 @@ use actix_web::{
     http::{StatusCode, header},
     test,
 };
-use angui::entities::audit_events;
+use angui::{
+    entities::{audit_events, task_location_reports},
+    services::task_service,
+};
 use chrono::{Duration, Utc};
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, sea_query::Expr};
 use serde_json::{Value, json};
 
 use crate::support::{ADMIN, COMMANDER, FAMILY, TestContext, VOLUNTEER, assert_error};
@@ -550,6 +553,29 @@ async fn task_location_reports_accept_only_recent_simulated_points_from_the_acti
     assert!(metadata.get("latitude").is_none());
     assert!(metadata.get("longitude").is_none());
     assert!(metadata.get("accuracy_meters").is_none());
+
+    task_location_reports::Entity::update_many()
+        .col_expr(
+            task_location_reports::Column::RetentionExpiresAt,
+            Expr::value((Utc::now() - Duration::seconds(1)).to_rfc3339()),
+        )
+        .filter(task_location_reports::Column::Id.eq(report_id))
+        .exec(&context.database)
+        .await
+        .expect("location report expiration should be configurable for the retention test");
+    assert_eq!(
+        task_service::purge_expired_location_reports(&context.database)
+            .await
+            .expect("expired location reports should be purged"),
+        1
+    );
+    assert!(
+        task_location_reports::Entity::find_by_id(report_id)
+            .one(&context.database)
+            .await
+            .expect("location report lookup should succeed")
+            .is_none()
+    );
 
     let completed = update_status!(&app, &task_id, &volunteer_token, "completed");
     assert_eq!(completed.status(), StatusCode::OK);


### PR DESCRIPTION
- enable Tokio time support for scheduled background tasks
- start a retention purger when the application initializes
- delete location reports once their retention expiry is reached
- log purge failures without stopping the recurring task
- document forbidden responses for task location report submissions
- add integration coverage for expired report cleanup