### PR TITLE
feat(tasks): add authorized safety and navigation guidance

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -205,6 +205,10 @@ Example:
 
 `GET /api/cases/{case_id}/summary` 提供不依赖外部 AI 的确定性案件摘要。响应的 `generated_at` 和 `source_scope` 说明生成时间与当前角色可用的数据范围。只有人工审核为 `confirmed` 的线索才会进入 `last_confirmed_information` 与 `confirmed_clues`；`pending_review` 和 `needs_verification` 始终保留在 `pending_verification`，不会被表述为确认事实。指挥可见待核实事项、已排除方向、未完成任务形成的当前重点和全部任务状态；家属不接收任务或内部搜索方向；志愿者只接收本人任务的执行与安全信息。
 
+`POST /api/tasks/{task_id}/feedback` 仅允许该任务受领志愿者在任务和案件均为 `active` 时提交。服务端将反馈与可选的本人上传附件写成关联任务的 `pending_review` 线索，并写入审计；反馈不会确认线索、改变案件事实或推进任务状态。
+
+`GET /api/tasks/{task_id}/safety-briefing` 和 `GET /api/tasks/{task_id}/navigation` 仅允许该任务受领志愿者与案件指挥访问。安全提示是规则化的辅助信息，不是现场强制指令；即使实时天气等外部条件不可用，也会返回人工规则和紧急停止提示。导航接口只返回已授权任务区域的文字路线摘要；现有任务坐标没有坐标系声明时，服务端不会生成可能偏移的第三方导航链接。家属、其他志愿者和非成员不会获取这些内容。
+
 ## 公开进展、草稿与周边资源
 
 `GET /api/cases/{case_id}/public-progress` 仅对该案件的 `family` 成员开放。它仅返回已人工审核为 `confirmed` 的进展类别、请求者本人仍待补充/核实的项目类别、以及安全和联系提醒；它绝不返回任何原始线索正文、未核实的他人线索、内部搜索方向、任务与分配、志愿者位置、病史全文或成员详情。每项仅包含服务端生成的公开类别、审核状态和更新时间，客户端不得把其他案件详情替代为“公开进展”。

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1459,7 +1459,7 @@ components:
 
     TaskStatusTransitionTarget:
       type: string
-      description: `pending_claim` and `assigned` are stored task states, not valid PATCH targets.
+      description: "`pending_claim` and `assigned` are stored task states, not valid PATCH targets."
       enum: [accepted, active, blocked, completed, cancelled]
 
     TaskRiskLevel:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -779,6 +779,60 @@ paths:
         "409": { $ref: "#/components/responses/Conflict" }
         "500": { $ref: "#/components/responses/InternalError" }
 
+  /api/tasks/{task_id}/safety-briefing:
+    parameters:
+      - $ref: "#/components/parameters/TaskId"
+    get:
+      tags: [Tasks]
+      operationId: getTaskSafetyBriefing
+      summary: Get rule-based task safety guidance
+      description: |
+        Only the assigned volunteer and case commander may read this guidance. It is a
+        rule-based aid, not a mandatory field command. Weather and live road conditions are
+        not asserted as current facts; the response always includes manual safety rules and an
+        emergency-stop message when external conditions are unavailable.
+      security:
+        - bearerAuth: []
+      x-account-types: [member]
+      x-case-roles: [commander, volunteer]
+      x-data-classification: case-restricted
+      responses:
+        "200":
+          description: Authorized task safety guidance
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/TaskSafetyBriefing" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
+  /api/tasks/{task_id}/navigation:
+    parameters:
+      - $ref: "#/components/parameters/TaskId"
+    get:
+      tags: [Tasks]
+      operationId: getTaskNavigation
+      summary: Get an authorized task route summary
+      description: |
+        Only the assigned volunteer and case commander may read the route summary. The server
+        never forwards tokens or unrelated case data to third-party navigation providers. Until
+        task coordinates include an explicit coordinate-system contract, this endpoint returns a
+        text fallback instead of a potentially offset external navigation URL.
+      security:
+        - bearerAuth: []
+      x-account-types: [member]
+      x-case-roles: [commander, volunteer]
+      x-data-classification: sensitive
+      responses:
+        "200":
+          description: Authorized task route summary or a text fallback
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/TaskNavigation" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
   /api/cases/{case_id}/map-view:
     parameters:
       - $ref: "#/components/parameters/CaseId"
@@ -2246,6 +2300,42 @@ components:
         clue_id: { type: string, format: uuid }
         status: { type: string, const: pending_review }
         submitted_at: { type: string, format: date-time }
