### PR TITLE
feat(cases): add role-filtered case place listing

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -26,6 +26,7 @@
 | `PATCH` | `/api/cases/{case_id}/status` | `200` | 人工更新案件状态 |
 | `GET` | `/api/cases/{case_id}/clues` | `200` | 获取角色裁剪、可分页的线索时间轴 |
 | `POST` | `/api/cases/{case_id}/clues` | `201` | 提交待审核线索 |
+| `GET` | `/api/cases/{case_id}/places` | `200` | 获取按案件角色、审核状态和可见级别裁剪的地点 |
 | `POST` | `/api/cases/{case_id}/places` | `201` | 家属或指挥提交常去/关键地点，始终待人工审核 |
 | `GET` | `/api/cases/{case_id}/resource-configuration` | `200` | 获取当前案件可用的地点类型和图片限制 |
 | `POST` | `/api/cases/{case_id}/attachments` | `201` | 上传受控 JPEG/PNG 案件图片，始终待人工审核 |
@@ -190,6 +191,8 @@ Example:
 ## 地点与图片补充
 
 `POST /api/cases/{case_id}/places` 只允许该案件的 `family` 或 `commander` 成员调用。请求需要地点名称、由 `GET /api/cases/{case_id}/resource-configuration` 返回的地点类型、文字地址和 `public`、`confirmed` 或 `internal` 可见级别；经纬度必须同时提供，且服务端校验 longitude 在 -180..180、latitude 在 -90..90。地点来源由服务端按提交者的案件角色写入，客户端不能伪造。新地点的 `review_status` 初始为 `pending_review`，不会直接成为确认进展。志愿者不能通过此接口添加家庭地址或其他敏感地点。
+
+`GET /api/cases/{case_id}/places` 只对案件成员开放，非成员统一返回 `404`。服务端按案件角色裁剪数据：指挥可查看案件全部地点；家属可查看本人提交的地点，以及已确认且非内部的地点；志愿者仅可查看已确认的公开地点。未审核地点和内部搜索方向不会通过该接口暴露给非必要角色。
 
 `POST /api/cases/{case_id}/attachments` 使用 `multipart/form-data` 的单个 `file` 字段。首版只接收 MIME 声明（允许带参数）与文件魔数一致的 JPEG/PNG。服务端解码并重新编码图片以移除 EXIF/GPS 等非必要元数据，使用随机且不可猜测的存储键保存，并在元数据或审计写入失败时删除刚写入的文件。存储目录由 `ANGUI_ATTACHMENT_STORAGE_DIRECTORY` 配置，默认 `data/attachments`，不能包含 `..` 路径分段，且必须位于静态公开目录外。下载响应包含 `X-Content-Type-Options: nosniff` 和 `Cache-Control: no-store, private`。
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -782,6 +782,27 @@ paths:
   /api/cases/{case_id}/places:
     parameters:
       - $ref: "#/components/parameters/CaseId"
+    get:
+      tags: [Cases]
+      operationId: listCasePlaces
+      summary: 获取按角色裁剪的关键地点
+      description: 服务端按案件角色和审核/可见级别裁剪地点。指挥可见案件内部地点；家属仅见本人提交或已确认的非内部地点；志愿者仅见已确认的公开地点。非成员返回 404。
+      security:
+        - bearerAuth: []
+      x-account-types: [member]
+      x-case-roles: [family, commander, volunteer]
+      x-data-classification: sensitive
+      responses:
+        "200":
+          description: 当前角色可见的地点
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "#/components/schemas/CasePlace" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "500": { $ref: "#/components/responses/InternalError" }
     post:
       tags: [Cases]
       operationId: createCasePlace

