### PR TITLE
feat(tasks): add assignee task feedback submission

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -694,6 +694,43 @@ paths:
         "409": { $ref: "#/components/responses/Conflict" }
         "500": { $ref: "#/components/responses/InternalError" }
 
+  /api/tasks/{task_id}/feedback:
+    parameters:
+      - $ref: "#/components/parameters/TaskId"
+    post:
+      tags: [Tasks]
+      operationId: submitTaskFeedback
+      summary: Submit an execution feedback clue for review
+      description: |
+        Only the assigned volunteer may submit feedback while both the task and case are active.
+        The server converts the feedback into a `pending_review` field-report clue linked to the
+        task. It does not confirm a clue, change case facts, advance the task status, or publish
+        a map update. Optional attachments must already belong to the case and have been uploaded
+        by the submitting volunteer. The endpoint accepts a textual location only; it does not
+        accept coordinates, device identifiers, or continuous tracking data.
+      security:
+        - bearerAuth: []
+      x-account-types: [member]
+      x-case-roles: [volunteer]
+      x-data-classification: case-restricted
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/SubmitTaskFeedbackRequest" }
+      responses:
+        "201":
+          description: Feedback was stored as a pending-review clue.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/TaskFeedbackReceipt" }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { $ref: "#/components/responses/Conflict" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
   /api/cases/{case_id}/places:
     parameters:
       - $ref: "#/components/parameters/CaseId"
@@ -1905,6 +1942,43 @@ components:
           format: date-time
           description: Server-derived 24-hour retention deadline for this protected location record.
         created_at: { type: string, format: date-time }
