### PR TITLE
feat: add clue evidence uploads and controlled archive drafts

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -33,11 +33,13 @@
 | `GET` | `/api/cases/{case_id}/pois` | `200` | 按服务端授权中心查询有上限的周边资源，失败时明确降级 |
 | `POST` | `/api/cases/{case_id}/summary-drafts` | `201` | 指挥创建带来源范围和版本的内部摘要草稿 |
 | `PATCH` | `/api/cases/{case_id}/summary-drafts/{draft_id}/review` | `200` | 指挥提交、审核发布、驳回或撤回摘要草稿 |
+| `POST` | `/api/cases/{case_id}/archive-drafts` | `201` | 指挥为已结束案件创建受控内部归档草稿 |
 | `GET` | `/api/cases/{case_id}/places` | `200` | 获取按案件角色、审核状态和可见级别裁剪的地点 |
 | `POST` | `/api/cases/{case_id}/places` | `201` | 家属或指挥提交常去/关键地点，始终待人工审核 |
 | `GET` | `/api/cases/{case_id}/resource-configuration` | `200` | 获取当前案件可用的地点类型和图片限制 |
 | `POST` | `/api/cases/{case_id}/attachments` | `201` | 上传受控 JPEG/PNG 案件图片，始终待人工审核 |
 | `GET` | `/api/cases/{case_id}/attachments/{attachment_id}` | `200` | 按案件权限下载本人上传的图片，指挥可下载案件全部图片 |
+| `POST` | `/api/clues/{clue_id}/attachments` | `201` | 为具体线索上传待审核 JPEG/PNG 佐证图片 |
 | `POST` | `/api/cases/{case_id}/members` | `201` | 家属邀请指挥，或指挥添加案件成员 |
 | `PATCH` | `/api/clues/{clue_id}/review` | `200` | 人工审核线索 |
 
@@ -219,7 +221,11 @@ Example:
 
 `POST /api/cases/{case_id}/summary-drafts` 和 `PATCH /api/cases/{case_id}/summary-drafts/{draft_id}/review` 仅对 `commander` 开放。生命周期包含 `draft`、`pending_review`、`published`、`rejected`、`withdrawn`、`superseded`。每次提交、审核、发布或撤回都记录操作者、理由、时间和版本；发布会将该案件既有的已发布版本标为 `superseded`。只有服务端依据受控来源范围生成的 `pending_review` 草稿可发布；自由文本草稿仅限内部使用，审核阶段不可用请求内容覆盖草稿，从而避免把未审核线索、内部任务或健康字段发布给非必要角色。
 
+`POST /api/cases/{case_id}/archive-drafts` is commander-only and accepts no client-supplied case material. It is available only after a case reaches `resolved` or `closed`. The server creates an internal `draft` from allowlisted status and count metadata for confirmed clues and completed tasks, persists its explicit `source_scope`, and marks `deidentification_status` as `manual_review_required`. It does not copy raw clue text, attachments, health notes, contacts, exact locations, routes, or task results. This endpoint does not publish, index, export, or print material; a separate authorized de-identification, review, and withdrawal workflow is required before any later reuse.
+
 `POST /api/cases/{case_id}/attachments` 使用 `multipart/form-data` 的单个 `file` 字段。首版只接收 MIME 声明（允许带参数）与文件魔数一致的 JPEG/PNG。服务端解码并重新编码图片以移除 EXIF/GPS 等非必要元数据，使用随机且不可猜测的存储键保存，并在元数据或审计写入失败时删除刚写入的文件。存储目录由 `ANGUI_ATTACHMENT_STORAGE_DIRECTORY` 配置，默认 `data/attachments`，不能包含 `..` 路径分段，且必须位于静态公开目录外。下载响应包含 `X-Content-Type-Options: nosniff` 和 `Cache-Control: no-store, private`。
+
+`POST /api/clues/{clue_id}/attachments` uses the same single-file JPEG/PNG validation, normalization, EXIF/GPS removal, byte limit, and protected storage policy. The attachment row, the clue-to-attachment link, and the audit event are committed together. A commander may add evidence to any clue in the case; family and volunteer members may only add evidence to clues they submitted. The new image remains `pending_review`, and ordinary attachment download rules still prevent family or volunteers from reading another member's internal evidence.
 
 以下限制均由启动配置统一控制，服务层和 multipart 读取层会使用同一份值：
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -989,6 +989,25 @@ paths:
         "404": { $ref: "#/components/responses/NotFound" }
         "409": { $ref: "#/components/responses/Conflict" }
 
