### PR TITLE
feat(cases): add role-filtered map view endpoint

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -195,7 +195,7 @@ Example:
 
 `GET /api/cases/{case_id}/places` 只对案件成员开放，非成员统一返回 `404`。服务端按案件角色裁剪数据：指挥可查看案件全部地点；家属可查看本人提交的地点，以及已确认且非内部的地点；志愿者仅可查看已确认的公开地点。未审核地点和内部搜索方向不会通过该接口暴露给非必要角色。
 
-`GET /api/cases/{case_id}/map-view` 是不依赖地图 SDK 的确定性态势接口。每个地图项都带对象类型、来源、时间、审核/任务状态、坐标或 `null` 与文字地点；无坐标记录保留在响应中作为文本回退。家属不接收内部任务或线索层，志愿者只接收本人任务和已确认公开地点，指挥可额外查看已确认线索；接口不会返回预测位置。
+`GET /api/cases/{case_id}/map-view` 是不依赖地图 SDK 的确定性态势接口。每个地图项都带对象类型、来源、时间、审核/任务状态、坐标或 `null` 与文字地点；无坐标记录保留在响应中作为文本回退。家属申报的最后出现地点始终标为 `pending_review`，其 `display_name` 为 `null`，客户端必须按 `object_type` 本地化标签而不能呈现为确认进展。家属不接收内部任务或线索层，志愿者只接收本人任务和已确认公开地点，指挥可额外查看已确认线索；接口不会返回预测位置。
 
 `POST /api/cases/{case_id}/attachments` 使用 `multipart/form-data` 的单个 `file` 字段。首版只接收 MIME 声明（允许带参数）与文件魔数一致的 JPEG/PNG。服务端解码并重新编码图片以移除 EXIF/GPS 等非必要元数据，使用随机且不可猜测的存储键保存，并在元数据或审计写入失败时删除刚写入的文件。存储目录由 `ANGUI_ATTACHMENT_STORAGE_DIRECTORY` 配置，默认 `data/attachments`，不能包含 `..` 路径分段，且必须位于静态公开目录外。下载响应包含 `X-Content-Type-Options: nosniff` 和 `Cache-Control: no-store, private`。
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -26,6 +26,7 @@
 | `PATCH` | `/api/cases/{case_id}/status` | `200` | 人工更新案件状态 |
 | `GET` | `/api/cases/{case_id}/clues` | `200` | 获取角色裁剪、可分页的线索时间轴 |
 | `POST` | `/api/cases/{case_id}/clues` | `201` | 提交待审核线索 |
+| `GET` | `/api/cases/{case_id}/map-view` | `200` | 获取含文字地点回退的角色裁剪地图态势 |
 | `GET` | `/api/cases/{case_id}/places` | `200` | 获取按案件角色、审核状态和可见级别裁剪的地点 |
 | `POST` | `/api/cases/{case_id}/places` | `201` | 家属或指挥提交常去/关键地点，始终待人工审核 |
 | `GET` | `/api/cases/{case_id}/resource-configuration` | `200` | 获取当前案件可用的地点类型和图片限制 |
@@ -193,6 +194,8 @@ Example:
 `POST /api/cases/{case_id}/places` 只允许该案件的 `family` 或 `commander` 成员调用。请求需要地点名称、由 `GET /api/cases/{case_id}/resource-configuration` 返回的地点类型、文字地址和 `public`、`confirmed` 或 `internal` 可见级别；经纬度必须同时提供，且服务端校验 longitude 在 -180..180、latitude 在 -90..90。地点来源由服务端按提交者的案件角色写入，客户端不能伪造。新地点的 `review_status` 初始为 `pending_review`，不会直接成为确认进展。志愿者不能通过此接口添加家庭地址或其他敏感地点。
 
 `GET /api/cases/{case_id}/places` 只对案件成员开放，非成员统一返回 `404`。服务端按案件角色裁剪数据：指挥可查看案件全部地点；家属可查看本人提交的地点，以及已确认且非内部的地点；志愿者仅可查看已确认的公开地点。未审核地点和内部搜索方向不会通过该接口暴露给非必要角色。
