### PR TITLE
feat(cases): add role-filtered deterministic case summaries

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -27,6 +27,7 @@
 | `GET` | `/api/cases/{case_id}/clues` | `200` | 获取角色裁剪、可分页的线索时间轴 |
 | `POST` | `/api/cases/{case_id}/clues` | `201` | 提交待审核线索 |
 | `GET` | `/api/cases/{case_id}/map-view` | `200` | 获取含文字地点回退的角色裁剪地图态势 |
+| `GET` | `/api/cases/{case_id}/summary` | `200` | 获取含来源范围与生成时间的角色裁剪确定性案件摘要 |
 | `GET` | `/api/cases/{case_id}/places` | `200` | 获取按案件角色、审核状态和可见级别裁剪的地点 |
 | `POST` | `/api/cases/{case_id}/places` | `201` | 家属或指挥提交常去/关键地点，始终待人工审核 |
 | `GET` | `/api/cases/{case_id}/resource-configuration` | `200` | 获取当前案件可用的地点类型和图片限制 |
@@ -196,6 +197,8 @@ Example:
 `GET /api/cases/{case_id}/places` 只对案件成员开放，非成员统一返回 `404`。服务端按案件角色裁剪数据：指挥可查看案件全部地点；家属可查看本人提交的地点，以及已确认且非内部的地点；志愿者仅可查看已确认的公开地点。未审核地点和内部搜索方向不会通过该接口暴露给非必要角色。
 
 `GET /api/cases/{case_id}/map-view` 是不依赖地图 SDK 的确定性态势接口。每个地图项都带对象类型、来源、时间、审核/任务状态、坐标或 `null` 与文字地点；无坐标记录保留在响应中作为文本回退。家属申报的最后出现地点始终标为 `pending_review`，其 `display_name` 为 `null`，客户端必须按 `object_type` 本地化标签而不能呈现为确认进展。家属不接收内部任务或线索层，志愿者只接收本人任务和已确认公开地点，指挥可额外查看已确认线索；接口不会返回预测位置。
+
+`GET /api/cases/{case_id}/summary` 提供不依赖外部 AI 的确定性案件摘要。响应的 `generated_at` 和 `source_scope` 说明生成时间与当前角色可用的数据范围。只有人工审核为 `confirmed` 的线索才会进入 `last_confirmed_information` 与 `confirmed_clues`；`pending_review` 和 `needs_verification` 始终保留在 `pending_verification`，不会被表述为确认事实。指挥可见待核实事项、已排除方向、未完成任务形成的当前重点和全部任务状态；家属不接收任务或内部搜索方向；志愿者只接收本人任务的执行与安全信息。
 
 `POST /api/cases/{case_id}/attachments` 使用 `multipart/form-data` 的单个 `file` 字段。首版只接收 MIME 声明（允许带参数）与文件魔数一致的 JPEG/PNG。服务端解码并重新编码图片以移除 EXIF/GPS 等非必要元数据，使用随机且不可猜测的存储键保存，并在元数据或审计写入失败时删除刚写入的文件。存储目录由 `ANGUI_ATTACHMENT_STORAGE_DIRECTORY` 配置，默认 `data/attachments`，不能包含 `..` 路径分段，且必须位于静态公开目录外。下载响应包含 `X-Content-Type-Options: nosniff` 和 `Cache-Control: no-store, private`。
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -802,6 +802,32 @@ paths:
         "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/InternalError" }
 
+  /api/cases/{case_id}/summary:
+    parameters:
+      - $ref: "#/components/parameters/CaseId"
+    get:
+      tags: [Cases]
+      operationId: getCaseSummary
+      summary: 获取按角色裁剪的确定性案件摘要
+      description: |
+        不调用外部 AI 的确定性聚合。仅 `confirmed` 线索会出现在最后确认信息和已确认线索中；
+        `pending_review` 与 `needs_verification` 始终单列为待核实事项。指挥可见完整内部摘要，
+        家属不接收任务或搜索方向，志愿者仅接收本人任务的必要执行信息。响应包含生成时间和数据来源范围。
+      security:
+        - bearerAuth: []
+      x-account-types: [member]
+      x-case-roles: [family, commander, volunteer]
+      x-data-classification: sensitive
+      responses:
+        "200":
+          description: 当前案件角色可见的确定性摘要
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/CaseSummary" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
   /api/cases/{case_id}/places:
     parameters:
       - $ref: "#/components/parameters/CaseId"
@@ -2204,6 +2230,81 @@ components:
         review_status: { type: string }
         related_task_id: { type: [string, "null"] }
         updated_at: { type: string, format: date-time }