+  /api/cases/{case_id}/archive-drafts:
+    parameters: [{ $ref: "#/components/parameters/CaseId" }]
+    post:
+      tags: [Cases]
+      operationId: createCaseArchiveDraft
+      summary: Create a controlled internal archive draft
+      description: Only a case commander may create this deterministic internal draft for a resolved or closed case. It records only allowlisted status and count metadata, remains manual_review_required, and cannot publish, index, export, or print case material.
+      security: [{ bearerAuth: [] }]
+      x-account-types: [member]
+      x-case-roles: [commander]
+      x-data-classification: case-restricted
+      responses:
+        "201": { description: Internal archive draft requiring de-identification review, content: { application/json: { schema: { $ref: "#/components/schemas/ArchiveDraft" } } } }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { $ref: "#/components/responses/Conflict" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
   /api/cases/{case_id}/places:
     parameters:
       - $ref: "#/components/parameters/CaseId"
@@ -1215,6 +1234,40 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalError"
+
+  /api/clues/{clue_id}/attachments:
+    parameters:
+      - $ref: "#/components/parameters/ClueId"
+    post:
+      tags: [Clues]
+      operationId: uploadClueAttachment
+      summary: Upload pending-review image evidence for one clue
+      description: Accepts exactly one multipart file (JPEG or PNG). The server verifies actual format, re-encodes the image to remove EXIF/GPS metadata, creates a pending_review attachment, links it to the clue, and audits the operation atomically. Commanders may attach evidence to any clue in their case; family and volunteers may only attach to clues they submitted. Attachments remain case-restricted and are never exposed through public progress.
+      security:
+        - bearerAuth: []
+      x-account-types: [member]
+      x-case-roles: [family, commander, volunteer]
+      x-data-classification: case-restricted
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              additionalProperties: false
+              required: [file]
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        "201": { description: Pending-review image evidence linked to the clue, content: { application/json: { schema: { $ref: "#/components/schemas/CaseAttachment" } } } }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { $ref: "#/components/responses/Conflict" }
+        "500": { $ref: "#/components/responses/InternalError" }
 
 components:
   securitySchemes:
@@ -2534,6 +2587,22 @@ components:
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
         publication_eligible: { type: boolean }
+
+    ArchiveDraft:
+      type: object
+      additionalProperties: false
+      required: [id, case_id, status, content, source_scope, deidentification_status, template_version, provider_model, created_at, updated_at]
+      properties:
+        id: { type: string, format: uuid }
+        case_id: { type: string, format: uuid }
+        status: { type: string, enum: [draft] }
+        content: { type: string, description: Internal deterministic draft content containing no raw case materials. }
+        source_scope: { type: array, items: { type: string, enum: [confirmed_clue_metadata, completed_task_metadata] } }
+        deidentification_status: { type: string, enum: [manual_review_required] }
+        template_version: { type: string }
+        provider_model: { type: [string, "null"], description: Always null for the rule-based draft generator. }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
 
     CaseSummary:
       type: object

--- a/migration/sql/mysql/down/0025_drop_archive_drafts.sql
+++ b/migration/sql/mysql/down/0025_drop_archive_drafts.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS archive_drafts;

--- a/migration/sql/mysql/up/0025_create_archive_drafts.sql
+++ b/migration/sql/mysql/up/0025_create_archive_drafts.sql
@@ -1,0 +1,19 @@
+CREATE TABLE archive_drafts (
+    id VARCHAR(36) PRIMARY KEY,
+    case_id VARCHAR(36) NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    content TEXT NOT NULL,
+    source_scope_json TEXT NOT NULL,
+    deidentification_status VARCHAR(64) NOT NULL,
+    template_version VARCHAR(128) NOT NULL,
+    provider_model VARCHAR(255),
+    created_by_user_id VARCHAR(36) NOT NULL,
+    created_at VARCHAR(40) NOT NULL,
+    updated_at VARCHAR(40) NOT NULL,
+    CONSTRAINT chk_archive_drafts_status CHECK (status IN ('draft')),
+    CONSTRAINT chk_archive_drafts_deidentification_status CHECK (deidentification_status IN ('manual_review_required')),
+    CONSTRAINT fk_archive_drafts_case FOREIGN KEY (case_id) REFERENCES cases(id) ON DELETE CASCADE,
+    CONSTRAINT fk_archive_drafts_creator FOREIGN KEY (created_by_user_id) REFERENCES users(id) ON DELETE RESTRICT
+) ENGINE=InnoDB;
+-- statement-break
+CREATE INDEX idx_archive_drafts_case_created ON archive_drafts(case_id, created_at);

--- a/migration/sql/postgres/down/0025_drop_archive_drafts.sql
+++ b/migration/sql/postgres/down/0025_drop_archive_drafts.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS archive_drafts;

--- a/migration/sql/postgres/up/0025_create_archive_drafts.sql
+++ b/migration/sql/postgres/up/0025_create_archive_drafts.sql
@@ -1,0 +1,17 @@
+CREATE TABLE archive_drafts (
+    id VARCHAR(36) PRIMARY KEY,
+    case_id VARCHAR(36) NOT NULL,
+    status VARCHAR(32) NOT NULL CHECK (status IN ('draft')),
+    content TEXT NOT NULL,
+    source_scope_json TEXT NOT NULL,
+    deidentification_status VARCHAR(64) NOT NULL CHECK (deidentification_status IN ('manual_review_required')),
+    template_version VARCHAR(128) NOT NULL,
+    provider_model VARCHAR(255),
+    created_by_user_id VARCHAR(36) NOT NULL,
+    created_at VARCHAR(40) NOT NULL,
+    updated_at VARCHAR(40) NOT NULL,
+    FOREIGN KEY (case_id) REFERENCES cases(id) ON DELETE CASCADE,
+    FOREIGN KEY (created_by_user_id) REFERENCES users(id) ON DELETE RESTRICT
+);
+-- statement-break
+CREATE INDEX idx_archive_drafts_case_created ON archive_drafts(case_id, created_at);

--- a/migration/sql/sqlite/down/0025_drop_archive_drafts.sql
+++ b/migration/sql/sqlite/down/0025_drop_archive_drafts.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS archive_drafts;

--- a/migration/sql/sqlite/up/0025_create_archive_drafts.sql
+++ b/migration/sql/sqlite/up/0025_create_archive_drafts.sql
@@ -1,0 +1,17 @@
+CREATE TABLE archive_drafts (
+    id TEXT PRIMARY KEY NOT NULL,
+    case_id TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('draft')),
+    content TEXT NOT NULL,
+    source_scope_json TEXT NOT NULL,
+    deidentification_status TEXT NOT NULL CHECK (deidentification_status IN ('manual_review_required')),
+    template_version TEXT NOT NULL,
+    provider_model TEXT,
+    created_by_user_id TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (case_id) REFERENCES cases(id) ON DELETE CASCADE,
+    FOREIGN KEY (created_by_user_id) REFERENCES users(id) ON DELETE RESTRICT
+);
+-- statement-break
+CREATE INDEX idx_archive_drafts_case_created ON archive_drafts(case_id, created_at);

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -24,6 +24,7 @@ mod m0021_create_user_profiles_and_elder_profile_revisions;
 mod m0022_create_summary_drafts;
 mod m0023_create_clue_drafts;
 mod m0024_enforce_single_published_summary_draft;
+mod m0025_create_archive_drafts;
 
 use sea_orm_migration::sea_orm::{DbBackend, Statement};
 
@@ -57,6 +58,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0022_create_summary_drafts::Migration),
             Box::new(m0023_create_clue_drafts::Migration),
             Box::new(m0024_enforce_single_published_summary_draft::Migration),
+            Box::new(m0025_create_archive_drafts::Migration),
         ]
     }
 }
@@ -265,6 +267,21 @@ mod tests {
         ),
     ];
 