+
+`GET /api/cases/{case_id}/map-view` 是不依赖地图 SDK 的确定性态势接口。每个地图项都带对象类型、来源、时间、审核/任务状态、坐标或 `null` 与文字地点；无坐标记录保留在响应中作为文本回退。家属不接收内部任务或线索层，志愿者只接收本人任务和已确认公开地点，指挥可额外查看已确认线索；接口不会返回预测位置。
 
 `POST /api/cases/{case_id}/attachments` 使用 `multipart/form-data` 的单个 `file` 字段。首版只接收 MIME 声明（允许带参数）与文件魔数一致的 JPEG/PNG。服务端解码并重新编码图片以移除 EXIF/GPS 等非必要元数据，使用随机且不可猜测的存储键保存，并在元数据或审计写入失败时删除刚写入的文件。存储目录由 `ANGUI_ATTACHMENT_STORAGE_DIRECTORY` 配置，默认 `data/attachments`，不能包含 `..` 路径分段，且必须位于静态公开目录外。下载响应包含 `X-Content-Type-Options: nosniff` 和 `Cache-Control: no-store, private`。
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -786,7 +786,7 @@ paths:
       tags: [Cases]
       operationId: getCaseMapView
       summary: 获取按角色裁剪的地图态势
-      description: 返回已授权的地点、已确认线索、任务区域和无坐标文字地点回退，不包含预测位置。家属不见内部任务；志愿者仅见本人任务和已确认公开地点；非成员返回 404。
+      description: 返回已授权的地点、已确认线索、任务区域和无坐标文字地点回退，不包含预测位置。家属申报的最后出现地点保持 pending_review，客户端依据 object_type 本地化其展示标签；家属不见内部任务；志愿者仅见本人任务和已确认公开地点；非成员返回 404。
       security:
         - bearerAuth: []
       x-account-types: [member]
@@ -2191,7 +2191,9 @@ components:
       properties:
         id: { type: string }
         object_type: { type: string, enum: [last_seen, place, clue, task] }
-        display_name: { type: string }
+        display_name:
+          type: [string, "null"]
+          description: 对象自身名称；last_seen 为 null，客户端必须依据 object_type 本地化展示标签。
         longitude: { type: [number, "null"] }
         latitude: { type: [number, "null"] }
         location_text: { type: [string, "null"] }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -779,6 +779,29 @@ paths:
         "409": { $ref: "#/components/responses/Conflict" }
         "500": { $ref: "#/components/responses/InternalError" }
 
+  /api/cases/{case_id}/map-view:
+    parameters:
+      - $ref: "#/components/parameters/CaseId"
+    get:
+      tags: [Cases]
+      operationId: getCaseMapView
+      summary: 获取按角色裁剪的地图态势
+      description: 返回已授权的地点、已确认线索、任务区域和无坐标文字地点回退，不包含预测位置。家属不见内部任务；志愿者仅见本人任务和已确认公开地点；非成员返回 404。
+      security:
+        - bearerAuth: []
+      x-account-types: [member]
+      x-case-roles: [family, commander, volunteer]
+      x-data-classification: sensitive
+      responses:
+        "200":
+          description: 当前角色完成职责所需的地图项
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/CaseMapView" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
   /api/cases/{case_id}/places:
     parameters:
       - $ref: "#/components/parameters/CaseId"
@@ -2151,6 +2174,34 @@ components:
         longitude: { type: [number, "null"], minimum: -180, maximum: 180 }
         latitude: { type: [number, "null"], minimum: -90, maximum: 90 }
         visibility: { type: string, enum: [public, confirmed, internal] }