--- a/src/api/routes/cases.rs
+++ b/src/api/routes/cases.rs
@@ -29,6 +29,7 @@ pub fn configure(config: &mut web::ServiceConfig) {
             .route("/{case_id}/clues", web::post().to(create_clue))
             .route("/{case_id}/tasks", web::get().to(list_tasks))
             .route("/{case_id}/tasks", web::post().to(create_task))
+            .route("/{case_id}/places", web::get().to(list_places))
             .route("/{case_id}/places", web::post().to(create_place))
             .route(
                 "/{case_id}/resource-configuration",
@@ -77,6 +78,24 @@ async fn create_place(
     )
     .await?;
     Ok(HttpResponse::Created().json(place))
+}
+
+async fn list_places(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    case_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    let role = case_service::require_case_role(
+        &state.db,
+        &auth.id,
+        &case_id,
+        &[CaseRole::Family, CaseRole::Commander, CaseRole::Volunteer],
+    )
+    .await?;
+    let places =
+        crate::services::case_resource_service::visible_places(&state.db, &case_id, &auth.id, role)
+            .await?;
+    Ok(HttpResponse::Ok().json(places))
 }
 
 async fn create_attachment(

--- a/src/application/services/case_resource_service.rs
+++ b/src/application/services/case_resource_service.rs
@@ -217,8 +217,12 @@ pub async fn visible_places(
         CaseRole::Commander => query,
         CaseRole::Family => query.filter(
             Condition::any()
-                .add(case_places::Column::Visibility.ne("internal"))
-                .add(case_places::Column::CreatedByUserId.eq(viewer_id)),
+                .add(case_places::Column::CreatedByUserId.eq(viewer_id))
+                .add(
+                    Condition::all()
+                        .add(case_places::Column::ReviewStatus.eq("confirmed"))
+                        .add(case_places::Column::Visibility.ne("internal")),
+                ),
         ),
         CaseRole::Volunteer => query
             .filter(case_places::Column::Visibility.eq("public"))

--- a/tests/api/authentication_guards.rs
+++ b/tests/api/authentication_guards.rs
@@ -48,6 +48,7 @@ async fn every_protected_endpoint_rejects_missing_and_invalid_bearer_tokens() {
     assert_unauthorized!(app, post, "/api/cases/not-used/members");
     assert_unauthorized!(app, get, "/api/cases/not-used/clues");
     assert_unauthorized!(app, post, "/api/cases/not-used/clues");
+    assert_unauthorized!(app, get, "/api/cases/not-used/places");
     assert_unauthorized!(app, post, "/api/cases/not-used/places");
     assert_unauthorized!(app, get, "/api/cases/not-used/resource-configuration");
     assert_unauthorized!(app, post, "/api/cases/not-used/attachments");

--- a/tests/api/case_resources_post.rs
+++ b/tests/api/case_resources_post.rs
@@ -2,9 +2,15 @@ use actix_web::{
     http::{StatusCode, header},
     test,
 };
+use angui::{
+    entities::case_places,
+    models::{CreateCasePlaceRequest, PlaceVisibility},
+    services::case_resource_service,
+};
+use sea_orm::{ActiveModelTrait, EntityTrait, IntoActiveModel, Set};
 use serde_json::json;
 
-use crate::support::{COMMANDER, FAMILY, TestContext, VOLUNTEER, assert_error};
+use crate::support::{COMMANDER, FAMILY, LEARNER, TestContext, VOLUNTEER, assert_error};
 
 #[actix_web::test]
 async fn resource_configuration_is_available_only_to_case_members() {
@@ -70,6 +76,150 @@ async fn post_case_places_requires_family_or_commander_and_returns_pending_revie
         .insert_header((header::AUTHORIZATION, format!("Bearer {volunteer_token}")))
         .set_json(json!({ "name": "Home", "place_type": "other", "address": "Private", "visibility": "internal" })).to_request()).await;
     assert_error(denied, StatusCode::FORBIDDEN, "forbidden").await;
+}
+
+#[actix_web::test]
+async fn get_case_places_applies_role_visibility_and_hides_non_members() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    context
+        .add_member(&case_id, COMMANDER, VOLUNTEER, "volunteer")
+        .await;
+    let place_types = context.app_state().case_place_types;
+    let family = context.authenticated(FAMILY).await;
+    let commander = context.authenticated(COMMANDER).await;
+    let own_draft = case_resource_service::create_place(
+        &context.database,
+        &family,
+        &case_id,
+        CreateCasePlaceRequest {
+            name: "Family private draft".to_owned(),
+            place_type: "frequent".to_owned(),
+            address: "Fictional family address".to_owned(),
+            longitude: None,
+            latitude: None,
+            visibility: PlaceVisibility::Internal,
+        },
+        &place_types,
+    )
+    .await
+    .expect("fixture place should be created");
+    let public_confirmed = case_resource_service::create_place(
+        &context.database,
+        &commander,
+        &case_id,
+        CreateCasePlaceRequest {
+            name: "Confirmed public meeting point".to_owned(),
+            place_type: "key_location".to_owned(),
+            address: "Fictional public square".to_owned(),
+            longitude: Some(117.2272),
+            latitude: Some(31.8206),
+            visibility: PlaceVisibility::Public,
+        },
+        &place_types,
+    )
+    .await
+    .expect("fixture place should be created");
+    let unreviewed_public = case_resource_service::create_place(
+        &context.database,
+        &commander,
+        &case_id,
+        CreateCasePlaceRequest {
+            name: "Unreviewed public report".to_owned(),
+            place_type: "other".to_owned(),
+            address: "Fictional unreviewed address".to_owned(),
+            longitude: None,
+            latitude: None,
+            visibility: PlaceVisibility::Public,
+        },
+        &place_types,
+    )
+    .await
+    .expect("fixture place should be created");
+    let internal_confirmed = case_resource_service::create_place(
+        &context.database,
+        &commander,
+        &case_id,
+        CreateCasePlaceRequest {
+            name: "Internal search direction".to_owned(),
+            place_type: "other".to_owned(),
+            address: "Fictional internal address".to_owned(),
+            longitude: None,
+            latitude: None,
+            visibility: PlaceVisibility::Internal,
+        },
+        &place_types,
+    )
+    .await
+    .expect("fixture place should be created");
+    mark_place_confirmed(&context, &public_confirmed.id).await;
+    mark_place_confirmed(&context, &internal_confirmed.id).await;
+
+    let app = crate::init_api_app!(&context);
+    let request_for = |token: String| {
+        test::TestRequest::get()
+            .uri(&format!("/api/cases/{case_id}/places"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .to_request()
+    };
+
+    let family_places: Vec<serde_json::Value> = test::read_body_json(
+        test::call_service(&app, request_for(context.token(FAMILY).await)).await,
+    )
+    .await;
+    assert!(
+        family_places
+            .iter()
+            .any(|place| place["id"] == own_draft.id)
+    );
+    assert!(
+        family_places
+            .iter()
+            .any(|place| place["id"] == public_confirmed.id)
+    );
+    assert!(
+        !family_places
+            .iter()
+            .any(|place| place["id"] == unreviewed_public.id)
+    );
+    assert!(
+        !family_places
+            .iter()
+            .any(|place| place["id"] == internal_confirmed.id)
+    );
+
+    let volunteer_places: Vec<serde_json::Value> = test::read_body_json(
+        test::call_service(&app, request_for(context.token(VOLUNTEER).await)).await,
+    )
+    .await;
+    assert_eq!(volunteer_places.len(), 1);
+    assert_eq!(volunteer_places[0]["id"], public_confirmed.id);
+
+    let commander_places: Vec<serde_json::Value> = test::read_body_json(
+        test::call_service(&app, request_for(context.token(COMMANDER).await)).await,
+    )
+    .await;
+    assert_eq!(commander_places.len(), 4);
+
+    let hidden = test::call_service(&app, request_for(context.token(LEARNER).await)).await;
+    assert_error(hidden, StatusCode::NOT_FOUND, "not_found").await;
+}
+
+async fn mark_place_confirmed(context: &TestContext, place_id: &str) {
+    let place = case_places::Entity::find_by_id(place_id)
+        .one(&context.database)
+        .await
+        .expect("fixture place should load")
+        .expect("fixture place should exist");
+    let mut place = place.into_active_model();
+    place.review_status = Set("confirmed".to_owned());
+    place
+        .update(&context.database)
+        .await
+        .expect("fixture place should update");
 }
 
 #[actix_web::test]

--- a/tests/api/case_resources_post.rs
+++ b/tests/api/case_resources_post.rs
@@ -123,6 +123,22 @@ async fn get_case_places_applies_role_visibility_and_hides_non_members() {
     )
     .await
     .expect("fixture place should be created");
+    let confirmed_visible = case_resource_service::create_place(
+        &context.database,
+        &commander,
+        &case_id,
+        CreateCasePlaceRequest {
+            name: "Confirmed non-public meeting point".to_owned(),
+            place_type: "key_location".to_owned(),
+            address: "Fictional confirmed square".to_owned(),
+            longitude: None,
+            latitude: None,
+            visibility: PlaceVisibility::Confirmed,
+        },
+        &place_types,
+    )
+    .await
+    .expect("fixture place should be created");
     let unreviewed_public = case_resource_service::create_place(
         &context.database,
         &commander,
@@ -156,6 +172,7 @@ async fn get_case_places_applies_role_visibility_and_hides_non_members() {
     .await
     .expect("fixture place should be created");
     mark_place_confirmed(&context, &public_confirmed.id).await;
+    mark_place_confirmed(&context, &confirmed_visible.id).await;
     mark_place_confirmed(&context, &internal_confirmed.id).await;
 
     let app = crate::init_api_app!(&context);
@@ -181,6 +198,11 @@ async fn get_case_places_applies_role_visibility_and_hides_non_members() {
             .any(|place| place["id"] == public_confirmed.id)
     );
     assert!(
+        family_places
+            .iter()
+            .any(|place| place["id"] == confirmed_visible.id)
+    );
+    assert!(
         !family_places
             .iter()
             .any(|place| place["id"] == unreviewed_public.id)
@@ -202,7 +224,7 @@ async fn get_case_places_applies_role_visibility_and_hides_non_members() {
         test::call_service(&app, request_for(context.token(COMMANDER).await)).await,
     )
     .await;
-    assert_eq!(commander_places.len(), 4);
+    assert_eq!(commander_places.len(), 5);
 
     let hidden = test::call_service(&app, request_for(context.token(LEARNER).await)).await;
     assert_error(hidden, StatusCode::NOT_FOUND, "not_found").await;

--- a/tests/api/openapi_intake_contract.rs
+++ b/tests/api/openapi_intake_contract.rs
@@ -173,3 +173,25 @@ fn clue_timeline_openapi_contract_covers_pagination_and_visibility() {
         ],
     );
 }
+
+#[test]
+fn case_places_openapi_contract_covers_role_filtered_reads() {
+    let (_, operation) = OPENAPI
+        .split_once("  /api/cases/{case_id}/places:\n")
+        .expect("OpenAPI places path must exist");
+    let get_operation = operation
+        .split_once("    get:\n")
+        .and_then(|(_, after_get)| after_get.split_once("    post:\n").map(|(get, _)| get))
+        .expect("OpenAPI places path must declare GET before POST");
+    for expected in [
+        "operationId: listCasePlaces",
+        "x-case-roles: [family, commander, volunteer]",
+        "#/components/schemas/CasePlace",
+        "\"404\": { $ref: \"#/components/responses/NotFound\" }",
+    ] {
+        assert!(
+            get_operation.contains(expected),
+            "OpenAPI places operation must declare {expected:?}"
+        );
+    }
+}


### PR DESCRIPTION
- expose GET /api/cases/{case_id}/places for case members
- filter places by viewer role, review status, visibility, and ownership
- return 404 for users who are not case members
- document the endpoint in API and OpenAPI specifications
- add authentication, visibility, and OpenAPI contract coverage

Close #27 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增获取案件关键地点列表的接口（GET `/api/cases/{case_id}/places`）。
  - 按案件角色与地点审核/可见性状态返回过滤结果：家属仅见本人提交及已确认且非内部地点；志愿者仅见已确认公开地点；指挥可见更全面的内部地点。
  - 非案件成员访问返回失败（如 404）。
- **文档**
  - 补充并更正地点列表接口的鉴权、可见性语义与 OpenAPI 契约。
- **测试**
  - 新增鉴权拦截、角色可见性过滤及 OpenAPI 顺序/字段契约的覆盖测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->