+
+    CaseSummary:
+      type: object
+      additionalProperties: false
+      required: [case_id, access_role, generated_at, source_scope, last_confirmed_information, confirmed_clues, pending_verification, excluded_directions, current_focus, task_status, safety_reminders]
+      properties:
+        case_id: { type: string, format: uuid }
+        access_role: { $ref: "#/components/schemas/CaseRole" }
+        generated_at: { type: string, format: date-time }
+        source_scope:
+          type: array
+          description: Machine-readable list of the authorized data categories used for this role's summary.
+          items: { type: string }
+        last_confirmed_information:
+          oneOf:
+            - $ref: "#/components/schemas/CaseSummaryClue"
+            - type: "null"
+          description: Most recently reported confirmed clue; never an unreviewed profile assertion or clue.
+        confirmed_clues:
+          type: array
+          items: { $ref: "#/components/schemas/CaseSummaryClue" }
+        pending_verification:
+          type: array
+          description: Items remain unverified and must not be presented as confirmed facts.
+          items: { $ref: "#/components/schemas/CaseSummaryClue" }
+        excluded_directions:
+          type: array
+          description: Commander-only non-confirmed directions with an exclusion status.
+          items: { $ref: "#/components/schemas/CaseSummaryClue" }
+        current_focus:
+          type: array
+          description: Commander-only active search directions derived from unfinished tasks.
+          items: { $ref: "#/components/schemas/CaseSummaryFocus" }
+        task_status:
+          type: array
+          description: Commander receives all tasks; volunteer receives only their assigned tasks; family receives none.
+          items: { $ref: "#/components/schemas/CaseSummaryTask" }
+        safety_reminders:
+          type: array
+          items: { type: string }
+
+    CaseSummaryClue:
+      type: object
+      additionalProperties: false
+      required: [clue_id, content, status, occurred_at, reported_at]
+      properties:
+        clue_id: { type: string, format: uuid }
+        content: { type: string }
+        status: { type: string }
+        occurred_at: { type: [string, "null"], format: date-time }
+        reported_at: { type: string, format: date-time }
+
+    CaseSummaryFocus:
+      type: object
+      additionalProperties: false
+      required: [task_id, title, objective, area_text, status]
+      properties:
+        task_id: { type: string, format: uuid }
+        title: { type: string }
+        objective: { type: string }
+        area_text: { type: string }
+        status: { $ref: "#/components/schemas/TaskStatus" }
+
+    CaseSummaryTask:
+      type: object
+      additionalProperties: false
+      required: [task_id, title, objective, area_text, due_at, status, safety_briefing]
+      properties:
+        task_id: { type: string, format: uuid }
+        title: { type: string }
+        objective: { type: string }
+        area_text: { type: string }
+        due_at: { type: string, format: date-time }
+        status: { $ref: "#/components/schemas/TaskStatus" }
+        safety_briefing: { type: string }
 
     CasePlace:
       type: object

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -705,6 +705,50 @@ pub struct CaseMapItem {
 }
 
 #[derive(Debug, Serialize)]