+
+    SubmitTaskFeedbackRequest:
+      type: object
+      additionalProperties: false
+      required: [content]
+      properties:
+        content:
+          type: string
+          minLength: 1
+          maxLength: 4000
+          description: Field observation that remains unconfirmed until commander review.
+        occurred_at:
+          type: [string, "null"]
+          format: date-time
+        location_text:
+          type: [string, "null"]
+          maxLength: 500
+          description: Optional human-readable place description; exact coordinates are unsupported.
+        location_precision:
+          type: [string, "null"]
+          enum: [exact, approximate, unknown, null]
+          description: Requires location_text when supplied.
+        attachment_ids:
+          type: array
+          maxItems: 10
+          uniqueItems: true
+          items: { type: string, format: uuid }
+
+    TaskFeedbackReceipt:
+      type: object
+      additionalProperties: false
+      required: [task_id, clue_id, status, submitted_at]
+      properties:
+        task_id: { type: string, format: uuid }
+        clue_id: { type: string, format: uuid }
+        status: { type: string, const: pending_review }
+        submitted_at: { type: string, format: date-time }
 
     Task:
       type: object

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -498,6 +498,20 @@ pub struct SubmitTaskLocationReportRequest {
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct SubmitTaskFeedbackRequest {
+    pub content: String,
+    #[serde(default)]
+    pub occurred_at: Option<String>,
+    #[serde(default)]
+    pub location_text: Option<String>,
+    #[serde(default)]
+    pub location_precision: Option<String>,
+    #[serde(default)]
+    pub attachment_ids: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AddCaseMemberRequest {
     pub email: String,
     pub case_role: CaseRole,
@@ -626,6 +640,14 @@ pub struct TaskLocationReportReceipt {
     pub captured_at: String,
     pub retention_expires_at: String,
     pub created_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TaskFeedbackReceipt {
+    pub task_id: String,
+    pub clue_id: String,
+    pub status: String,
+    pub submitted_at: String,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/api/routes/tasks.rs
+++ b/src/api/routes/tasks.rs
@@ -3,7 +3,10 @@ use actix_web::{HttpResponse, web};
 use crate::{
     app_state::AppState,
     error::ApiError,
-    models::{AuthenticatedUser, SubmitTaskLocationReportRequest, UpdateTaskStatusRequest},
+    models::{
+        AuthenticatedUser, SubmitTaskFeedbackRequest, SubmitTaskLocationReportRequest,
+        UpdateTaskStatusRequest,
+    },
     services::task_service,
 };
 
@@ -15,6 +18,7 @@ pub fn configure(config: &mut web::ServiceConfig) {
                 "/{task_id}/location-reports",
                 web::post().to(submit_location_report),
             )
+            .route("/{task_id}/feedback", web::post().to(submit_task_feedback))
             .route("/{task_id}/status", web::patch().to(update_task_status)),
     );
 }
@@ -45,6 +49,18 @@ async fn submit_location_report(
 ) -> Result<HttpResponse, ApiError> {
     let receipt =
         task_service::submit_location_report(&state.db, &auth, &task_id, request.into_inner())
+            .await?;
+    Ok(HttpResponse::Created().json(receipt))
+}
+
+async fn submit_task_feedback(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    task_id: web::Path<String>,
+    request: web::Json<SubmitTaskFeedbackRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let receipt =
+        task_service::submit_task_feedback(&state.db, &auth, &task_id, request.into_inner())
             .await?;
     Ok(HttpResponse::Created().json(receipt))
 }

--- a/src/application/services/task_service.rs
+++ b/src/application/services/task_service.rs
@@ -13,13 +13,14 @@ use serde_json::json;
 
 use crate::{
     entities::{
-        case_memberships, cases, clues, task_assignments, task_location_reports, tasks,
-        user_global_capabilities, users,
+        case_attachments, case_memberships, cases, clue_attachment_links, clue_attributions, clues,
+        task_assignments, task_location_reports, tasks, user_global_capabilities, users,
     },
     error::ApiError,
     models::{
-        AuthenticatedUser, CreateTaskRequest, SubmitTaskLocationReportRequest, TaskListQuery,
-        TaskListResponse, TaskLocationReportReceipt, TaskResponse, UpdateTaskStatusRequest,
+        AuthenticatedUser, CreateTaskRequest, SubmitTaskFeedbackRequest,
+        SubmitTaskLocationReportRequest, TaskFeedbackReceipt, TaskListQuery, TaskListResponse,
+        TaskLocationReportReceipt, TaskResponse, UpdateTaskStatusRequest,
     },
     roles::{CaseRole, GlobalCapability},
     services::case_service::{require_case_role, write_audit},
@@ -41,6 +42,7 @@ const MAX_LOCATION_REPORT_AGE: Duration = Duration::minutes(15);
 const MAX_LOCATION_REPORT_FUTURE_SKEW: Duration = Duration::minutes(5);
 const LOCATION_REPORT_RETENTION: Duration = Duration::hours(24);
 const LOCATION_REPORT_PURGE_INTERVAL: StdDuration = StdDuration::from_secs(60);
+const CLUE_LOCATION_PRECISIONS: &[&str] = &["exact", "approximate", "unknown"];
 
 pub fn start_location_report_retention_purger(db: DatabaseConnection) {
     actix_web::rt::spawn(async move {
@@ -469,6 +471,159 @@ pub async fn submit_location_report(
     })
 }
 
+pub async fn submit_task_feedback(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    task_id: &str,
+    request: SubmitTaskFeedbackRequest,
+) -> Result<TaskFeedbackReceipt, ApiError> {
+    let request = ValidatedTaskFeedbackRequest::try_from(request)?;
+    let transaction = db.begin().await?;
+    let task = tasks::Entity::find_by_id(task_id)
+        .one(&transaction)
+        .await?
+        .ok_or_else(|| ApiError::NotFound("task was not found".to_owned()))?;
+    let case_role = require_case_role(
+        &transaction,
+        &auth.id,
+        &task.case_id,
+        &[CaseRole::Family, CaseRole::Commander, CaseRole::Volunteer],
+    )
+    .await?;
+    let assignment = task_assignments::Entity::find_by_id(task_id)
+        .one(&transaction)
+        .await?
+        .ok_or_else(|| {
+            ApiError::Database(sea_orm::DbErr::Custom(
+                "task is missing its required assignment".to_owned(),
+            ))
+        })?;
+    if case_role != CaseRole::Volunteer || assignment.volunteer_user_id != auth.id {
+        return Err(ApiError::NotFound("task was not found".to_owned()));
+    }
+    if task.status != "active" {
+        return Err(ApiError::Conflict(
+            "feedback can only be submitted while the task is active".to_owned(),
+        ));
+    }
+    let case_model = cases::Entity::find_by_id(&task.case_id)
+        .one(&transaction)
+        .await?
+        .ok_or_else(|| ApiError::NotFound("case was not found".to_owned()))?;
+    if case_model.status != "active" {
+        return Err(ApiError::Conflict(
+            "feedback cannot be submitted for a non-active case".to_owned(),
+        ));
+    }
+
+    let timestamp = now();
+    let active_guard = tasks::Entity::update_many()
+        .col_expr(tasks::Column::UpdatedAt, Expr::value(timestamp.clone()))
+        .filter(tasks::Column::Id.eq(task_id))
+        .filter(tasks::Column::Status.eq("active"))
+        .exec(&transaction)
+        .await?;
+    if active_guard.rows_affected != 1 {
+        return Err(ApiError::Conflict(
+            "feedback can only be submitted while the task is active".to_owned(),
+        ));
+    }
+
+    let clue_id = crate::services::case_service::new_id();
+    let clue = clues::ActiveModel {
+        id: Set(clue_id.clone()),
+        case_id: Set(task.case_id.clone()),
+        status: Set("pending_review".to_owned()),
+        source: Set("task_feedback".to_owned()),
+        source_type: Set("field_report".to_owned()),
+        content: Set(request.content),
+        raw_record_reference: Set(None),
+        occurred_at: Set(request.occurred_at),
+        reported_at: Set(timestamp.clone()),
+        confirmed_at: Set(None),
+        location_text: Set(request.location_text),
+        location_precision: Set(request.location_precision),
+        next_action: Set(None),
+        linked_task_reference: Set(Some(task.id.clone())),
+        related_clue_id: Set(None),
+        relationship_type: Set(None),
+        review_reason: Set(None),
+        created_at: Set(timestamp.clone()),
+        updated_at: Set(timestamp.clone()),
+    }
+    .insert(&transaction)
+    .await?;
+
+    for attachment_id in &request.attachment_ids {
+        let attachment = case_attachments::Entity::find_by_id(attachment_id)
+            .one(&transaction)
+            .await?
+            .filter(|attachment| attachment.case_id == task.case_id)
+            .ok_or_else(|| {
+                ApiError::Validation(
+                    "attachment_ids must reference attachments in this case".to_owned(),
+                )
+            })?;
+        if attachment.created_by_user_id != auth.id {
+            return Err(ApiError::Forbidden(
+                "an attachment can only be linked by its uploader".to_owned(),
+            ));
+        }
+        clue_attachment_links::ActiveModel {
+            clue_id: Set(clue_id.clone()),
+            attachment_id: Set(attachment_id.clone()),
+            created_at: Set(timestamp.clone()),
+        }
+        .insert(&transaction)
+        .await?;
+    }
+
+    clue_attributions::ActiveModel {
+        clue_id: Set(clue_id.clone()),
+        submitted_by_user_id: Set(Some(auth.id.clone())),
+        reviewed_by_user_id: Set(None),
+        reviewed_at: Set(None),
+    }
+    .insert(&transaction)
+    .await?;
+    write_audit(
+        &transaction,
+        Some(task.case_id.clone()),
+        auth,
+        "task.feedback_submitted",
+        "task",
+        task.id.clone(),
+        Some(json!({
+            "clue_id": clue_id,
+            "status": "pending_review",
+            "attachment_count": request.attachment_ids.len(),
+        })),
+    )
+    .await?;
+    write_audit(
+        &transaction,
+        Some(task.case_id),
+        auth,
+        "clue.submitted",
+        "clue",
+        clue.id.clone(),
+        Some(json!({
+            "status": "pending_review",
+            "source_type": "field_report",
+            "linked_task_reference": task.id,
+        })),
+    )
+    .await?;
+    transaction.commit().await?;
+
+    Ok(TaskFeedbackReceipt {
+        task_id: task_id.to_owned(),
+        clue_id: clue.id,
+        status: clue.status,
+        submitted_at: timestamp,
+    })
+}
+
 async fn assignments_for_tasks(
     db: &DatabaseConnection,
     task_ids: impl IntoIterator<Item = String>,
@@ -552,6 +707,14 @@ struct ValidatedLocationReportRequest {
     captured_at: DateTime<Utc>,
 }
 
+struct ValidatedTaskFeedbackRequest {
+    content: String,
+    occurred_at: Option<String>,
+    location_text: Option<String>,
+    location_precision: Option<String>,
+    attachment_ids: Vec<String>,
+}
+
 impl TryFrom<SubmitTaskLocationReportRequest> for ValidatedLocationReportRequest {
     type Error = ApiError;
 
@@ -597,6 +760,68 @@ impl TryFrom<SubmitTaskLocationReportRequest> for ValidatedLocationReportRequest
     }
 }
 
+impl TryFrom<SubmitTaskFeedbackRequest> for ValidatedTaskFeedbackRequest {
+    type Error = ApiError;
+
+    fn try_from(value: SubmitTaskFeedbackRequest) -> Result<Self, Self::Error> {
+        let content = required_field("content", value.content, 4_000)?;
+        let occurred_at = match optional_field("occurred_at", value.occurred_at, 64)? {
+            Some(occurred_at) => Some(
+                DateTime::parse_from_rfc3339(&occurred_at)
+                    .map_err(|_| {
+                        ApiError::Validation("occurred_at must be an RFC 3339 timestamp".to_owned())
+                    })?
+                    .with_timezone(&Utc)
+                    .to_rfc3339_opts(SecondsFormat::Millis, true),
+            ),
+            None => None,
+        };
+        let location_text = optional_field("location_text", value.location_text, 500)?;
+        let location_precision =
+            optional_field("location_precision", value.location_precision, 16)?
+                .map(|precision| precision.to_lowercase());
+        if location_precision
+            .as_deref()
+            .is_some_and(|precision| !CLUE_LOCATION_PRECISIONS.contains(&precision))
+        {
+            return Err(ApiError::Validation(
+                "location_precision is unsupported".to_owned(),
+            ));
+        }
+        if location_precision.is_some() && location_text.is_none() {
+            return Err(ApiError::Validation(
+                "location_precision requires location_text".to_owned(),
+            ));
+        }
+        if value.attachment_ids.len() > 10 {
+            return Err(ApiError::Validation(
+                "attachment_ids cannot contain more than 10 items".to_owned(),
+            ));
+        }
+        let mut unique_ids = HashSet::new();
+        let attachment_ids = value
+            .attachment_ids
+            .into_iter()
+            .map(|attachment_id| attachment_id.trim().to_owned())
+            .collect::<Vec<_>>();
+        if attachment_ids
+            .iter()
+            .any(|attachment_id| attachment_id.is_empty() || !unique_ids.insert(attachment_id))
+        {
+            return Err(ApiError::Validation(
+                "attachment_ids must contain unique non-empty IDs".to_owned(),
+            ));
+        }
+        Ok(Self {
+            content,
+            occurred_at,
+            location_text,
+            location_precision,
+            attachment_ids,
+        })
+    }
+}
+
 impl ValidatedTaskListQuery {
     fn offset(&self) -> Result<usize, ApiError> {
         let offset = self
@@ -638,6 +863,26 @@ fn required_field(label: &str, value: String, maximum: usize) -> Result<String, 
         )));
     }
     Ok(value.to_owned())
+}
+
+fn optional_field(
+    label: &str,
+    value: Option<String>,
+    maximum: usize,
+) -> Result<Option<String>, ApiError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let value = value.trim();
+    if value.is_empty() {
+        return Ok(None);
+    }
+    if value.chars().count() > maximum {
+        return Err(ApiError::Validation(format!(
+            "{label} must contain at most {maximum} characters"
+        )));
+    }
+    Ok(Some(value.to_owned()))
 }
 
 fn validate_coordinates(latitude: Option<f64>, longitude: Option<f64>) -> Result<(), ApiError> {

--- a/tests/api/tasks_api.rs
+++ b/tests/api/tasks_api.rs
@@ -3,14 +3,16 @@ use actix_web::{
     test,
 };
 use angui::{
-    entities::{audit_events, task_location_reports},
+    entities::{
+        audit_events, clues, task_location_reports, tasks, user_global_capabilities, users,
+    },
     services::task_service,
 };
 use chrono::{Duration, Utc};
-use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, sea_query::Expr};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, Set, sea_query::Expr};
 use serde_json::{Value, json};
 