+
+    TaskSafetyBriefing:
+      type: object
+      additionalProperties: false
+      required: [task_id, risk_level, notices, emergency_stop_message, source, degradation_status, updated_at]
+      properties:
+        task_id: { type: string, format: uuid }
+        risk_level: { $ref: "#/components/schemas/TaskRiskLevel" }
+        notices:
+          type: array
+          minItems: 1
+          items: { type: string }
+        emergency_stop_message: { type: string }
+        source: { type: string, const: rule_based }
+        degradation_status:
+          type: string
+          const: rule_based_fallback
+          description: Real-time external weather and road data are not asserted as current facts.
+        updated_at: { type: string, format: date-time }
+
+    TaskNavigation:
+      type: object
+      additionalProperties: false
+      required: [task_id, area_text, navigation_url, route_summary, source, degradation_status, fallback_message, updated_at]
+      properties:
+        task_id: { type: string, format: uuid }
+        area_text: { type: string }
+        navigation_url:
+          type: [string, "null"]
+          format: uri
+          description: Null until task coordinates carry an explicit coordinate-system contract.
+        route_summary: { type: string }
+        source: { type: string, const: task_area_text }
+        degradation_status: { type: string, const: text_fallback }
+        fallback_message: { type: [string, "null"] }
+        updated_at: { type: string, format: date-time }
 
     Task:
       type: object

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -862,6 +862,29 @@ pub struct TaskFeedbackReceipt {
 }
 
 #[derive(Debug, Serialize)]
+pub struct TaskSafetyBriefingResponse {
+    pub task_id: String,
+    pub risk_level: String,
+    pub notices: Vec<String>,
+    pub emergency_stop_message: String,
+    pub source: String,
+    pub degradation_status: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TaskNavigationResponse {
+    pub task_id: String,
+    pub area_text: String,
+    pub navigation_url: Option<String>,
+    pub route_summary: String,
+    pub source: String,
+    pub degradation_status: String,
+    pub fallback_message: Option<String>,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Serialize)]
 pub struct CasePlaceResponse {
     pub id: String,
     pub case_id: String,

--- a/src/api/routes/tasks.rs
+++ b/src/api/routes/tasks.rs
@@ -19,6 +19,11 @@ pub fn configure(config: &mut web::ServiceConfig) {
                 web::post().to(submit_location_report),
             )
             .route("/{task_id}/feedback", web::post().to(submit_task_feedback))
+            .route(
+                "/{task_id}/safety-briefing",
+                web::get().to(get_safety_briefing),
+            )
+            .route("/{task_id}/navigation", web::get().to(get_navigation))
             .route("/{task_id}/status", web::patch().to(update_task_status)),
     );
 }
@@ -63,4 +68,22 @@ async fn submit_task_feedback(
         task_service::submit_task_feedback(&state.db, &auth, &task_id, request.into_inner())
             .await?;
     Ok(HttpResponse::Created().json(receipt))
+}
+
+async fn get_safety_briefing(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    task_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    Ok(HttpResponse::Ok()
+        .json(task_service::get_task_safety_briefing(&state.db, &auth, &task_id).await?))
+}
+
+async fn get_navigation(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    task_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    Ok(HttpResponse::Ok()
+        .json(task_service::get_task_navigation(&state.db, &auth, &task_id).await?))
 }

--- a/src/application/services/task_service.rs
+++ b/src/application/services/task_service.rs
@@ -20,7 +20,8 @@ use crate::{
     models::{
         AuthenticatedUser, CreateTaskRequest, SubmitTaskFeedbackRequest,
         SubmitTaskLocationReportRequest, TaskFeedbackReceipt, TaskListQuery, TaskListResponse,
-        TaskLocationReportReceipt, TaskResponse, UpdateTaskStatusRequest,
+        TaskLocationReportReceipt, TaskNavigationResponse, TaskResponse,
+        TaskSafetyBriefingResponse, UpdateTaskStatusRequest,
     },
     roles::{CaseRole, GlobalCapability},
     services::case_service::{require_case_role, write_audit},
@@ -302,6 +303,95 @@ pub async fn list_my_tasks(
             TaskResponse::new(task, assignment, false)
         })
         .collect())