+
+    CaseMapView:
+      type: object
+      additionalProperties: false
+      required: [items]
+      properties:
+        items:
+          type: array
+          items: { $ref: "#/components/schemas/CaseMapItem" }
+
+    CaseMapItem:
+      type: object
+      additionalProperties: false
+      required: [id, object_type, display_name, longitude, latitude, location_text, location_precision, source, occurred_at, reported_at, review_status, related_task_id, updated_at]
+      properties:
+        id: { type: string }
+        object_type: { type: string, enum: [last_seen, place, clue, task] }
+        display_name: { type: string }
+        longitude: { type: [number, "null"] }
+        latitude: { type: [number, "null"] }
+        location_text: { type: [string, "null"] }
+        location_precision: { type: string, enum: [exact, unknown, approximate] }
+        source: { type: string }
+        occurred_at: { type: [string, "null"], format: date-time }
+        reported_at: { type: [string, "null"], format: date-time }
+        review_status: { type: string }
+        related_task_id: { type: [string, "null"] }
+        updated_at: { type: string, format: date-time }
 
     CasePlace:
       type: object

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -691,7 +691,7 @@ pub struct CaseMapViewResponse {
 pub struct CaseMapItem {
     pub id: String,
     pub object_type: String,
-    pub display_name: String,
+    pub display_name: Option<String>,
     pub longitude: Option<f64>,
     pub latitude: Option<f64>,
     pub location_text: Option<String>,

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -683,6 +683,28 @@ pub struct TaskListResponse {
 }
 
 #[derive(Debug, Serialize)]
+pub struct CaseMapViewResponse {
+    pub items: Vec<CaseMapItem>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CaseMapItem {
+    pub id: String,
+    pub object_type: String,
+    pub display_name: String,
+    pub longitude: Option<f64>,
+    pub latitude: Option<f64>,
+    pub location_text: Option<String>,
+    pub location_precision: String,
+    pub source: String,
+    pub occurred_at: Option<String>,
+    pub reported_at: Option<String>,
+    pub review_status: String,
+    pub related_task_id: Option<String>,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Serialize)]
 pub struct TaskLocationReportReceipt {
     pub id: String,
     pub source: String,

--- a/src/api/routes/cases.rs
+++ b/src/api/routes/cases.rs
@@ -242,7 +242,7 @@ async fn get_map_view(
         items.push(CaseMapItem {
             id: format!("case:{}:last-seen", detail.id),
             object_type: "last_seen".to_owned(),
-            display_name: "Last confirmed location".to_owned(),
+            display_name: None,
             longitude: None,
             latitude: None,
             location_text: Some(location_text),
@@ -250,7 +250,7 @@ async fn get_map_view(
             source: "case_profile".to_owned(),
             occurred_at: detail.elder_profile.last_seen_at,
             reported_at: None,
-            review_status: "confirmed".to_owned(),
+            review_status: "pending_review".to_owned(),
             related_task_id: None,
             updated_at: detail.updated_at.clone(),
         });
@@ -259,7 +259,7 @@ async fn get_map_view(
         CaseMapItem {
             id: place.id,
             object_type: "place".to_owned(),
-            display_name: place.name,
+            display_name: Some(place.name),
             longitude: place.longitude,
             latitude: place.latitude,
             location_text: Some(place.address),
@@ -286,7 +286,7 @@ async fn get_map_view(
                 .map(|clue| CaseMapItem {
                     id: clue.id,
                     object_type: "clue".to_owned(),
-                    display_name: clue.content,
+                    display_name: Some(clue.content),
                     longitude: None,
                     latitude: None,
                     location_text: clue.location_text,
@@ -306,7 +306,7 @@ async fn get_map_view(
         CaseMapItem {
             id: task.id.clone(),
             object_type: "task".to_owned(),
-            display_name: task.title,
+            display_name: Some(task.title),
             longitude: task.longitude,
             latitude: task.latitude,
             location_text: Some(task.area_text),

--- a/src/api/routes/cases.rs
+++ b/src/api/routes/cases.rs
@@ -216,16 +216,25 @@ async fn get_map_view(
     case_id: web::Path<String>,
 ) -> Result<HttpResponse, ApiError> {
     let detail = case_service::get_case(&state.db, &auth, &case_id).await?;
-    let tasks = crate::services::task_service::list_tasks(
-        &state.db,
-        &auth,
-        &case_id,
-        TaskListQuery {
-            page: Some(1),
-            page_size: Some(100),
-        },
-    )
-    .await?;
+    let mut task_items = Vec::new();
+    let mut task_page = 1;
+    loop {
+        let tasks = crate::services::task_service::list_tasks(
+            &state.db,
+            &auth,
+            &case_id,
+            TaskListQuery {
+                page: Some(task_page),
+                page_size: Some(100),
+            },
+        )
+        .await?;
+        task_items.extend(tasks.items);
+        if u64::try_from(task_items.len()).map_err(|_| ApiError::Internal)? >= tasks.total {
+            break;
+        }
+        task_page = task_page.checked_add(1).ok_or(ApiError::Internal)?;
+    }
     let mut items = Vec::new();
     if detail.access_role != CaseRole::Volunteer
         && let Some(location_text) = detail.elder_profile.last_seen_location
@@ -293,7 +302,7 @@ async fn get_map_view(
                 }),
         );
     }
-    items.extend(tasks.items.into_iter().map(|task| {
+    items.extend(task_items.into_iter().map(|task| {
         CaseMapItem {
             id: task.id.clone(),
             object_type: "task".to_owned(),

--- a/src/api/routes/cases.rs
+++ b/src/api/routes/cases.rs
@@ -6,9 +6,10 @@ use crate::{
     app_state::AppState,
     error::ApiError,
     models::{
-        AddCaseMemberRequest, AuthenticatedUser, CaseResourceConfigurationResponse,
-        CreateCasePlaceRequest, CreateCaseRequest, CreateClueRequest, CreateTaskRequest,
-        TaskListQuery, UpdateCaseStatusRequest, UpdateElderProfileRequest,
+        AddCaseMemberRequest, AuthenticatedUser, CaseMapItem, CaseMapViewResponse,
+        CaseResourceConfigurationResponse, CreateCasePlaceRequest, CreateCaseRequest,
+        CreateClueRequest, CreateTaskRequest, TaskListQuery, UpdateCaseStatusRequest,
+        UpdateElderProfileRequest,
     },
     roles::CaseRole,
     services::case_service,
@@ -29,6 +30,7 @@ pub fn configure(config: &mut web::ServiceConfig) {
             .route("/{case_id}/clues", web::post().to(create_clue))
             .route("/{case_id}/tasks", web::get().to(list_tasks))
             .route("/{case_id}/tasks", web::post().to(create_task))
+            .route("/{case_id}/map-view", web::get().to(get_map_view))
             .route("/{case_id}/places", web::get().to(list_places))
             .route("/{case_id}/places", web::post().to(create_place))
             .route(
@@ -206,6 +208,114 @@ async fn get_case(
 ) -> Result<HttpResponse, ApiError> {
     let case = case_service::get_case(&state.db, &auth, &case_id).await?;
     Ok(HttpResponse::Ok().json(case))
+}
+
+async fn get_map_view(
+    state: web::Data<AppState>,
+    auth: AuthenticatedUser,
+    case_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    let detail = case_service::get_case(&state.db, &auth, &case_id).await?;
+    let tasks = crate::services::task_service::list_tasks(
+        &state.db,
+        &auth,
+        &case_id,
+        TaskListQuery {
+            page: Some(1),
+            page_size: Some(100),
+        },
+    )
+    .await?;
+    let mut items = Vec::new();
+    if detail.access_role != CaseRole::Volunteer
+        && let Some(location_text) = detail.elder_profile.last_seen_location
+    {
+        items.push(CaseMapItem {
+            id: format!("case:{}:last-seen", detail.id),
+            object_type: "last_seen".to_owned(),
+            display_name: "Last confirmed location".to_owned(),
+            longitude: None,
+            latitude: None,
+            location_text: Some(location_text),
+            location_precision: "unknown".to_owned(),
+            source: "case_profile".to_owned(),
+            occurred_at: detail.elder_profile.last_seen_at,
+            reported_at: None,
+            review_status: "confirmed".to_owned(),
+            related_task_id: None,
+            updated_at: detail.updated_at.clone(),
+        });
+    }
+    items.extend(detail.places.into_iter().map(|place| {
+        CaseMapItem {
+            id: place.id,
+            object_type: "place".to_owned(),
+            display_name: place.name,
+            longitude: place.longitude,
+            latitude: place.latitude,
+            location_text: Some(place.address),
+            location_precision: if place.longitude.is_some() {
+                "exact"
+            } else {
+                "unknown"
+            }
+            .to_owned(),
+            source: place.source,
+            occurred_at: None,
+            reported_at: Some(place.created_at),
+            review_status: place.review_status,
+            related_task_id: None,
+            updated_at: place.updated_at,
+        }
+    }));
+    if detail.access_role == CaseRole::Commander {
+        items.extend(
+            detail
+                .clues
+                .into_iter()
+                .filter(|clue| clue.status == "confirmed" && clue.location_text.is_some())
+                .map(|clue| CaseMapItem {
+                    id: clue.id,
+                    object_type: "clue".to_owned(),
+                    display_name: clue.content,
+                    longitude: None,
+                    latitude: None,
+                    location_text: clue.location_text,
+                    location_precision: clue
+                        .location_precision
+                        .unwrap_or_else(|| "unknown".to_owned()),
+                    source: clue.source_type,
+                    occurred_at: clue.occurred_at,
+                    reported_at: Some(clue.reported_at),
+                    review_status: clue.status,
+                    related_task_id: clue.linked_task_reference,
+                    updated_at: clue.updated_at,
+                }),
+        );
+    }
+    items.extend(tasks.items.into_iter().map(|task| {
+        CaseMapItem {
+            id: task.id.clone(),
+            object_type: "task".to_owned(),
+            display_name: task.title,
+            longitude: task.longitude,
+            latitude: task.latitude,
+            location_text: Some(task.area_text),
+            location_precision: if task.longitude.is_some() {
+                "exact"
+            } else {
+                "unknown"
+            }
+            .to_owned(),
+            source: "task".to_owned(),
+            occurred_at: Some(task.due_at),
+            reported_at: Some(task.created_at),
+            review_status: task.status,
+            related_task_id: Some(task.id),
+            updated_at: task.updated_at,
+        }
+    }));
+    Ok(HttpResponse::Ok().json(CaseMapViewResponse { items }))
 }
 
 async fn update_case_status(

--- a/tests/api/authentication_guards.rs
+++ b/tests/api/authentication_guards.rs
@@ -48,6 +48,7 @@ async fn every_protected_endpoint_rejects_missing_and_invalid_bearer_tokens() {
     assert_unauthorized!(app, post, "/api/cases/not-used/members");
     assert_unauthorized!(app, get, "/api/cases/not-used/clues");
     assert_unauthorized!(app, post, "/api/cases/not-used/clues");
+    assert_unauthorized!(app, get, "/api/cases/not-used/map-view");
     assert_unauthorized!(app, get, "/api/cases/not-used/places");
     assert_unauthorized!(app, post, "/api/cases/not-used/places");
     assert_unauthorized!(app, get, "/api/cases/not-used/resource-configuration");

--- a/tests/api/case_map_view_get.rs
+++ b/tests/api/case_map_view_get.rs
@@ -100,7 +100,10 @@ async fn get_case_map_view_returns_only_role_necessary_layers_with_text_fallback
     assert!(
         commander_items
             .iter()
-            .any(|item| item["object_type"] == "last_seen" && item["longitude"].is_null())
+            .any(|item| item["object_type"] == "last_seen"
+                && item["longitude"].is_null()
+                && item["review_status"] == "pending_review"
+                && item["display_name"].is_null())
     );
     assert!(
         commander_items

--- a/tests/api/case_map_view_get.rs
+++ b/tests/api/case_map_view_get.rs
@@ -1,0 +1,122 @@
+use actix_web::{
+    http::{StatusCode, header},
+    test,
+};
+use serde_json::{Value, json};
+
+use crate::support::{COMMANDER, FAMILY, LEARNER, TestContext, VOLUNTEER, assert_error};
+
+#[actix_web::test]
+async fn get_case_map_view_returns_only_role_necessary_layers_with_text_fallbacks() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    context
+        .add_member(&case_id, COMMANDER, VOLUNTEER, "volunteer")
+        .await;
+    let app = crate::init_api_app!(&context);
+    let commander_token = context.token(COMMANDER).await;
+    let volunteer = context.authenticated(VOLUNTEER).await;
+    let clue_id = context.create_clue(&case_id, FAMILY).await;
+    let reviewed = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&format!("/api/clues/{clue_id}/review"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(json!({ "status": "confirmed", "reason": "fictional source verified" }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(reviewed.status(), StatusCode::OK);
+    let task = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/tasks"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(json!({
+                "source_clue_id": clue_id,
+                "volunteer_user_id": volunteer.id,
+                "title": "Verify fictional north gate",
+                "objective": "Check the fictional reported route and submit observations.",
+                "area_text": "Fictional north gate",
+                "latitude": 31.8206,
+                "longitude": 117.2272,
+                "due_at": "2099-07-27T12:00:00Z",
+                "background": "Fictional confirmed clue.",
+                "risk_level": "medium",
+                "risk_notes": "Stay in public areas and do not enter restricted property.",
+                "safety_briefing": "Keep contact with the commander and stop if conditions change.",
+                "expected_feedback": "Submit a factual text report for commander review."
+            }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(task.status(), StatusCode::CREATED);
+    let task: Value = test::read_body_json(task).await;
+    let task_id = task["id"].as_str().expect("task id");
+
+    let request_for = |token: String| {
+        test::TestRequest::get()
+            .uri(&format!("/api/cases/{case_id}/map-view"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .to_request()
+    };
+    let commander_view: Value = test::read_body_json(
+        test::call_service(&app, request_for(context.token(COMMANDER).await)).await,
+    )
+    .await;
+    let commander_items = commander_view["items"].as_array().expect("map items");
+    assert!(
+        commander_items
+            .iter()
+            .any(|item| item["object_type"] == "last_seen" && item["longitude"].is_null())
+    );
+    assert!(
+        commander_items
+            .iter()
+            .any(|item| item["object_type"] == "clue" && item["review_status"] == "confirmed")
+    );
+    assert!(
+        commander_items
+            .iter()
+            .any(|item| item["id"] == task_id && item["latitude"] == 31.8206)
+    );
+
+    let family_view: Value = test::read_body_json(
+        test::call_service(&app, request_for(context.token(FAMILY).await)).await,
+    )
+    .await;
+    let family_items = family_view["items"].as_array().expect("map items");
+    assert!(
+        family_items
+            .iter()
+            .any(|item| item["object_type"] == "last_seen")
+    );
+    assert!(
+        !family_items
+            .iter()
+            .any(|item| item["object_type"] == "clue")
+    );
+    assert!(
+        !family_items
+            .iter()
+            .any(|item| item["object_type"] == "task")
+    );
+
+    let volunteer_view: Value = test::read_body_json(
+        test::call_service(&app, request_for(context.token(VOLUNTEER).await)).await,
+    )
+    .await;
+    let volunteer_items = volunteer_view["items"].as_array().expect("map items");
+    assert!(volunteer_items.iter().any(|item| item["id"] == task_id));
+    assert!(
+        !volunteer_items
+            .iter()
+            .any(|item| item["object_type"] == "last_seen" || item["object_type"] == "clue")
+    );
+
+    let hidden = test::call_service(&app, request_for(context.token(LEARNER).await)).await;
+    assert_error(hidden, StatusCode::NOT_FOUND, "not_found").await;
+}

--- a/tests/api/case_map_view_get.rs
+++ b/tests/api/case_map_view_get.rs
@@ -2,6 +2,8 @@ use actix_web::{
     http::{StatusCode, header},
     test,
 };
+use angui::entities::tasks;
+use sea_orm::{ActiveModelTrait, Set};
 use serde_json::{Value, json};
 
 use crate::support::{COMMANDER, FAMILY, LEARNER, TestContext, VOLUNTEER, assert_error};
@@ -36,7 +38,7 @@ async fn get_case_map_view_returns_only_role_necessary_layers_with_text_fallback
             .uri(&format!("/api/cases/{case_id}/tasks"))
             .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
             .set_json(json!({
-                "source_clue_id": clue_id,
+                "source_clue_id": clue_id.clone(),
                 "volunteer_user_id": volunteer.id,
                 "title": "Verify fictional north gate",
                 "objective": "Check the fictional reported route and submit observations.",
@@ -56,6 +58,33 @@ async fn get_case_map_view_returns_only_role_necessary_layers_with_text_fallback
     assert_eq!(task.status(), StatusCode::CREATED);
     let task: Value = test::read_body_json(task).await;
     let task_id = task["id"].as_str().expect("task id");
+    let commander = context.authenticated(COMMANDER).await;
+    for index in 0..100 {
+        tasks::ActiveModel {
+            id: Set(format!("map-extra-task-{index}")),
+            case_id: Set(case_id.clone()),
+            source_clue_id: Set(Some(clue_id.clone())),
+            title: Set(format!("Fictional extra task {index}")),
+            objective: Set("Fictional task objective.".to_owned()),
+            area_text: Set("Fictional task area".to_owned()),
+            latitude: Set(None),
+            longitude: Set(None),
+            due_at: Set("2099-07-27T12:00:00Z".to_owned()),
+            background: Set("Fictional confirmed clue.".to_owned()),
+            risk_level: Set("medium".to_owned()),
+            risk_notes: Set("Fictional safety note.".to_owned()),
+            safety_briefing: Set("Fictional safety briefing.".to_owned()),
+            expected_feedback: Set("Fictional feedback.".to_owned()),
+            status: Set("pending_claim".to_owned()),
+            result_summary: Set(None),
+            created_by_user_id: Set(commander.id.clone()),
+            created_at: Set("2026-07-27T00:00:00Z".to_owned()),
+            updated_at: Set("2026-07-27T00:00:00Z".to_owned()),
+        }
+        .insert(&context.database)
+        .await
+        .expect("fixture task should be created");
+    }
 
     let request_for = |token: String| {
         test::TestRequest::get()
@@ -82,6 +111,18 @@ async fn get_case_map_view_returns_only_role_necessary_layers_with_text_fallback
         commander_items
             .iter()
             .any(|item| item["id"] == task_id && item["latitude"] == 31.8206)
+    );
+    assert_eq!(
+        commander_items
+            .iter()
+            .filter(|item| item["object_type"] == "task")
+            .count(),
+        101
+    );
+    assert!(
+        commander_items
+            .iter()
+            .any(|item| item["id"] == "map-extra-task-99")
     );
 
     let family_view: Value = test::read_body_json(

--- a/tests/api/mod.rs
+++ b/tests/api/mod.rs
@@ -6,6 +6,7 @@ mod case_clues_get;
 mod case_clues_post;
 mod case_detail_get;
 mod case_elder_profile_patch;
+mod case_map_view_get;
 mod case_members_post;
 mod case_resources_post;
 mod case_status_patch;


### PR DESCRIPTION
- expose GET /api/cases/{case_id}/map-view for case members
- return places, tasks, confirmed clues, and last-seen text fallbacks
- filter map layers by family, commander, and volunteer permissions
- preserve records without coordinates for deterministic text location fallback
- exclude predicted locations and unauthorized internal data
- document the endpoint and map-view response schemas in API and OpenAPI docs
- add authentication and role-based map-view integration tests

close #28 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增案件地图态势接口 `GET /api/cases/{case_id}/map-view`：以统一地图条目返回地点、线索、任务与最近确认位置，按访问角色裁剪可见内容，并明确不包含预测位置。
  - 坐标缺失时支持文本/字段回退；家属可见的最后出现标记为 `pending_review` 且 `display_name` 为 `null`（不展示为确认进展）。
- **文档**
  - 完善接口说明与响应形态、字段类型与边界（成功/错误状态）。
- **测试**
  - 覆盖角色过滤、坐标/文本回退、越权与未找到场景（401/404）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->