+    const ARCHIVE_DRAFT_SCRIPTS: &[(&str, &str)] = &[
+        (
+            "sqlite",
+            include_str!("../sql/sqlite/up/0025_create_archive_drafts.sql"),
+        ),
+        (
+            "postgres",
+            include_str!("../sql/postgres/up/0025_create_archive_drafts.sql"),
+        ),
+        (
+            "mysql",
+            include_str!("../sql/mysql/up/0025_create_archive_drafts.sql"),
+        ),
+    ];
+
     #[tokio::test]
     async fn sqlite_migrations_support_up_down_up() {
         let database = Database::connect("sqlite::memory:")
@@ -280,6 +297,44 @@ mod tests {
         Migrator::up(&database, None)
             .await
             .expect("migrations should be repeatable after rollback");
+    }
+
+    #[tokio::test]
+    async fn sqlite_archive_draft_migration_preserves_data_and_refuses_unsafe_rollback() {
+        let database = Database::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite connection should succeed");
+        Migrator::up(&database, Some(24))
+            .await
+            .expect("schema before archive draft migration should succeed");
+        insert_member_and_session(&database, "archive-draft").await;
+        database
+            .execute_unprepared(
+                "INSERT INTO cases (id, case_code, status, created_at, updated_at) VALUES ('archive-draft-case', 'AG-00000025', 'resolved', '2026-07-28T00:00:00.000Z', '2026-07-28T00:00:00.000Z')",
+            )
+            .await
+            .expect("archive draft case fixture should be stored");
+
+        Migrator::up(&database, Some(1))
+            .await
+            .expect("archive draft migration should succeed");
+        database
+            .execute_unprepared(
+                "INSERT INTO archive_drafts (id, case_id, status, content, source_scope_json, deidentification_status, template_version, provider_model, created_by_user_id, created_at, updated_at) VALUES ('archive-draft-1', 'archive-draft-case', 'draft', 'Internal test archive draft.', '[\"confirmed_clue_metadata\"]', 'manual_review_required', 'v1', NULL, 'archive-draft-user', '2026-07-28T00:00:00.000Z', '2026-07-28T00:00:00.000Z')",
+            )
+            .await
+            .expect("archive draft should satisfy schema constraints");
+        assert!(Migrator::down(&database, Some(1)).await.is_err());
+        assert!(
+            database
+                .query_one(Statement::from_string(
+                    sea_orm_migration::sea_orm::DbBackend::Sqlite,
+                    "SELECT 1 FROM archive_drafts WHERE id = 'archive-draft-1'",
+                ))
+                .await
+                .expect("archive draft query should succeed")
+                .is_some()
+        );
     }
 
     #[tokio::test]
@@ -814,6 +869,26 @@ mod tests {
                 assert!(
                     normalized.contains("check (publication_eligible in (0, 1))"),
                     "{name} must constrain publication eligibility to 0 or 1"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn archive_drafts_have_matching_restricted_lifecycle_constraints_across_dialects() {
+        for (name, script) in ARCHIVE_DRAFT_SCRIPTS {
+            let normalized = script.to_ascii_lowercase();
+            for required in [
+                "archive_drafts",
+                "source_scope_json",
+                "manual_review_required",
+                "foreign key (case_id)",
+                "foreign key (created_by_user_id)",
+                "idx_archive_drafts_case_created",
+            ] {
+                assert!(
+                    normalized.contains(required),
+                    "{name} archive draft schema must declare {required}"
                 );
             }
         }

--- a/migration/src/m0025_create_archive_drafts.rs
+++ b/migration/src/m0025_create_archive_drafts.rs
@@ -1,0 +1,48 @@
+use sea_orm_migration::prelude::*;
+
+use crate::{ensure_rollback_is_safe, execute_script, sql_for_backend};
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m0025_create_archive_drafts"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        execute_script(
+            manager,
+            sql_for_backend(
+                manager,
+                include_str!("../sql/sqlite/up/0025_create_archive_drafts.sql"),
+                include_str!("../sql/postgres/up/0025_create_archive_drafts.sql"),
+                include_str!("../sql/mysql/up/0025_create_archive_drafts.sql"),
+            ),
+        )
+        .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        ensure_rollback_is_safe(
+            manager,
+            &[(
+                "archive drafts exist",
+                "SELECT 1 FROM archive_drafts LIMIT 1",
+            )],
+        )
+        .await?;
+        execute_script(
+            manager,
+            sql_for_backend(
+                manager,
+                include_str!("../sql/sqlite/down/0025_drop_archive_drafts.sql"),
+                include_str!("../sql/postgres/down/0025_drop_archive_drafts.sql"),
+                include_str!("../sql/mysql/down/0025_drop_archive_drafts.sql"),
+            ),
+        )
+        .await
+    }
+}

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -820,6 +820,20 @@ pub struct SummaryDraftResponse {
     pub publication_eligible: bool,
 }
 
+#[derive(Debug, Serialize)]
+pub struct ArchiveDraftResponse {
+    pub id: String,
+    pub case_id: String,
+    pub status: String,
+    pub content: String,
+    pub source_scope: Vec<String>,
+    pub deidentification_status: String,
+    pub template_version: String,
+    pub provider_model: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CasePoiQuery {

--- a/src/api/routes/cases.rs
+++ b/src/api/routes/cases.rs
@@ -1,6 +1,4 @@
-use actix_multipart::Multipart;
 use actix_web::{HttpResponse, http::header, web};
-use futures_util::StreamExt;
 
 use crate::{
     app_state::AppState,
@@ -46,6 +44,10 @@ pub fn configure(config: &mut web::ServiceConfig) {
             .route(
                 "/{case_id}/summary-drafts/{draft_id}/review",
                 web::patch().to(review_summary_draft),
+            )
+            .route(
+                "/{case_id}/archive-drafts",
+                web::post().to(create_archive_draft),
             )
             .route("/{case_id}/places", web::get().to(list_places))
             .route("/{case_id}/places", web::post().to(create_place))
@@ -120,42 +122,14 @@ async fn create_attachment(
     auth: AuthenticatedUser,
     state: web::Data<AppState>,
     case_id: web::Path<String>,
-    mut multipart: Multipart,
+    multipart: actix_multipart::Multipart,
 ) -> Result<HttpResponse, ApiError> {
-    let mut file: Option<(String, String, Vec<u8>)> = None;
-    while let Some(item) = multipart.next().await {
-        let mut field =
-            item.map_err(|_| ApiError::Validation("multipart upload is malformed".to_owned()))?;
-        if field.name() != Some("file") || file.is_some() {
-            return Err(ApiError::Validation(
-                "submit exactly one file field".to_owned(),
-            ));
-        }
-        let filename = field
-            .content_disposition()
-            .and_then(|value| value.get_filename())
-            .ok_or_else(|| ApiError::Validation("file name is required".to_owned()))?
-            .to_owned();
-        let content_type = field
-            .content_type()
-            .map(|value| value.essence_str().to_owned())
-            .ok_or_else(|| ApiError::Validation("file content type is required".to_owned()))?;
-        let mut bytes = Vec::new();
-        while let Some(chunk) = field.next().await {
-            let chunk = chunk
-                .map_err(|_| ApiError::Validation("file upload could not be read".to_owned()))?;
-            if bytes.len().saturating_add(chunk.len()) > state.attachment_max_image_bytes {
-                return Err(ApiError::Validation(format!(
-                    "image must not exceed {} bytes",
-                    state.attachment_max_image_bytes
-                )));
-            }
-            bytes.extend_from_slice(&chunk);
-        }
-        file = Some((filename, content_type, bytes));
-    }
     let (filename, content_type, bytes) =
-        file.ok_or_else(|| ApiError::Validation("file field is required".to_owned()))?;
+        crate::services::case_resource_service::read_single_image_upload(
+            multipart,
+            state.attachment_max_image_bytes,
+        )
+        .await?;
     let attachment = crate::services::case_resource_service::store_image_attachment(
         &state.db,
         &auth,
@@ -173,6 +147,18 @@ async fn create_attachment(
     )
     .await?;
     Ok(HttpResponse::Created().json(attachment))
+}
+
+async fn create_archive_draft(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    case_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    let draft = crate::services::case_collaboration_service::create_archive_draft(
+        &state.db, &auth, &case_id,
+    )
+    .await?;
+    Ok(HttpResponse::Created().json(draft))
 }
 
 async fn download_attachment(

--- a/src/api/routes/clues.rs
+++ b/src/api/routes/clues.rs
@@ -1,3 +1,4 @@
+use actix_multipart::Multipart;
 use actix_web::{HttpResponse, web};
 
 use crate::{
@@ -8,7 +9,11 @@ use crate::{
 };
 
 pub fn configure(config: &mut web::ServiceConfig) {
-    config.service(web::scope("/clues").route("/{clue_id}/review", web::patch().to(review_clue)));
+    config.service(
+        web::scope("/clues")
+            .route("/{clue_id}/review", web::patch().to(review_clue))
+            .route("/{clue_id}/attachments", web::post().to(create_attachment)),
+    );
 }
 
 async fn review_clue(
@@ -19,4 +24,35 @@ async fn review_clue(
 ) -> Result<HttpResponse, ApiError> {
     let clue = case_service::review_clue(&state.db, &auth, &clue_id, request.into_inner()).await?;
     Ok(HttpResponse::Ok().json(clue))
+}
+
+async fn create_attachment(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    clue_id: web::Path<String>,
+    multipart: Multipart,
+) -> Result<HttpResponse, ApiError> {
+    let (filename, content_type, bytes) =
+        crate::services::case_resource_service::read_single_image_upload(
+            multipart,
+            state.attachment_max_image_bytes,
+        )
+        .await?;
+    let attachment = crate::services::case_resource_service::store_image_attachment_for_clue(
+        &state.db,
+        &auth,
+        &clue_id,
+        crate::services::case_resource_service::AttachmentUpload {
+            filename: &filename,
+            declared_content_type: &content_type,
+            bytes: &bytes,
+        },
+        crate::services::case_resource_service::AttachmentStorage {
+            directory: &state.attachment_storage_directory,
+            max_image_bytes: state.attachment_max_image_bytes,
+            max_attachments_per_case: state.attachment_max_per_case,
+        },
+    )
+    .await?;
+    Ok(HttpResponse::Created().json(attachment))
 }

--- a/src/application/services/case_collaboration_service.rs
+++ b/src/application/services/case_collaboration_service.rs
@@ -1,25 +1,102 @@
 use chrono::{SecondsFormat, Utc};
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, IntoActiveModel, QueryFilter,
-    QueryOrder, Set, TransactionTrait,
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, IntoActiveModel,
+    PaginatorTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
 };
 use serde_json::json;
 
 use crate::{
     ai_gateway::{AiCapability, AiPurpose, AiRequest, DataLevel, GatewayDecision},
     amap_service::{Coordinate, PoiSearch},
-    entities::{case_places, clue_drafts, summary_drafts},
+    entities::{archive_drafts, case_places, cases, clue_drafts, clues, summary_drafts, tasks},
     error::ApiError,
     models::{
-        AuthenticatedUser, CasePoiItem, CasePoiQuery, CasePoiResponse, CasePublicProgressItem,
-        CasePublicProgressResponse, ClueDraftResponse, CreateClueDraftRequest,
-        CreateSummaryDraftRequest, ReviewSummaryDraftRequest, SummaryDraftResponse,
+        ArchiveDraftResponse, AuthenticatedUser, CasePoiItem, CasePoiQuery, CasePoiResponse,
+        CasePublicProgressItem, CasePublicProgressResponse, ClueDraftResponse,
+        CreateClueDraftRequest, CreateSummaryDraftRequest, ReviewSummaryDraftRequest,
+        SummaryDraftResponse,
     },
     roles::CaseRole,
     services::{case_service, case_summary_service, task_service},
 };
 
 const DRAFT_TEMPLATE_VERSION: &str = "case-summary-rule-v1";
+const ARCHIVE_DRAFT_TEMPLATE_VERSION: &str = "case-archive-safe-metadata-v1";
+
+pub async fn create_archive_draft(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    case_id: &str,
+) -> Result<ArchiveDraftResponse, ApiError> {
+    let transaction = db.begin().await?;
+    case_service::require_case_role(&transaction, &auth.id, case_id, &[CaseRole::Commander])
+        .await?;
+    let case = cases::Entity::find_by_id(case_id)
+        .one(&transaction)
+        .await?
+        .ok_or_else(|| ApiError::NotFound("case was not found".to_owned()))?;
+    if !matches!(case.status.as_str(), "resolved" | "closed") {
+        return Err(ApiError::Conflict(
+            "archive drafts can only be created for resolved or closed cases".to_owned(),
+        ));
+    }
+
+    let confirmed_clue_count = clues::Entity::find()
+        .filter(clues::Column::CaseId.eq(case_id))
+        .filter(clues::Column::Status.eq("confirmed"))
+        .count(&transaction)
+        .await?;
+    let completed_task_count = tasks::Entity::find()
+        .filter(tasks::Column::CaseId.eq(case_id))
+        .filter(tasks::Column::Status.eq("completed"))
+        .count(&transaction)
+        .await?;
+    let source_scope = vec![
+        "confirmed_clue_metadata".to_owned(),
+        "completed_task_metadata".to_owned(),
+    ];
+    let timestamp = now();
+    let model = archive_drafts::ActiveModel {
+        id: Set(case_service::new_id()),
+        case_id: Set(case_id.to_owned()),
+        status: Set("draft".to_owned()),
+        content: Set(deterministic_archive_draft_content(
+            &case.status,
+            confirmed_clue_count,
+            completed_task_count,
+        )),
+        source_scope_json: Set(
+            serde_json::to_string(&source_scope).map_err(|_| ApiError::Internal)?
+        ),
+        deidentification_status: Set("manual_review_required".to_owned()),
+        template_version: Set(ARCHIVE_DRAFT_TEMPLATE_VERSION.to_owned()),
+        provider_model: Set(None),
+        created_by_user_id: Set(auth.id.clone()),
+        created_at: Set(timestamp.clone()),
+        updated_at: Set(timestamp),
+    }
+    .insert(&transaction)
+    .await?;
+    case_service::write_audit(
+        &transaction,
+        Some(case_id.to_owned()),
+        auth,
+        "archive_draft.created",
+        "archive_draft",
+        model.id.clone(),
+        Some(json!({
+            "status": model.status,
+            "deidentification_status": model.deidentification_status,
+            "template_version": model.template_version,
+            "source_scope": source_scope,
+            "confirmed_clue_count": confirmed_clue_count,
+            "completed_task_count": completed_task_count,
+        })),
+    )
+    .await?;
+    transaction.commit().await?;
+    archive_draft_response(model)
+}
 
 pub async fn get_public_progress(
     db: &DatabaseConnection,
@@ -397,6 +474,16 @@ fn deterministic_draft_content(summary: &crate::models::CaseSummaryResponse) -> 
         summary.safety_reminders.join(" ")
     )
 }
+
+fn deterministic_archive_draft_content(
+    case_status: &str,
+    confirmed_clue_count: u64,
+    completed_task_count: u64,
+) -> String {
+    format!(
+        "Internal archive draft. This record is not de-identified, publishable, indexable, exportable, or printable. Case status: {case_status}. Confirmed clue count: {confirmed_clue_count}. Completed task count: {completed_task_count}. Source scope is limited to counts and status metadata; it excludes raw clues, attachments, health notes, contacts, exact locations, routes, and task result text. Human de-identification and review are required before any separate reuse workflow."
+    )
+}
 fn required_text(label: &str, value: String, maximum: usize) -> Result<String, ApiError> {
     let value = value.trim().to_owned();
     if value.is_empty() || value.chars().count() > maximum {
@@ -428,6 +515,22 @@ fn response(model: summary_drafts::Model) -> Result<SummaryDraftResponse, ApiErr
         created_at: model.created_at,
         updated_at: model.updated_at,
         publication_eligible: model.publication_eligible,
+    })
+}
+
+fn archive_draft_response(model: archive_drafts::Model) -> Result<ArchiveDraftResponse, ApiError> {
+    Ok(ArchiveDraftResponse {
+        id: model.id,
+        case_id: model.case_id,
+        status: model.status,
+        content: model.content,
+        source_scope: serde_json::from_str(&model.source_scope_json)
+            .map_err(|_| ApiError::Internal)?,
+        deidentification_status: model.deidentification_status,
+        template_version: model.template_version,
+        provider_model: model.provider_model,
+        created_at: model.created_at,
+        updated_at: model.updated_at,
     })
 }
 

--- a/src/application/services/case_resource_service.rs
+++ b/src/application/services/case_resource_service.rs
@@ -4,19 +4,23 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use actix_multipart::Multipart;
 use actix_web::web;
 use chrono::{SecondsFormat, Utc};
+use futures_util::StreamExt;
 use image::ImageFormat;
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, Condition, DatabaseConnection, EntityTrait, PaginatorTrait,
-    QueryFilter, QueryOrder, Set, TransactionTrait,
+    ActiveModelTrait, ColumnTrait, Condition, DatabaseConnection, DatabaseTransaction, EntityTrait,
+    PaginatorTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
 };
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::{
-    entities::{case_attachments, case_places, cases},
+    entities::{
+        case_attachments, case_places, cases, clue_attachment_links, clue_attributions, clues,
+    },
     error::ApiError,
     models::{
         AuthenticatedUser, CaseAttachmentResponse, CasePlaceResponse, CreateCasePlaceRequest,
@@ -35,6 +39,44 @@ pub struct AttachmentStorage<'a> {
     pub directory: &'a Path,
     pub max_image_bytes: usize,
     pub max_attachments_per_case: u64,
+}
+
+pub async fn read_single_image_upload(
+    mut multipart: Multipart,
+    max_image_bytes: usize,
+) -> Result<(String, String, Vec<u8>), ApiError> {
+    let mut file: Option<(String, String, Vec<u8>)> = None;
+    while let Some(item) = multipart.next().await {
+        let mut field =
+            item.map_err(|_| ApiError::Validation("multipart upload is malformed".to_owned()))?;
+        if field.name() != Some("file") || file.is_some() {
+            return Err(ApiError::Validation(
+                "submit exactly one file field".to_owned(),
+            ));
+        }
+        let filename = field
+            .content_disposition()
+            .and_then(|value| value.get_filename())
+            .ok_or_else(|| ApiError::Validation("file name is required".to_owned()))?
+            .to_owned();
+        let content_type = field
+            .content_type()
+            .map(|value| value.essence_str().to_owned())
+            .ok_or_else(|| ApiError::Validation("file content type is required".to_owned()))?;
+        let mut bytes = Vec::new();
+        while let Some(chunk) = field.next().await {
+            let chunk = chunk
+                .map_err(|_| ApiError::Validation("file upload could not be read".to_owned()))?;
+            if bytes.len().saturating_add(chunk.len()) > max_image_bytes {
+                return Err(ApiError::Validation(format!(
+                    "image must not exceed {max_image_bytes} bytes"
+                )));
+            }
+            bytes.extend_from_slice(&chunk);
+        }
+        file = Some((filename, content_type, bytes));
+    }
+    file.ok_or_else(|| ApiError::Validation("file field is required".to_owned()))
 }
 
 pub async fn create_place(
@@ -84,15 +126,8 @@ pub async fn store_image_attachment(
     upload: AttachmentUpload<'_>,
     storage: AttachmentStorage<'_>,
 ) -> Result<CaseAttachmentResponse, ApiError> {
-    let declared_content_type = upload.declared_content_type.to_owned();
-    let uploaded_bytes = upload.bytes.to_vec();
-    let max_image_bytes = storage.max_image_bytes;
-    let (content_type, extension, normalized) = web::block(move || {
-        normalize_image(&declared_content_type, &uploaded_bytes, max_image_bytes)
-    })
-    .await
-    .map_err(|_| ApiError::Internal)??;
-    let original_filename = safe_filename(upload.filename, extension)?;
+    let (content_type, original_filename, normalized) =
+        normalize_attachment_upload(upload, storage.max_image_bytes).await?;
     let transaction = db.begin().await?;
     let role = require_case_role(
         &transaction,
@@ -102,66 +137,70 @@ pub async fn store_image_attachment(
     )
     .await?;
     ensure_case_is_open(&transaction, case_id).await?;
-    let current_count = case_attachments::Entity::find()
-        .filter(case_attachments::Column::CaseId.eq(case_id))
-        .count(&transaction)
-        .await?;
-    if current_count >= storage.max_attachments_per_case {
-        return Err(ApiError::Validation(
-            "this case already has the maximum number of attachments".to_owned(),
-        ));
-    }
-    let id = new_id();
-    let storage_key = format!("{id}.{extension}");
-    let storage_path = storage.directory.join(&storage_key);
-    let storage_directory = storage.directory.to_path_buf();
-    let path_for_write = storage_path.clone();
-    let bytes_for_write = normalized.clone();
-    web::block(move || {
-        fs::create_dir_all(storage_directory)?;
-        fs::write(path_for_write, bytes_for_write)
-    })
-    .await
-    .map_err(|_| ApiError::Internal)?
-    .map_err(|_| ApiError::Internal)?;
-    let timestamp = now();
-    let model = case_attachments::ActiveModel {
-        id: Set(id),
-        case_id: Set(case_id.to_owned()),
-        storage_key: Set(storage_key),
-        original_filename: Set(original_filename),
-        content_type: Set(content_type),
-        byte_size: Set(normalized.len() as i64),
-        sha256: Set(hex::encode(Sha256::digest(&normalized))),
-        source: Set(role.to_string()),
-        review_status: Set("pending_review".to_owned()),
-        created_by_user_id: Set(auth.id.clone()),
-        created_at: Set(timestamp.clone()),
-        updated_at: Set(timestamp),
-    }
-    .insert(&transaction)
-    .await;
-    let model = match model {
-        Ok(model) => model,
-        Err(error) => {
-            remove_file_best_effort(storage_path.clone()).await;
-            return Err(ApiError::Database(error));
-        }
-    };
-    if let Err(error) = write_audit(
+    let (model, storage_path) = persist_image_attachment(
         &transaction,
-        Some(case_id.to_owned()),
         auth,
-        "case.attachment_submitted",
-        "case_attachment",
-        model.id.clone(),
-        Some(json!({ "review_status": "pending_review", "content_type": model.content_type })),
+        case_id,
+        role,
+        content_type,
+        original_filename,
+        normalized,
+        storage,
+        None,
     )
-    .await
-    {
-        remove_file_best_effort(storage_path.clone()).await;
-        return Err(error);
+    .await?;
+    if let Err(error) = transaction.commit().await {
+        remove_file_best_effort(storage_path).await;
+        return Err(ApiError::Database(error));
     }
+    Ok(attachment_response(model, &auth.id))
+}
+
+pub async fn store_image_attachment_for_clue(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    clue_id: &str,
+    upload: AttachmentUpload<'_>,
+    storage: AttachmentStorage<'_>,
+) -> Result<CaseAttachmentResponse, ApiError> {
+    let (content_type, original_filename, normalized) =
+        normalize_attachment_upload(upload, storage.max_image_bytes).await?;
+    let transaction = db.begin().await?;
+    let clue = clues::Entity::find_by_id(clue_id)
+        .one(&transaction)
+        .await?
+        .ok_or_else(|| ApiError::NotFound("clue was not found".to_owned()))?;
+    let role = require_case_role(
+        &transaction,
+        &auth.id,
+        &clue.case_id,
+        &[CaseRole::Family, CaseRole::Commander, CaseRole::Volunteer],
+    )
+    .await?;
+    if role != CaseRole::Commander {
+        let is_submitter = clue_attributions::Entity::find_by_id(&clue.id)
+            .one(&transaction)
+            .await?
+            .and_then(|attribution| attribution.submitted_by_user_id)
+            .as_deref()
+            == Some(auth.id.as_str());
+        if !is_submitter {
+            return Err(ApiError::NotFound("clue was not found".to_owned()));
+        }
+    }
+    ensure_case_is_open(&transaction, &clue.case_id).await?;
+    let (model, storage_path) = persist_image_attachment(
+        &transaction,
+        auth,
+        &clue.case_id,
+        role,
+        content_type,
+        original_filename,
+        normalized,
+        storage,
+        Some(&clue.id),
+    )
+    .await?;
     if let Err(error) = transaction.commit().await {
         remove_file_best_effort(storage_path).await;
         return Err(ApiError::Database(error));
@@ -266,6 +305,137 @@ pub struct DownloadedAttachment {
     pub bytes: Vec<u8>,
     pub content_type: String,
     pub filename: String,
+}
+
+async fn normalize_attachment_upload(
+    upload: AttachmentUpload<'_>,
+    max_image_bytes: usize,
+) -> Result<(String, String, Vec<u8>), ApiError> {
+    let declared_content_type = upload.declared_content_type.to_owned();
+    let uploaded_bytes = upload.bytes.to_vec();
+    let (content_type, extension, normalized) = web::block(move || {
+        normalize_image(&declared_content_type, &uploaded_bytes, max_image_bytes)
+    })
+    .await
+    .map_err(|_| ApiError::Internal)??;
+    Ok((
+        content_type,
+        safe_filename(upload.filename, extension)?,
+        normalized,
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn persist_image_attachment(
+    transaction: &DatabaseTransaction,
+    auth: &AuthenticatedUser,
+    case_id: &str,
+    role: CaseRole,
+    content_type: String,
+    original_filename: String,
+    normalized: Vec<u8>,
+    storage: AttachmentStorage<'_>,
+    clue_id: Option<&str>,
+) -> Result<(case_attachments::Model, PathBuf), ApiError> {
+    let current_count = case_attachments::Entity::find()
+        .filter(case_attachments::Column::CaseId.eq(case_id))
+        .count(transaction)
+        .await?;
+    if current_count >= storage.max_attachments_per_case {
+        return Err(ApiError::Validation(
+            "this case already has the maximum number of attachments".to_owned(),
+        ));
+    }
+
+    let extension = match content_type.as_str() {
+        "image/jpeg" => "jpg",
+        "image/png" => "png",
+        _ => return Err(ApiError::Internal),
+    };
+    let id = new_id();
+    let storage_key = format!("{id}.{extension}");
+    let storage_path = storage.directory.join(&storage_key);
+    let storage_directory = storage.directory.to_path_buf();
+    let path_for_write = storage_path.clone();
+    let bytes_for_write = normalized.clone();
+    web::block(move || {
+        fs::create_dir_all(storage_directory)?;
+        fs::write(path_for_write, bytes_for_write)
+    })
+    .await
+    .map_err(|_| ApiError::Internal)?
+    .map_err(|_| ApiError::Internal)?;
+
+    let timestamp = now();
+    let model = case_attachments::ActiveModel {
+        id: Set(id),
+        case_id: Set(case_id.to_owned()),
+        storage_key: Set(storage_key),
+        original_filename: Set(original_filename),
+        content_type: Set(content_type),
+        byte_size: Set(normalized.len() as i64),
+        sha256: Set(hex::encode(Sha256::digest(&normalized))),
+        source: Set(role.to_string()),
+        review_status: Set("pending_review".to_owned()),
+        created_by_user_id: Set(auth.id.clone()),
+        created_at: Set(timestamp.clone()),
+        updated_at: Set(timestamp.clone()),
+    }
+    .insert(transaction)
+    .await;
+    let model = match model {
+        Ok(model) => model,
+        Err(error) => {
+            remove_file_best_effort(storage_path.clone()).await;
+            return Err(ApiError::Database(error));
+        }
+    };
+
+    let (action, entity_type, entity_id, metadata) = if let Some(clue_id) = clue_id {
+        let link = clue_attachment_links::ActiveModel {
+            clue_id: Set(clue_id.to_owned()),
+            attachment_id: Set(model.id.clone()),
+            created_at: Set(timestamp),
+        }
+        .insert(transaction)
+        .await;
+        if let Err(error) = link {
+            remove_file_best_effort(storage_path.clone()).await;
+            return Err(ApiError::Database(error));
+        }
+        (
+            "clue.attachment_submitted",
+            "clue_attachment",
+            model.id.clone(),
+            json!({
+                "clue_id": clue_id,
+                "review_status": "pending_review",
+                "content_type": model.content_type,
+            }),
+        )
+    } else {
+        (
+            "case.attachment_submitted",
+            "case_attachment",
+            model.id.clone(),
+            json!({ "review_status": "pending_review", "content_type": model.content_type }),
+        )
+    };
+    if let Err(error) = write_audit(
+        transaction,
+        Some(case_id.to_owned()),
+        auth,
+        action,
+        entity_type,
+        entity_id,
+        Some(metadata),
+    )
+    .await
+    {
+        remove_file_best_effort(storage_path.clone()).await;
+        return Err(error);
+    }
+    Ok((model, storage_path))
 }
 
 fn validate_place(

--- a/src/persistence/entities/archive_drafts.rs
+++ b/src/persistence/entities/archive_drafts.rs
@@ -1,0 +1,40 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "archive_drafts")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub case_id: String,
+    pub status: String,
+    pub content: String,
+    pub source_scope_json: String,
+    pub deidentification_status: String,
+    pub template_version: String,
+    pub provider_model: Option<String>,
+    pub created_by_user_id: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::cases::Entity",
+        from = "Column::CaseId",
+        to = "super::cases::Column::Id",
+        on_update = "Cascade",
+        on_delete = "Cascade"
+    )]
+    Case,
+    #[sea_orm(
+        belongs_to = "super::users::Entity",
+        from = "Column::CreatedByUserId",
+        to = "super::users::Column::Id",
+        on_update = "Cascade",
+        on_delete = "Restrict"
+    )]
+    Creator,
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/persistence/entities/mod.rs
+++ b/src/persistence/entities/mod.rs
@@ -1,4 +1,5 @@
 pub mod ai_prompt_templates;
+pub mod archive_drafts;
 pub mod audit_events;
 pub mod auth_sessions;
 pub mod case_attachments;

--- a/tests/api/case_archive_drafts_post.rs
+++ b/tests/api/case_archive_drafts_post.rs
@@ -1,0 +1,134 @@
+use actix_web::{
+    http::{StatusCode, header},
+    test,
+};
+use angui::entities::{archive_drafts, audit_events};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use serde_json::json;
+
+use crate::support::{COMMANDER, FAMILY, LEARNER, TestContext, VOLUNTEER, assert_error};
+
+#[actix_web::test]
+async fn post_archive_drafts_requires_finished_commander_case_and_keeps_raw_material_out() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    context
+        .add_member(&case_id, COMMANDER, VOLUNTEER, "volunteer")
+        .await;
+    let clue_id = context.create_clue(&case_id, FAMILY).await;
+    let app = crate::init_api_app!(&context);
+    let commander_token = context.token(COMMANDER).await;
+
+    let active_case = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/archive-drafts"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_error(active_case, StatusCode::CONFLICT, "conflict").await;
+
+    let reviewed = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&format!("/api/clues/{clue_id}/review"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(json!({ "status": "confirmed", "reason": "fictional source verification" }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(reviewed.status(), StatusCode::OK);
+
+    let resolved = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&format!("/api/cases/{case_id}/status"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(json!({ "status": "resolved" }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(resolved.status(), StatusCode::OK);
+
+    let family = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/archive-drafts"))
+            .insert_header((
+                header::AUTHORIZATION,
+                format!("Bearer {}", context.token(FAMILY).await),
+            ))
+            .to_request(),
+    )
+    .await;
+    assert_error(family, StatusCode::FORBIDDEN, "forbidden").await;
+
+    let created = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/archive-drafts"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(created.status(), StatusCode::CREATED);
+    let created: serde_json::Value = test::read_body_json(created).await;
+    let draft_id = created["id"].as_str().expect("archive draft id");
+    assert_eq!(created["status"], "draft");
+    assert_eq!(created["deidentification_status"], "manual_review_required");
+    assert_eq!(
+        created["source_scope"],
+        json!(["confirmed_clue_metadata", "completed_task_metadata"])
+    );
+    assert!(created["provider_model"].is_null());
+    assert!(!created.to_string().contains("测试线索"));
+
+    let stored = archive_drafts::Entity::find_by_id(draft_id)
+        .one(&context.database)
+        .await
+        .expect("archive draft query should succeed")
+        .expect("archive draft should be persisted");
+    assert_eq!(stored.case_id, case_id);
+    assert!(!stored.content.contains("测试线索"));
+    assert!(!stored.content.contains("健康"));
+    let audit = audit_events::Entity::find()
+        .filter(audit_events::Column::EntityId.eq(draft_id))
+        .filter(audit_events::Column::Action.eq("archive_draft.created"))
+        .one(&context.database)
+        .await
+        .expect("archive audit query should succeed")
+        .expect("archive audit should be written");
+    assert!(!audit.metadata_json.unwrap_or_default().contains("测试线索"));
+
+    let hidden = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/archive-drafts"))
+            .insert_header((
+                header::AUTHORIZATION,
+                format!("Bearer {}", context.token(LEARNER).await),
+            ))
+            .to_request(),
+    )
+    .await;
+    assert_error(hidden, StatusCode::NOT_FOUND, "not_found").await;
+
+    let closed_case_id = context.create_case().await;
+    context
+        .add_member(&closed_case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    context.close_case(&closed_case_id).await;
+    let closed = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{closed_case_id}/archive-drafts"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(closed.status(), StatusCode::CREATED);
+}

--- a/tests/api/case_resources_post.rs
+++ b/tests/api/case_resources_post.rs
@@ -3,11 +3,11 @@ use actix_web::{
     test,
 };
 use angui::{
-    entities::case_places,
+    entities::{audit_events, case_places, clue_attachment_links},
     models::{CreateCasePlaceRequest, PlaceVisibility},
     services::case_resource_service,
 };
-use sea_orm::{ActiveModelTrait, EntityTrait, IntoActiveModel, Set};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, Set};
 use serde_json::json;
 
 use crate::support::{COMMANDER, FAMILY, LEARNER, TestContext, VOLUNTEER, assert_error};
@@ -451,4 +451,115 @@ async fn post_case_attachments_rejects_mismatched_or_non_image_content() {
         .await;
         assert_error(response, StatusCode::BAD_REQUEST, "validation_error").await;
     }
+}
+
+#[actix_web::test]
+async fn post_clue_attachments_links_evidence_atomically_and_enforces_submitter_scope() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    context
+        .add_member(&case_id, COMMANDER, VOLUNTEER, "volunteer")
+        .await;
+    let family_clue_id = context.create_clue(&case_id, FAMILY).await;
+    let volunteer_clue_id = context.create_clue(&case_id, VOLUNTEER).await;
+    let app = crate::init_api_app!(&context);
+    let png: [u8; 68] = [
+        137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 4,
+        0, 0, 0, 181, 28, 12, 2, 0, 0, 0, 11, 73, 68, 65, 84, 120, 218, 99, 100, 248, 15, 0, 1, 5,
+        1, 1, 39, 24, 227, 102, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+    ];
+    let upload = |clue_id: &str, token: &str, boundary: &str| {
+        let mut body = format!("--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"fictional-evidence.png\"\r\nContent-Type: image/png\r\n\r\n").into_bytes();
+        body.extend_from_slice(&png);
+        body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+        test::TestRequest::post()
+            .uri(&format!("/api/clues/{clue_id}/attachments"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .insert_header((
+                header::CONTENT_TYPE,
+                format!("multipart/form-data; boundary={boundary}"),
+            ))
+            .set_payload(body)
+            .to_request()
+    };
+
+    let family_token = context.token(FAMILY).await;
+    let uploaded = test::call_service(
+        &app,
+        upload(&family_clue_id, &family_token, "clue-attachment-family"),
+    )
+    .await;
+    assert_eq!(uploaded.status(), StatusCode::CREATED);
+    let uploaded: serde_json::Value = test::read_body_json(uploaded).await;
+    let attachment_id = uploaded["id"].as_str().expect("attachment id");
+    assert_eq!(uploaded["review_status"], "pending_review");
+    assert!(
+        clue_attachment_links::Entity::find()
+            .filter(clue_attachment_links::Column::ClueId.eq(&family_clue_id))
+            .filter(clue_attachment_links::Column::AttachmentId.eq(attachment_id))
+            .one(&context.database)
+            .await
+            .expect("attachment link query should succeed")
+            .is_some()
+    );
+    assert!(
+        audit_events::Entity::find()
+            .filter(audit_events::Column::EntityId.eq(attachment_id))
+            .filter(audit_events::Column::Action.eq("clue.attachment_submitted"))
+            .one(&context.database)
+            .await
+            .expect("attachment audit query should succeed")
+            .is_some()
+    );
+
+    let volunteer_token = context.token(VOLUNTEER).await;
+    let hidden = test::call_service(
+        &app,
+        upload(&family_clue_id, &volunteer_token, "clue-attachment-hidden"),
+    )
+    .await;
+    assert_error(hidden, StatusCode::NOT_FOUND, "not_found").await;
+
+    let commander_token = context.token(COMMANDER).await;
+    let commander_upload = test::call_service(
+        &app,
+        upload(
+            &volunteer_clue_id,
+            &commander_token,
+            "clue-attachment-commander",
+        ),
+    )
+    .await;
+    assert_eq!(commander_upload.status(), StatusCode::CREATED);
+    let commander_attachment: serde_json::Value = test::read_body_json(commander_upload).await;
+    let commander_attachment_id = commander_attachment["id"]
+        .as_str()
+        .expect("commander attachment id");
+    let family_cannot_download_internal_evidence = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!(
+                "/api/cases/{case_id}/attachments/{commander_attachment_id}"
+            ))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {family_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_error(
+        family_cannot_download_internal_evidence,
+        StatusCode::FORBIDDEN,
+        "forbidden",
+    )
+    .await;
+
+    context.close_case(&case_id).await;
+    let closed = test::call_service(
+        &app,
+        upload(&family_clue_id, &family_token, "clue-attachment-closed"),
+    )
+    .await;
+    assert_error(closed, StatusCode::CONFLICT, "conflict").await;
 }

--- a/tests/api/mod.rs
+++ b/tests/api/mod.rs
@@ -2,6 +2,7 @@ mod auth_login_post;
 mod auth_logout_post;
 mod auth_me_get;
 mod authentication_guards;
+mod case_archive_drafts_post;
 mod case_clues_get;
 mod case_clues_post;
 mod case_collaboration_get_post;

--- a/tests/api/openapi_intake_contract.rs
+++ b/tests/api/openapi_intake_contract.rs
@@ -292,6 +292,12 @@ fn case_collaboration_openapi_contract_covers_public_progress_drafts_and_pois() 
             "x-case-roles: [commander]",
             "#/components/schemas/ReviewSummaryDraftRequest",
         ),
+        (
+            "/api/cases/{case_id}/archive-drafts:\n",
+            "operationId: createCaseArchiveDraft",
+            "x-case-roles: [commander]",
+            "#/components/schemas/ArchiveDraft",
+        ),
     ] {
         let operation = operation(path);
         for expected in [operation_id, roles, schema_name] {
@@ -321,10 +327,37 @@ fn case_collaboration_openapi_contract_covers_public_progress_drafts_and_pois() 
             "rule_based_fallback",
         ],
     );
+    assert_schema_contains(
+        "ArchiveDraft",
+        &[
+            "enum: [draft]",
+            "source_scope:",
+            "manual_review_required",
+            "Internal deterministic draft content containing no raw case materials.",
+        ],
+    );
     let public_progress_item = schema("CasePublicProgressItem");
     assert!(public_progress_item.contains("progress_type:"));
     assert!(public_progress_item.contains("Raw clue text is never returned."));
     assert!(!public_progress_item.contains("content:"));
+}
+
+#[test]
+fn clue_attachment_openapi_contract_keeps_evidence_case_restricted() {
+    let attachment_operation = operation("/api/clues/{clue_id}/attachments:\n");
+    for expected in [
+        "operationId: uploadClueAttachment",
+        "x-case-roles: [family, commander, volunteer]",
+        "x-data-classification: case-restricted",
+        "multipart/form-data:",
+        "#/components/schemas/CaseAttachment",
+        "re-encodes the image to remove EXIF/GPS metadata",
+    ] {
+        assert!(
+            attachment_operation.contains(expected),
+            "OpenAPI clue attachment operation must declare {expected:?}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add atomic, pending-review JPEG/PNG evidence uploads for individual clues with submitter-scoped authorization, EXIF/GPS stripping, protected downloads, and audit records.
- Add commander-only internal archive drafts for resolved or closed cases, with explicit allowlisted source scope and mandatory de-identification review.
- Add SQLite, PostgreSQL, and MySQL archive-draft migrations with safe rollback protection, API contracts, and regression coverage.

## Validation
- cargo test --test api_contract
- cargo test -p migration --lib
- cargo clippy --all-targets -- -D warnings
- git diff --check

Closes #39
Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增受控归档草稿创建功能，仅适用于已解决或已关闭的案件。
  * 新增线索图片佐证上传功能，支持安全校验并自动移除 EXIF/GPS 信息。
  * 附件上传与审计记录采用原子提交，权限和案件状态限制更加明确。

* **文档**
  * 更新 API 与 OpenAPI 文档，补充新接口、响应结构及安全约束。

* **测试**
  * 新增归档草稿、线索附件权限、数据安全和接口契约覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->