+}
+
+pub async fn get_task_safety_briefing(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    task_id: &str,
+) -> Result<TaskSafetyBriefingResponse, ApiError> {
+    let task = load_task_for_assignee_or_commander(db, auth, task_id).await?;
+    let mut notices = vec![task.safety_briefing.clone(), task.risk_notes.clone()];
+    notices.push(format!("区域提示：{}", task.area_text));
+    notices.push("夜间、恶劣天气或能见度不足时不要单独行动；情况不明时先联系指挥。".to_owned());
+    notices.push(match task.risk_level.as_str() {
+        "critical" | "high" => {
+            "高风险任务不得擅自进入受限区域、跨越危险地带或改变任务目标。".to_owned()
+        }
+        "medium" => "执行中保持联络，遇到阻碍先暂停并报告。".to_owned(),
+        _ => "保持任务边界，任何异常情况先暂停并报告。".to_owned(),
+    });
+    notices.push("当前为规则化安全提示；出发前请自行核实当地天气、道路与现场条件。".to_owned());
+
+    Ok(TaskSafetyBriefingResponse {
+        task_id: task.id,
+        risk_level: task.risk_level,
+        notices,
+        emergency_stop_message:
+            "立即停止行动并前往安全、公开地点；通过既有人工联系方式向指挥报告。".to_owned(),
+        source: "rule_based".to_owned(),
+        degradation_status: "rule_based_fallback".to_owned(),
+        updated_at: task.updated_at,
+    })
+}
+
+pub async fn get_task_navigation(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    task_id: &str,
+) -> Result<TaskNavigationResponse, ApiError> {
+    let task = load_task_for_assignee_or_commander(db, auth, task_id).await?;
+    let coordinate_note = if task.latitude.is_some() && task.longitude.is_some() {
+        "任务点坐标仅在受限任务卡内可见；因当前任务坐标未声明坐标系，服务不会生成可能偏移的第三方导航链接。"
+    } else {
+        "该任务未配置坐标，请依据文字区域说明并与指挥确认集合点或路线。"
+    };
+
+    Ok(TaskNavigationResponse {
+        task_id: task.id,
+        area_text: task.area_text.clone(),
+        navigation_url: None,
+        route_summary: format!(
+            "前往任务区域：{}。{} 执行前阅读任务安全提示，导航不可用时继续使用文字任务卡并联系指挥。",
+            task.area_text, coordinate_note
+        ),
+        source: "task_area_text".to_owned(),
+        degradation_status: "text_fallback".to_owned(),
+        fallback_message: Some(
+            "自动导航当前不可用；请使用任务区域文字说明并联系指挥确认路线。".to_owned(),
+        ),
+        updated_at: task.updated_at,
+    })
+}
+
+async fn load_task_for_assignee_or_commander(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    task_id: &str,
+) -> Result<tasks::Model, ApiError> {
+    let task = tasks::Entity::find_by_id(task_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| ApiError::NotFound("task was not found".to_owned()))?;
+    let role = require_case_role(
+        db,
+        &auth.id,
+        &task.case_id,
+        &[CaseRole::Family, CaseRole::Commander, CaseRole::Volunteer],
+    )
+    .await?;
+    if role == CaseRole::Commander {
+        return Ok(task);
+    }
+    let is_assignee = role == CaseRole::Volunteer
+        && task_assignments::Entity::find_by_id(task_id)
+            .one(db)
+            .await?
+            .is_some_and(|assignment| assignment.volunteer_user_id == auth.id);
+    if !is_assignee {
+        return Err(ApiError::NotFound("task was not found".to_owned()));
+    }
+    Ok(task)
 }
 
 pub async fn update_task_status(

--- a/tests/api/openapi_intake_contract.rs
+++ b/tests/api/openapi_intake_contract.rs
@@ -346,3 +346,39 @@ fn operation_blocks_stop_before_later_paths_and_top_level_sections() {
     assert!(final_operation.contains("finalOperation"));
     assert!(!final_operation.contains("FinalSchema"));
 }
+
+#[test]
+fn task_safety_and_navigation_openapi_contract_preserves_authorized_fallbacks() {
+    for (path, operation_id, schema_name) in [
+        (
+            "/api/tasks/{task_id}/safety-briefing:\n",
+            "operationId: getTaskSafetyBriefing",
+            "#/components/schemas/TaskSafetyBriefing",
+        ),
+        (
+            "/api/tasks/{task_id}/navigation:\n",
+            "operationId: getTaskNavigation",
+            "#/components/schemas/TaskNavigation",
+        ),
+    ] {
+        let operation = operation(path);
+        for expected in [
+            operation_id,
+            "x-case-roles: [commander, volunteer]",
+            schema_name,
+        ] {
+            assert!(
+                operation.contains(expected),
+                "OpenAPI task operation {path} must declare {expected:?}"
+            );
+        }
+    }
+    assert_schema_contains(
+        "TaskSafetyBriefing",
+        &["rule_based_fallback", "emergency_stop_message:"],
+    );
+    assert_schema_contains(
+        "TaskNavigation",
+        &["text_fallback", "navigation_url:", "fallback_message:"],
+    );
+}

--- a/tests/api/tasks_api.rs
+++ b/tests/api/tasks_api.rs
@@ -866,6 +866,128 @@ async fn task_feedback_is_an_assignee_only_pending_review_clue_without_task_side
     assert_error(closed_case_feedback, StatusCode::CONFLICT, "conflict").await;
 }
 