-use crate::support::{ADMIN, COMMANDER, FAMILY, TestContext, VOLUNTEER, assert_error};
+use crate::support::{ADMIN, COMMANDER, FAMILY, LEARNER, TestContext, VOLUNTEER, assert_error};
 
 macro_rules! confirmed_clue {
     ($context:expr, $app:expr, $case_id:expr, $commander_token:expr) => {{
@@ -80,6 +82,42 @@ macro_rules! submit_location_report {
         )
         .await
     }};
+}
+
+macro_rules! submit_task_feedback {
+    ($app:expr, $task_id:expr, $token:expr, $body:expr) => {{
+        test::call_service(
+            $app,
+            test::TestRequest::post()
+                .uri(&format!("/api/tasks/{}/feedback", $task_id))
+                .insert_header((header::AUTHORIZATION, format!("Bearer {}", $token)))
+                .set_json($body)
+                .to_request(),
+        )
+        .await
+    }};
+}
+
+async fn add_second_case_volunteer(context: &TestContext, case_id: &str) -> String {
+    let learner = context.authenticated(LEARNER).await;
+    users::Entity::update_many()
+        .col_expr(users::Column::AccountType, Expr::value("member"))
+        .filter(users::Column::Id.eq(&learner.id))
+        .exec(&context.database)
+        .await
+        .expect("fixture learner should become a member account");
+    user_global_capabilities::ActiveModel {
+        user_id: Set(learner.id),
+        capability: Set("volunteer".to_owned()),
+        created_at: Set(Utc::now().to_rfc3339()),
+    }
+    .insert(&context.database)
+    .await
+    .expect("fixture should grant a second volunteer capability");
+    context
+        .add_member(case_id, COMMANDER, LEARNER, "volunteer")
+        .await;
+    context.token(LEARNER).await
 }
 
 #[actix_web::test]