+pub struct CaseSummaryResponse {
+    pub case_id: String,
+    pub access_role: CaseRole,
+    pub generated_at: String,
+    pub source_scope: Vec<String>,
+    pub last_confirmed_information: Option<CaseSummaryClue>,
+    pub confirmed_clues: Vec<CaseSummaryClue>,
+    pub pending_verification: Vec<CaseSummaryClue>,
+    pub excluded_directions: Vec<CaseSummaryClue>,
+    pub current_focus: Vec<CaseSummaryFocus>,
+    pub task_status: Vec<CaseSummaryTask>,
+    pub safety_reminders: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct CaseSummaryClue {
+    pub clue_id: String,
+    pub content: String,
+    pub status: String,
+    pub occurred_at: Option<String>,
+    pub reported_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CaseSummaryFocus {
+    pub task_id: String,
+    pub title: String,
+    pub objective: String,
+    pub area_text: String,
+    pub status: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CaseSummaryTask {
+    pub task_id: String,
+    pub title: String,
+    pub objective: String,
+    pub area_text: String,
+    pub due_at: String,
+    pub status: String,
+    pub safety_briefing: String,
+}
+
+#[derive(Debug, Serialize)]
 pub struct TaskLocationReportReceipt {
     pub id: String,
     pub source: String,

--- a/src/api/routes/cases.rs
+++ b/src/api/routes/cases.rs
@@ -217,25 +217,8 @@ async fn get_map_view(
     case_id: web::Path<String>,
 ) -> Result<HttpResponse, ApiError> {
     let detail = case_service::get_case(&state.db, &auth, &case_id).await?;
-    let mut task_items = Vec::new();
-    let mut task_page = 1;
-    loop {
-        let tasks = crate::services::task_service::list_tasks(
-            &state.db,
-            &auth,
-            &case_id,
-            TaskListQuery {
-                page: Some(task_page),
-                page_size: Some(100),
-            },
-        )
-        .await?;
-        task_items.extend(tasks.items);
-        if u64::try_from(task_items.len()).map_err(|_| ApiError::Internal)? >= tasks.total {
-            break;
-        }
-        task_page = task_page.checked_add(1).ok_or(ApiError::Internal)?;
-    }
+    let task_items =
+        crate::services::task_service::list_all_visible_tasks(&state.db, &auth, &case_id).await?;
     let mut items = Vec::new();
     if detail.access_role != CaseRole::Volunteer
         && let Some(location_text) = detail.elder_profile.last_seen_location

--- a/src/api/routes/cases.rs
+++ b/src/api/routes/cases.rs
@@ -31,6 +31,7 @@ pub fn configure(config: &mut web::ServiceConfig) {
             .route("/{case_id}/tasks", web::get().to(list_tasks))
             .route("/{case_id}/tasks", web::post().to(create_task))
             .route("/{case_id}/map-view", web::get().to(get_map_view))
+            .route("/{case_id}/summary", web::get().to(get_case_summary))
             .route("/{case_id}/places", web::get().to(list_places))
             .route("/{case_id}/places", web::post().to(create_place))
             .route(
@@ -325,6 +326,16 @@ async fn get_map_view(
         }
     }));
     Ok(HttpResponse::Ok().json(CaseMapViewResponse { items }))
+}
+
+async fn get_case_summary(
+    state: web::Data<AppState>,
+    auth: AuthenticatedUser,
+    case_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    Ok(HttpResponse::Ok().json(
+        crate::services::case_summary_service::get_case_summary(&state.db, &auth, &case_id).await?,
+    ))
 }
 
 async fn update_case_status(

--- a/src/application/services/case_summary_service.rs
+++ b/src/application/services/case_summary_service.rs
@@ -5,7 +5,7 @@ use crate::{
     error::ApiError,
     models::{
         AuthenticatedUser, CaseSummaryClue, CaseSummaryFocus, CaseSummaryResponse, CaseSummaryTask,
-        ClueResponse, TaskListQuery, TaskResponse,
+        ClueResponse, TaskResponse,
     },
     roles::CaseRole,
     services::{case_service, task_service},
@@ -25,13 +25,19 @@ pub async fn get_case_summary(
     case_id: &str,
 ) -> Result<CaseSummaryResponse, ApiError> {
     let detail = case_service::get_case(db, auth, case_id).await?;
-    let task_status = list_visible_tasks(db, auth, case_id).await?;
-    let confirmed_clues = detail
+    let task_status = task_service::list_all_visible_tasks(db, auth, case_id).await?;
+    let mut confirmed_clues = detail
         .clues
         .iter()
         .filter(|clue| clue.status == "confirmed")
         .map(summary_clue)
         .collect::<Vec<_>>();
+    confirmed_clues.sort_by(|left, right| {
+        right
+            .reported_at
+            .cmp(&left.reported_at)
+            .then_with(|| right.clue_id.cmp(&left.clue_id))
+    });
     let last_confirmed_information = (detail.access_role != CaseRole::Volunteer)
         .then(|| confirmed_clues.first().cloned())
         .flatten();
@@ -88,32 +94,6 @@ pub async fn get_case_summary(
         task_status: task_status.into_iter().map(summary_task).collect(),
         safety_reminders: safety_reminders(detail.access_role),
     })
-}
-
-async fn list_visible_tasks(
-    db: &DatabaseConnection,
-    auth: &AuthenticatedUser,
-    case_id: &str,
-) -> Result<Vec<TaskResponse>, ApiError> {
-    let mut items = Vec::new();
-    let mut page = 1;
-    loop {
-        let response = task_service::list_tasks(
-            db,
-            auth,
-            case_id,
-            TaskListQuery {
-                page: Some(page),
-                page_size: Some(100),
-            },
-        )
-        .await?;
-        items.extend(response.items);
-        if u64::try_from(items.len()).map_err(|_| ApiError::Internal)? >= response.total {
-            return Ok(items);
-        }
-        page = page.checked_add(1).ok_or(ApiError::Internal)?;
-    }
 }
 
 fn summary_clue(clue: &ClueResponse) -> CaseSummaryClue {

--- a/src/application/services/case_summary_service.rs
+++ b/src/application/services/case_summary_service.rs
@@ -1,0 +1,182 @@
+use chrono::{SecondsFormat, Utc};
+use sea_orm::DatabaseConnection;
+
+use crate::{
+    error::ApiError,
+    models::{
+        AuthenticatedUser, CaseSummaryClue, CaseSummaryFocus, CaseSummaryResponse, CaseSummaryTask,
+        ClueResponse, TaskListQuery, TaskResponse,
+    },
+    roles::CaseRole,
+    services::{case_service, task_service},
+};
+
+const EXCLUDED_CLUE_STATUSES: &[&str] = &[
+    "rejected",
+    "expired",
+    "duplicate",
+    "conflicting",
+    "insufficient_information",
+];
+
+pub async fn get_case_summary(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    case_id: &str,
+) -> Result<CaseSummaryResponse, ApiError> {
+    let detail = case_service::get_case(db, auth, case_id).await?;
+    let task_status = list_visible_tasks(db, auth, case_id).await?;
+    let confirmed_clues = detail
+        .clues
+        .iter()
+        .filter(|clue| clue.status == "confirmed")
+        .map(summary_clue)
+        .collect::<Vec<_>>();
+    let last_confirmed_information = (detail.access_role != CaseRole::Volunteer)
+        .then(|| confirmed_clues.first().cloned())
+        .flatten();
+
+    let pending_verification = if detail.access_role == CaseRole::Volunteer {
+        Vec::new()
+    } else {
+        detail
+            .clues
+            .iter()
+            .filter(|clue| {
+                matches!(
+                    clue.status.as_str(),
+                    "pending_review" | "needs_verification"
+                )
+            })
+            .map(summary_clue)
+            .collect()
+    };
+    let excluded_directions = if detail.access_role == CaseRole::Commander {
+        detail
+            .clues
+            .iter()
+            .filter(|clue| EXCLUDED_CLUE_STATUSES.contains(&clue.status.as_str()))
+            .map(summary_clue)
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let current_focus = if detail.access_role == CaseRole::Commander {
+        task_status
+            .iter()
+            .filter(|task| !matches!(task.status.as_str(), "completed" | "cancelled"))
+            .map(summary_focus)
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    Ok(CaseSummaryResponse {
+        case_id: detail.id,
+        access_role: detail.access_role,
+        generated_at: Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
+        source_scope: source_scope(detail.access_role),
+        last_confirmed_information,
+        confirmed_clues: if detail.access_role == CaseRole::Volunteer {
+            Vec::new()
+        } else {
+            confirmed_clues
+        },
+        pending_verification,
+        excluded_directions,
+        current_focus,
+        task_status: task_status.into_iter().map(summary_task).collect(),
+        safety_reminders: safety_reminders(detail.access_role),
+    })
+}
+
+async fn list_visible_tasks(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    case_id: &str,
+) -> Result<Vec<TaskResponse>, ApiError> {
+    let mut items = Vec::new();
+    let mut page = 1;
+    loop {
+        let response = task_service::list_tasks(
+            db,
+            auth,
+            case_id,
+            TaskListQuery {
+                page: Some(page),
+                page_size: Some(100),
+            },
+        )
+        .await?;
+        items.extend(response.items);
+        if u64::try_from(items.len()).map_err(|_| ApiError::Internal)? >= response.total {
+            return Ok(items);
+        }
+        page = page.checked_add(1).ok_or(ApiError::Internal)?;
+    }
+}
+
+fn summary_clue(clue: &ClueResponse) -> CaseSummaryClue {
+    CaseSummaryClue {
+        clue_id: clue.id.clone(),
+        content: clue.content.clone(),
+        status: clue.status.clone(),
+        occurred_at: clue.occurred_at.clone(),
+        reported_at: clue.reported_at.clone(),
+    }
+}
+
+fn summary_focus(task: &TaskResponse) -> CaseSummaryFocus {
+    CaseSummaryFocus {
+        task_id: task.id.clone(),
+        title: task.title.clone(),
+        objective: task.objective.clone(),
+        area_text: task.area_text.clone(),
+        status: task.status.clone(),
+    }
+}
+
+fn summary_task(task: TaskResponse) -> CaseSummaryTask {
+    CaseSummaryTask {
+        task_id: task.id,
+        title: task.title,
+        objective: task.objective,
+        area_text: task.area_text,
+        due_at: task.due_at,
+        status: task.status,
+        safety_briefing: task.safety_briefing,
+    }
+}
+
+fn source_scope(role: CaseRole) -> Vec<String> {
+    match role {
+        CaseRole::Commander => vec![
+            "confirmed_clues".to_owned(),
+            "unverified_clues".to_owned(),
+            "excluded_clues".to_owned(),
+            "all_case_tasks".to_owned(),
+        ],
+        CaseRole::Family => vec![
+            "confirmed_clues".to_owned(),
+            "own_unverified_clues".to_owned(),
+        ],
+        CaseRole::Volunteer => vec!["own_assigned_tasks".to_owned()],
+    }
+}
+
+fn safety_reminders(role: CaseRole) -> Vec<String> {
+    match role {
+        CaseRole::Commander => vec![
+            "Only human-reviewed clues marked confirmed are confirmed facts.".to_owned(),
+            "Keep task assignments and search directions within authorized case roles.".to_owned(),
+        ],
+        CaseRole::Family => vec![
+            "Only human-reviewed clues marked confirmed are confirmed facts.".to_owned(),
+            "Do not share sensitive case information publicly.".to_owned(),
+        ],
+        CaseRole::Volunteer => vec![
+            "Follow the safety briefing for each assigned task.".to_owned(),
+            "Stop work and notify the commander if conditions become unsafe.".to_owned(),
+        ],
+    }
+}

--- a/src/application/services/mod.rs
+++ b/src/application/services/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth_service;
 pub mod case_resource_service;
 pub mod case_service;
+pub mod case_summary_service;
 pub mod intake_session_service;
 pub mod task_service;

--- a/src/application/services/task_service.rs
+++ b/src/application/services/task_service.rs
@@ -241,6 +241,32 @@ pub async fn list_tasks(
     })
 }
 
+pub async fn list_all_visible_tasks(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    case_id: &str,
+) -> Result<Vec<TaskResponse>, ApiError> {
+    let mut items = Vec::new();
+    let mut page = 1;
+    loop {
+        let response = list_tasks(
+            db,
+            auth,
+            case_id,
+            TaskListQuery {
+                page: Some(page),
+                page_size: Some(MAX_TASK_PAGE_SIZE),
+            },
+        )
+        .await?;
+        items.extend(response.items);
+        if u64::try_from(items.len()).map_err(|_| ApiError::Internal)? >= response.total {
+            return Ok(items);
+        }
+        page = page.checked_add(1).ok_or(ApiError::Internal)?;
+    }
+}
+
 pub async fn list_my_tasks(
     db: &DatabaseConnection,
     auth: &AuthenticatedUser,

--- a/src/application/services/task_service.rs
+++ b/src/application/services/task_service.rs
@@ -188,49 +188,13 @@ pub async fn list_tasks(
     query: TaskListQuery,
 ) -> Result<TaskListResponse, ApiError> {
     let query = ValidatedTaskListQuery::try_from(query)?;
-    let case_role = require_case_role(
-        db,
-        &auth.id,
-        case_id,
-        &[CaseRole::Family, CaseRole::Commander, CaseRole::Volunteer],
-    )
-    .await?;
-    if case_role == CaseRole::Family {
-        return Ok(TaskListResponse {
-            items: Vec::new(),
-            page: query.page,
-            page_size: query.page_size,
-            total: 0,
-        });
-    }
-
-    let task_models = tasks::Entity::find()
-        .filter(tasks::Column::CaseId.eq(case_id))
-        .order_by_asc(tasks::Column::DueAt)
-        .order_by_asc(tasks::Column::Id)
-        .all(db)
-        .await?;
-    let assignments =
-        assignments_for_tasks(db, task_models.iter().map(|task| task.id.clone())).await?;
-    let visible_tasks = task_models
-        .into_iter()
-        .filter(|task| {
-            case_role == CaseRole::Commander
-                || assignments
-                    .get(&task.id)
-                    .is_some_and(|assignment| assignment.volunteer_user_id == auth.id)
-        })
-        .collect::<Vec<_>>();
+    let visible_tasks = load_visible_tasks(db, auth, case_id).await?;
     let total = u64::try_from(visible_tasks.len()).map_err(|_| ApiError::Internal)?;
     let start = query.offset()?;
     let items = visible_tasks
         .into_iter()
         .skip(start)
         .take(query.page_size_usize())
-        .map(|task| {
-            let assignment = assignments.get(&task.id).cloned();
-            TaskResponse::new(task, assignment, case_role == CaseRole::Commander)
-        })
         .collect();
 
     Ok(TaskListResponse {
@@ -241,30 +205,51 @@ pub async fn list_tasks(
     })
 }
 
+async fn load_visible_tasks(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    case_id: &str,
+) -> Result<Vec<TaskResponse>, ApiError> {
+    let case_role = require_case_role(
+        db,
+        &auth.id,
+        case_id,
+        &[CaseRole::Family, CaseRole::Commander, CaseRole::Volunteer],
+    )
+    .await?;
+    if case_role == CaseRole::Family {
+        return Ok(Vec::new());
+    }
+
+    let task_models = tasks::Entity::find()
+        .filter(tasks::Column::CaseId.eq(case_id))
+        .order_by_asc(tasks::Column::DueAt)
+        .order_by_asc(tasks::Column::Id)
+        .all(db)
+        .await?;
+    let assignments =
+        assignments_for_tasks(db, task_models.iter().map(|task| task.id.clone())).await?;
+    Ok(task_models
+        .into_iter()
+        .filter(|task| {
+            case_role == CaseRole::Commander
+                || assignments
+                    .get(&task.id)
+                    .is_some_and(|assignment| assignment.volunteer_user_id == auth.id)
+        })
+        .map(|task| {
+            let assignment = assignments.get(&task.id).cloned();
+            TaskResponse::new(task, assignment, case_role == CaseRole::Commander)
+        })
+        .collect())
+}
+
 pub async fn list_all_visible_tasks(
     db: &DatabaseConnection,
     auth: &AuthenticatedUser,
     case_id: &str,
 ) -> Result<Vec<TaskResponse>, ApiError> {
-    let mut items = Vec::new();
-    let mut page = 1;
-    loop {
-        let response = list_tasks(
-            db,
-            auth,
-            case_id,
-            TaskListQuery {
-                page: Some(page),
-                page_size: Some(MAX_TASK_PAGE_SIZE),
-            },
-        )
-        .await?;
-        items.extend(response.items);
-        if u64::try_from(items.len()).map_err(|_| ApiError::Internal)? >= response.total {
-            return Ok(items);
-        }
-        page = page.checked_add(1).ok_or(ApiError::Internal)?;
-    }
+    load_visible_tasks(db, auth, case_id).await
 }
 
 pub async fn list_my_tasks(

--- a/tests/api/case_summary_get.rs
+++ b/tests/api/case_summary_get.rs
@@ -1,0 +1,185 @@
+use actix_web::{
+    http::{StatusCode, header},
+    test,
+};
+use serde_json::{Value, json};
+
+use crate::support::{COMMANDER, FAMILY, LEARNER, TestContext, VOLUNTEER, assert_error};
+
+#[actix_web::test]
+async fn get_case_summary_classifies_review_states_and_crops_each_role() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    context
+        .add_member(&case_id, COMMANDER, VOLUNTEER, "volunteer")
+        .await;
+    let app = crate::init_api_app!(&context);
+    let commander_token = context.token(COMMANDER).await;
+    let volunteer = context.authenticated(VOLUNTEER).await;
+
+    let confirmed_id = context.create_clue(&case_id, FAMILY).await;
+    let own_pending_id = context.create_clue(&case_id, FAMILY).await;
+    let internal_pending_id = context.create_clue(&case_id, COMMANDER).await;
+    let excluded_id = context.create_clue(&case_id, COMMANDER).await;
+    for (clue_id, status, reason) in [
+        (&confirmed_id, "confirmed", "fictional source verified"),
+        (&excluded_id, "rejected", "fictional report disproven"),
+    ] {
+        let response = test::call_service(
+            &app,
+            test::TestRequest::patch()
+                .uri(&format!("/api/clues/{clue_id}/review"))
+                .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+                .set_json(json!({ "status": status, "reason": reason }))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    let task_response = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/tasks"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(json!({
+                "source_clue_id": confirmed_id,
+                "volunteer_user_id": volunteer.id,
+                "title": "Verify fictional north gate",
+                "objective": "Check the fictional reported route and submit observations.",
+                "area_text": "Fictional north gate",
+                "latitude": 31.8206,
+                "longitude": 117.2272,
+                "due_at": "2099-07-27T12:00:00Z",
+                "background": "Commander-only fictional direction.",
+                "risk_level": "medium",
+                "risk_notes": "Stay in public areas.",
+                "safety_briefing": "Keep contact with the commander.",
+                "expected_feedback": "Submit a factual text report."
+            }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(task_response.status(), StatusCode::CREATED);
+
+    let request_for = |token: String| {
+        test::TestRequest::get()
+            .uri(&format!("/api/cases/{case_id}/summary"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .to_request()
+    };
+
+    let commander: Value = test::read_body_json(
+        test::call_service(&app, request_for(context.token(COMMANDER).await)).await,
+    )
+    .await;
+    assert_eq!(commander["access_role"], "commander");
+    assert!(commander["generated_at"].as_str().is_some());
+    assert_eq!(
+        commander["last_confirmed_information"]["status"],
+        "confirmed"
+    );
+    assert_eq!(
+        commander["confirmed_clues"].as_array().map(Vec::len),
+        Some(1)
+    );
+    assert_eq!(
+        commander["pending_verification"].as_array().map(Vec::len),
+        Some(2)
+    );
+    assert!(
+        commander["pending_verification"]
+            .as_array()
+            .expect("pending items")
+            .iter()
+            .all(|item| item["status"] != "confirmed")
+    );
+    assert_eq!(commander["excluded_directions"][0]["clue_id"], excluded_id);
+    assert_eq!(commander["current_focus"].as_array().map(Vec::len), Some(1));
+    assert_eq!(commander["task_status"].as_array().map(Vec::len), Some(1));
+    assert!(
+        commander["source_scope"]
+            .as_array()
+            .expect("source scope")
+            .iter()
+            .any(|scope| scope == "all_case_tasks")
+    );
+
+    let family: Value = test::read_body_json(
+        test::call_service(&app, request_for(context.token(FAMILY).await)).await,
+    )
+    .await;
+    assert_eq!(family["access_role"], "family");
+    assert_eq!(family["confirmed_clues"].as_array().map(Vec::len), Some(1));
+    assert_eq!(family["pending_verification"][0]["clue_id"], own_pending_id);
+    assert_ne!(
+        family["pending_verification"][0]["clue_id"],
+        internal_pending_id
+    );
+    assert_eq!(family["excluded_directions"], json!([]));
+    assert_eq!(family["current_focus"], json!([]));
+    assert_eq!(family["task_status"], json!([]));
+
+    let volunteer: Value = test::read_body_json(
+        test::call_service(&app, request_for(context.token(VOLUNTEER).await)).await,
+    )
+    .await;
+    assert_eq!(volunteer["access_role"], "volunteer");
+    assert!(volunteer["last_confirmed_information"].is_null());
+    assert_eq!(volunteer["confirmed_clues"], json!([]));
+    assert_eq!(volunteer["pending_verification"], json!([]));
+    assert_eq!(volunteer["excluded_directions"], json!([]));
+    assert_eq!(volunteer["current_focus"], json!([]));
+    assert_eq!(volunteer["task_status"].as_array().map(Vec::len), Some(1));
+    assert!(volunteer["task_status"][0].get("background").is_none());
+    assert!(
+        volunteer["source_scope"]
+            .as_array()
+            .expect("source scope")
+            .iter()
+            .all(|scope| scope == "own_assigned_tasks")
+    );
+
+    let hidden = test::call_service(&app, request_for(context.token(LEARNER).await)).await;
+    assert_error(hidden, StatusCode::NOT_FOUND, "not_found").await;
+}
+
+#[actix_web::test]
+async fn get_case_summary_returns_empty_deterministic_sections_without_ai() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    let app = crate::init_api_app!(&context);
+    let response = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/cases/{case_id}/summary"))
+            .insert_header((
+                header::AUTHORIZATION,
+                format!("Bearer {}", context.token(FAMILY).await),
+            ))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = test::read_body_json(response).await;
+    assert!(body["generated_at"].as_str().is_some());
+    for section in [
+        "confirmed_clues",
+        "pending_verification",
+        "excluded_directions",
+        "current_focus",
+        "task_status",
+    ] {
+        assert_eq!(body[section], json!([]));
+    }
+    assert!(body["last_confirmed_information"].is_null());
+    assert!(
+        !body["safety_reminders"]
+            .as_array()
+            .expect("reminders")
+            .is_empty()
+    );
+}

--- a/tests/api/case_summary_get.rs
+++ b/tests/api/case_summary_get.rs
@@ -2,6 +2,8 @@ use actix_web::{
     http::{StatusCode, header},
     test,
 };
+use angui::entities::clues;
+use sea_orm::{ActiveModelTrait, EntityTrait, IntoActiveModel, Set};
 use serde_json::{Value, json};
 
 use crate::support::{COMMANDER, FAMILY, LEARNER, TestContext, VOLUNTEER, assert_error};
@@ -21,11 +23,19 @@ async fn get_case_summary_classifies_review_states_and_crops_each_role() {
     let volunteer = context.authenticated(VOLUNTEER).await;
 
     let confirmed_id = context.create_clue(&case_id, FAMILY).await;
+    let latest_confirmed_id = context.create_clue(&case_id, FAMILY).await;
     let own_pending_id = context.create_clue(&case_id, FAMILY).await;
     let internal_pending_id = context.create_clue(&case_id, COMMANDER).await;
     let excluded_id = context.create_clue(&case_id, COMMANDER).await;
+    set_reported_at(&context, &confirmed_id, "2026-07-13T09:10:00Z").await;
+    set_reported_at(&context, &latest_confirmed_id, "2026-07-13T09:20:00Z").await;
     for (clue_id, status, reason) in [
         (&confirmed_id, "confirmed", "fictional source verified"),
+        (
+            &latest_confirmed_id,
+            "confirmed",
+            "fictional later source verified",
+        ),
         (&excluded_id, "rejected", "fictional report disproven"),
     ] {
         let response = test::call_service(
@@ -46,7 +56,7 @@ async fn get_case_summary_classifies_review_states_and_crops_each_role() {
             .uri(&format!("/api/cases/{case_id}/tasks"))
             .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
             .set_json(json!({
-                "source_clue_id": confirmed_id,
+                "source_clue_id": latest_confirmed_id,
                 "volunteer_user_id": volunteer.id,
                 "title": "Verify fictional north gate",
                 "objective": "Check the fictional reported route and submit observations.",
@@ -83,8 +93,12 @@ async fn get_case_summary_classifies_review_states_and_crops_each_role() {
         "confirmed"
     );
     assert_eq!(
+        commander["last_confirmed_information"]["clue_id"],
+        latest_confirmed_id
+    );
+    assert_eq!(
         commander["confirmed_clues"].as_array().map(Vec::len),
-        Some(1)
+        Some(2)
     );
     assert_eq!(
         commander["pending_verification"].as_array().map(Vec::len),
@@ -113,7 +127,11 @@ async fn get_case_summary_classifies_review_states_and_crops_each_role() {
     )
     .await;
     assert_eq!(family["access_role"], "family");
-    assert_eq!(family["confirmed_clues"].as_array().map(Vec::len), Some(1));
+    assert_eq!(family["confirmed_clues"].as_array().map(Vec::len), Some(2));
+    assert_eq!(
+        family["last_confirmed_information"]["clue_id"],
+        latest_confirmed_id
+    );
     assert_eq!(family["pending_verification"][0]["clue_id"], own_pending_id);
     assert_ne!(
         family["pending_verification"][0]["clue_id"],
@@ -145,6 +163,20 @@ async fn get_case_summary_classifies_review_states_and_crops_each_role() {
 
     let hidden = test::call_service(&app, request_for(context.token(LEARNER).await)).await;
     assert_error(hidden, StatusCode::NOT_FOUND, "not_found").await;
+}
+
+async fn set_reported_at(context: &TestContext, clue_id: &str, reported_at: &str) {
+    let clue = clues::Entity::find_by_id(clue_id)
+        .one(&context.database)
+        .await
+        .expect("fixture clue should load")
+        .expect("fixture clue should exist");
+    let mut active = clue.into_active_model();
+    active.reported_at = Set(reported_at.to_owned());
+    active
+        .update(&context.database)
+        .await
+        .expect("fixture clue update");
 }
 
 #[actix_web::test]

--- a/tests/api/mod.rs
+++ b/tests/api/mod.rs
@@ -10,6 +10,7 @@ mod case_map_view_get;
 mod case_members_post;
 mod case_resources_post;
 mod case_status_patch;
+mod case_summary_get;
 mod cases_create_post;
 mod cases_list_get;
 mod clue_review_patch;

--- a/tests/api/openapi_intake_contract.rs
+++ b/tests/api/openapi_intake_contract.rs
@@ -195,3 +195,41 @@ fn case_places_openapi_contract_covers_role_filtered_reads() {
         );
     }
 }
+
+#[test]
+fn case_summary_openapi_contract_covers_role_filtered_deterministic_output() {
+    let (_, operation) = OPENAPI
+        .split_once("  /api/cases/{case_id}/summary:\n")
+        .expect("OpenAPI case summary path must exist");
+    let get_operation = operation
+        .split_once("    get:\n")
+        .and_then(|(_, get)| {
+            get.split_once("\n  /api/cases/{case_id}/places:")
+                .map(|(get, _)| get)
+        })
+        .expect("OpenAPI case summary path must declare GET");
+    for expected in [
+        "operationId: getCaseSummary",
+        "x-case-roles: [family, commander, volunteer]",
+        "#/components/schemas/CaseSummary",
+        "\"404\": { $ref: \"#/components/responses/NotFound\" }",
+    ] {
+        assert!(
+            get_operation.contains(expected),
+            "OpenAPI case summary operation must declare {expected:?}"
+        );
+    }
+    assert_schema_contains(
+        "CaseSummary",
+        &[
+            "generated_at:",
+            "source_scope:",
+            "last_confirmed_information:",
+            "pending_verification:",
+            "excluded_directions:",
+            "current_focus:",
+            "task_status:",
+            "safety_reminders:",
+        ],
+    );
+}


### PR DESCRIPTION
- Add GET /api/cases/{case_id}/summary endpoint
- Classify confirmed, pending, and excluded clues by review status
- Restrict summary data, tasks, and focus areas by case role
- Include generation time, source scope, and safety reminders
- Add summary response models and service module
- Document endpoint and schemas in API and OpenAPI specs
- Add API and OpenAPI contract coverage for role-filtered summaries

close #30 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“案件确定性摘要”接口（GET `/api/cases/{case_id}/summary`），按访问角色返回：已确认线索、待核实事项、排除方向、当前关注与任务状态、安全提醒及生成时间。
  * 摘要以确定性规则生成，并提供数据来源范围，用于界定可见信息范围。
* **文档**
  * 更新接口文档与 OpenAPI：新增接口与 `CaseSummary` 相关字段/结构说明。
* **测试**
  * 新增多角色集成测试及接口契约校验，覆盖默认与缺失内容场景。
* **改进**
  * 地图视图的任务汇总获取逻辑优化，提升一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->