+#[actix_web::test]
+async fn task_safety_and_navigation_are_limited_to_the_assignee_and_commander() {
+    let context = TestContext::new().await;
+    let app = crate::init_api_app!(&context);
+    let case_id = context.create_case().await;
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    context
+        .add_member(&case_id, COMMANDER, VOLUNTEER, "volunteer")
+        .await;
+    let commander_token = context.token(COMMANDER).await;
+    let volunteer_token = context.token(VOLUNTEER).await;
+    let family_token = context.token(FAMILY).await;
+    let admin_token = context.token(ADMIN).await;
+    let volunteer = context.authenticated(VOLUNTEER).await;
+    let second_volunteer_token = add_second_case_volunteer(&context, &case_id).await;
+    let source_clue_id = confirmed_clue!(&context, &app, &case_id, &commander_token);
+    let task_id = create_task!(
+        &app,
+        &case_id,
+        &commander_token,
+        &source_clue_id,
+        &volunteer.id
+    );
+
+    for token in [&commander_token, &volunteer_token] {
+        let safety = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/api/tasks/{task_id}/safety-briefing"))
+                .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(safety.status(), StatusCode::OK);
+        let safety: Value = test::read_body_json(safety).await;
+        assert_eq!(safety["task_id"], task_id);
+        assert_eq!(safety["risk_level"], "medium");
+        assert_eq!(safety["source"], "rule_based");
+        assert_eq!(safety["degradation_status"], "rule_based_fallback");
+        assert!(safety["emergency_stop_message"].as_str().is_some());
+        assert!(
+            safety["notices"]
+                .as_array()
+                .is_some_and(|notices| !notices.is_empty())
+        );
+
+        let navigation = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&format!("/api/tasks/{task_id}/navigation"))
+                .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(navigation.status(), StatusCode::OK);
+        let navigation: Value = test::read_body_json(navigation).await;
+        assert_eq!(navigation["task_id"], task_id);
+        assert_eq!(navigation["source"], "task_area_text");
+        assert_eq!(navigation["degradation_status"], "text_fallback");
+        assert!(navigation["navigation_url"].is_null());
+        assert!(
+            navigation["route_summary"]
+                .as_str()
+                .is_some_and(|summary| summary.contains("North gate to market"))
+        );
+    }
+
+    for token in [&family_token, &second_volunteer_token, &admin_token] {
+        for endpoint in ["safety-briefing", "navigation"] {
+            assert_error(
+                test::call_service(
+                    &app,
+                    test::TestRequest::get()
+                        .uri(&format!("/api/tasks/{task_id}/{endpoint}"))
+                        .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+                        .to_request(),
+                )
+                .await,
+                StatusCode::NOT_FOUND,
+                "not_found",
+            )
+            .await;
+        }
+    }
+
+    let mut no_coordinate_payload = task_json(&source_clue_id, &volunteer.id);
+    no_coordinate_payload["latitude"] = Value::Null;
+    no_coordinate_payload["longitude"] = Value::Null;
+    let no_coordinate_task = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/tasks"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(no_coordinate_payload)
+            .to_request(),
+    )
+    .await;
+    assert_eq!(no_coordinate_task.status(), StatusCode::CREATED);
+    let no_coordinate_task: Value = test::read_body_json(no_coordinate_task).await;
+    let no_coordinate_task_id = no_coordinate_task["id"]
+        .as_str()
+        .expect("task id should be returned");
+    let navigation = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/tasks/{no_coordinate_task_id}/navigation"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {volunteer_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(navigation.status(), StatusCode::OK);
+    let navigation: Value = test::read_body_json(navigation).await;
+    assert!(navigation["navigation_url"].is_null());
+    assert!(
+        navigation["route_summary"]
+            .as_str()
+            .is_some_and(|summary| summary.contains("未配置坐标"))
+    );
+}
+
 fn task_json(source_clue_id: &str, volunteer_user_id: &str) -> Value {
     json!({
         "source_clue_id": source_clue_id,


### PR DESCRIPTION
- add safety briefing endpoint for assigned volunteers and commanders
- provide rule-based risk notices and emergency-stop instructions
- add navigation endpoint with task-area text fallback responses
- withhold external navigation links without coordinate-system contracts
- restrict both endpoints from family, other volunteers, and admins
- document OpenAPI schemas, access controls, and degradation behavior
- add API and OpenAPI contract coverage for authorized fallbacks

close #40 
close #41 
close #43 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增任务安全简报接口：返回风险要点、通知及紧急停止信息（含规则化降级元数据）。
  - 新增任务导航接口：提供授权区域内的文字路线摘要；缺少坐标时不生成导航链接并返回文本回退。
  - 补充任务反馈接口说明：反馈进入待审核线索流程，不用于确认线索或推进任务状态。
- **权限与安全**
  - 安全简报与导航仅限任务已受领的志愿者与案件指挥访问；越权返回未找到。
- **文档与测试**
  - 更新 API/OpenAPI 说明与响应结构，并新增契约与访问控制集成测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->