@@ -344,7 +382,10 @@ async fn task_status_state_machine_is_limited_to_the_assignee_or_commander_cance
         .await;
     let commander_token = context.token(COMMANDER).await;
     let volunteer_token = context.token(VOLUNTEER).await;
+    let family_token = context.token(FAMILY).await;
+    let admin_token = context.token(ADMIN).await;
     let volunteer = context.authenticated(VOLUNTEER).await;
+    let second_volunteer_token = add_second_case_volunteer(&context, &case_id).await;
     let source_clue_id = confirmed_clue!(&context, &app, &case_id, &commander_token);
     let task_id = create_task!(
         &app,
@@ -362,6 +403,10 @@ async fn task_status_state_machine_is_limited_to_the_assignee_or_commander_cance
         illegal["error"]["message"],
         "task status cannot change from assigned to completed"
     );
+    for token in [&family_token, &second_volunteer_token, &admin_token] {
+        let unauthorized = update_status!(&app, &task_id, token, "accepted");
+        assert_error(unauthorized, StatusCode::NOT_FOUND, "not_found").await;
+    }
     for status in ["accepted", "active", "blocked", "active", "completed"] {
         let response = update_status!(&app, &task_id, &volunteer_token, status);
         assert_eq!(response.status(), StatusCode::OK);
@@ -411,7 +456,10 @@ async fn task_location_reports_accept_only_recent_simulated_points_from_the_acti
         .await;
     let commander_token = context.token(COMMANDER).await;
     let volunteer_token = context.token(VOLUNTEER).await;
+    let family_token = context.token(FAMILY).await;
+    let admin_token = context.token(ADMIN).await;
     let volunteer = context.authenticated(VOLUNTEER).await;
+    let second_volunteer_token = add_second_case_volunteer(&context, &case_id).await;
     let source_clue_id = confirmed_clue!(&context, &app, &case_id, &commander_token);
     let task_id = create_task!(
         &app,
@@ -434,13 +482,22 @@ async fn task_location_reports_accept_only_recent_simulated_points_from_the_acti
     let active = update_status!(&app, &task_id, &volunteer_token, "active");
     assert_eq!(active.status(), StatusCode::OK);
 
-    let non_assignee = submit_location_report!(
-        &app,
-        &task_id,
+    for token in [
+        &family_token,
         &commander_token,
-        location_report_json(Utc::now())
-    );
-    assert_error(non_assignee, StatusCode::NOT_FOUND, "not_found").await;
+        &second_volunteer_token,
+        &admin_token,
+    ] {
+        let non_assignee =
+            submit_location_report!(&app, &task_id, token, location_report_json(Utc::now()));
+        assert_eq!(non_assignee.status(), StatusCode::NOT_FOUND);
+        let body: Value = test::read_body_json(non_assignee).await;
+        assert_eq!(body["error"]["code"], "not_found");
+        let serialized = body.to_string();
+        assert!(!serialized.contains("31.2"));
+        assert!(!serialized.contains("121.5"));
+        assert!(!serialized.contains("20"));
+    }
 
     let invalid_source = submit_location_report!(
         &app,
@@ -577,12 +634,31 @@ async fn task_location_reports_accept_only_recent_simulated_points_from_the_acti
             .is_none()
     );
 
-    let completed = update_status!(&app, &task_id, &volunteer_token, "completed");
+    let logout = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/auth/logout")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {volunteer_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(logout.status(), StatusCode::NO_CONTENT);
+    let logged_out_report = submit_location_report!(
+        &app,
+        &task_id,
+        &volunteer_token,
+        location_report_json(Utc::now())
+    );
+    assert_error(logged_out_report, StatusCode::UNAUTHORIZED, "unauthorized").await;
+
+    let active_volunteer_token = context.token(VOLUNTEER).await;
+
+    let completed = update_status!(&app, &task_id, &active_volunteer_token, "completed");
     assert_eq!(completed.status(), StatusCode::OK);
     let completed_report = submit_location_report!(
         &app,
         &task_id,
-        &volunteer_token,
+        &active_volunteer_token,
         location_report_json(Utc::now())
     );
     assert_error(completed_report, StatusCode::CONFLICT, "conflict").await;
@@ -599,10 +675,195 @@ async fn task_location_reports_accept_only_recent_simulated_points_from_the_acti
     let cancelled_report = submit_location_report!(
         &app,
         &cancelled_task_id,
-        &volunteer_token,
+        &active_volunteer_token,
         location_report_json(Utc::now())
     );
     assert_error(cancelled_report, StatusCode::CONFLICT, "conflict").await;
+}
+
+#[actix_web::test]
+async fn task_feedback_is_an_assignee_only_pending_review_clue_without_task_side_effects() {
+    let context = TestContext::new().await;
+    let app = crate::init_api_app!(&context);
+    let case_id = context.create_case().await;
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    context
+        .add_member(&case_id, COMMANDER, VOLUNTEER, "volunteer")
+        .await;
+    let commander_token = context.token(COMMANDER).await;
+    let volunteer_token = context.token(VOLUNTEER).await;
+    let family_token = context.token(FAMILY).await;
+    let admin_token = context.token(ADMIN).await;
+    let volunteer = context.authenticated(VOLUNTEER).await;
+    let second_volunteer_token = add_second_case_volunteer(&context, &case_id).await;
+    let source_clue_id = confirmed_clue!(&context, &app, &case_id, &commander_token);
+    let task_id = create_task!(
+        &app,
+        &case_id,
+        &commander_token,
+        &source_clue_id,
+        &volunteer.id
+    );
+
+    let before_active = submit_task_feedback!(&app, &task_id, &volunteer_token, feedback_json());
+    assert_error(before_active, StatusCode::CONFLICT, "conflict").await;
+    assert_eq!(
+        update_status!(&app, &task_id, &volunteer_token, "accepted").status(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        update_status!(&app, &task_id, &volunteer_token, "active").status(),
+        StatusCode::OK
+    );
+
+    for token in [
+        &family_token,
+        &commander_token,
+        &second_volunteer_token,
+        &admin_token,
+    ] {
+        let forbidden = submit_task_feedback!(&app, &task_id, token, feedback_json());
+        assert_error(forbidden, StatusCode::NOT_FOUND, "not_found").await;
+    }
+
+    let invalid_location = submit_task_feedback!(
+        &app,
+        &task_id,
+        &volunteer_token,
+        json!({
+            "content": "Observed a safe route.",
+            "location_precision": "approximate"
+        })
+    );
+    assert_error(
+        invalid_location,
+        StatusCode::BAD_REQUEST,
+        "validation_error",
+    )
+    .await;
+    let invalid_attachment = submit_task_feedback!(
+        &app,
+        &task_id,
+        &volunteer_token,
+        json!({ "content": "Observed a safe route.", "attachment_ids": ["missing"] })
+    );
+    assert_error(
+        invalid_attachment,
+        StatusCode::BAD_REQUEST,
+        "validation_error",
+    )
+    .await;
+
+    let feedback = submit_task_feedback!(&app, &task_id, &volunteer_token, feedback_json());
+    assert_eq!(feedback.status(), StatusCode::CREATED);
+    let feedback: Value = test::read_body_json(feedback).await;
+    assert_eq!(feedback["task_id"], task_id);
+    assert_eq!(feedback["status"], "pending_review");
+    let feedback_clue_id = feedback["clue_id"]
+        .as_str()
+        .expect("feedback receipt should identify its clue");
+
+    let feedback_clue = clues::Entity::find_by_id(feedback_clue_id)
+        .one(&context.database)
+        .await
+        .expect("feedback clue lookup should succeed")
+        .expect("feedback should create a clue");
+    assert_eq!(feedback_clue.status, "pending_review");
+    assert_eq!(feedback_clue.source, "task_feedback");
+    assert_eq!(feedback_clue.source_type, "field_report");
+    assert_eq!(
+        feedback_clue.content,
+        "Observed a safe route and no immediate hazard."
+    );
+    assert_eq!(
+        feedback_clue.location_text.as_deref(),
+        Some("North gate walkway")
+    );
+    assert_eq!(
+        feedback_clue.location_precision.as_deref(),
+        Some("approximate")
+    );
+    assert_eq!(
+        feedback_clue.linked_task_reference.as_deref(),
+        Some(task_id.as_str())
+    );
+
+    let task = tasks::Entity::find_by_id(&task_id)
+        .one(&context.database)
+        .await
+        .expect("task lookup should succeed")
+        .expect("task should exist");
+    assert_eq!(task.status, "active");
+    assert_eq!(task.result_summary, None);
+
+    let audit = audit_events::Entity::find()
+        .filter(audit_events::Column::EntityId.eq(&task_id))
+        .filter(audit_events::Column::Action.eq("task.feedback_submitted"))
+        .one(&context.database)
+        .await
+        .expect("feedback audit lookup should succeed")
+        .expect("feedback should be audited");
+    let metadata = audit
+        .metadata_json
+        .expect("feedback audit should include metadata");
+    assert!(metadata.contains(feedback_clue_id));
+    assert!(!metadata.contains("Observed a safe route"));
+    assert!(!metadata.contains("North gate walkway"));
+
+    let reviewed = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&format!("/api/clues/{feedback_clue_id}/review"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(
+                json!({ "status": "confirmed", "reason": "commander verified field feedback" }),
+            )
+            .to_request(),
+    )
+    .await;
+    assert_eq!(reviewed.status(), StatusCode::OK);
+
+    assert_eq!(
+        update_status!(&app, &task_id, &volunteer_token, "completed").status(),
+        StatusCode::OK
+    );
+    let completed_feedback =
+        submit_task_feedback!(&app, &task_id, &volunteer_token, feedback_json());
+    assert_error(completed_feedback, StatusCode::CONFLICT, "conflict").await;
+
+    let closed_case_id = context.create_case().await;
+    context
+        .add_member(&closed_case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    context
+        .add_member(&closed_case_id, COMMANDER, VOLUNTEER, "volunteer")
+        .await;
+    let closed_case_source = confirmed_clue!(&context, &app, &closed_case_id, &commander_token);
+    let closed_case_task_id = create_task!(
+        &app,
+        &closed_case_id,
+        &commander_token,
+        &closed_case_source,
+        &volunteer.id
+    );
+    assert_eq!(
+        update_status!(&app, &closed_case_task_id, &volunteer_token, "accepted").status(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        update_status!(&app, &closed_case_task_id, &volunteer_token, "active").status(),
+        StatusCode::OK
+    );
+    context.close_case(&closed_case_id).await;
+    let closed_case_feedback = submit_task_feedback!(
+        &app,
+        &closed_case_task_id,
+        &volunteer_token,
+        feedback_json()
+    );
+    assert_error(closed_case_feedback, StatusCode::CONFLICT, "conflict").await;
 }
 
 fn task_json(source_clue_id: &str, volunteer_user_id: &str) -> Value {
@@ -630,5 +891,14 @@ fn location_report_json(captured_at: chrono::DateTime<Utc>) -> Value {
         "longitude": 121.5,
         "accuracy_meters": 20,
         "captured_at": captured_at.to_rfc3339(),
+    })
+}
+
+fn feedback_json() -> Value {
+    json!({
+        "content": "Observed a safe route and no immediate hazard.",
+        "occurred_at": "2026-07-27T09:00:00Z",
+        "location_text": "North gate walkway",
+        "location_precision": "approximate"
     })
 }


### PR DESCRIPTION
- Add a protected POST /api/tasks/{task_id}/feedback endpoint
- Store feedback as pending-review field-report clues linked to tasks
- Validate timestamps, textual locations, precision, and attachments
- Restrict submissions to assigned volunteers on active tasks and cases
- Link uploader-owned case attachments and record clue attribution
- Audit feedback and clue submissions without exposing field content
- Document request and receipt schemas in the OpenAPI specification
- Add coverage for authorization, validation, lifecycle, and side effects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增任务反馈接口，允许已分配且处于活跃状态的志愿者提交文字反馈。
  - 支持补充发生时间、地点描述、定位精度及附件。
  - 提交后生成待审核的线索回执，不会直接改变任务或案件状态。
- **校验与安全**
  - 增加权限、内容格式、附件归属及状态校验。
  - 补充未授权、无权限、冲突和无效请求等错误提示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->