### PR TITLE
feat(admin): add audited account management APIs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -42,6 +42,9 @@
 | `POST` | `/api/clues/{clue_id}/attachments` | `201` | 为具体线索上传待审核 JPEG/PNG 佐证图片 |
 | `POST` | `/api/cases/{case_id}/members` | `201` | 家属邀请指挥，或指挥添加案件成员 |
 | `PATCH` | `/api/clues/{clue_id}/review` | `200` | 人工审核线索 |
+| `GET` | `/api/admin/audit-events` | `200` | 管理员分页查看经过脱敏的审计事件 |
+| `GET` | `/api/admin/users` | `200` | 管理员分页查看不含凭据的账号状态 |
+| `PATCH` | `/api/admin/users/{user_id}/status` | `200` | 管理员启用、停用或锁定账号 |
 
 除健康检查和登录外，所有接口都要求：
 
@@ -272,3 +275,13 @@ Example:
 - `auth.logout`
 
 审计 actor 来自认证用户 ID。登录失败不会把邮箱或密码写入审计元数据；密码和 Bearer 令牌禁止进入日志。账号初始化 CLI 每次更新演示账号密码时会撤销该账号的既有会话。
+
+## 管理员账号管理
+
+`admin` 是平台级 capability，只授权 `/api/admin/*` 下的管理员接口；它不会自动成为任何案件的成员，也不会绕过案件级权限检查。管理员接口不提供创建、角色或 capability 变更功能。
+
+`GET /api/admin/audit-events` 支持按案件 ID、实体类型、事件 action、RFC 3339 时间范围以及白名单排序分页查询。响应只包含审计事件标识、关联案件/实体、操作人、事件类别和时间，不返回 `metadata_json`、原始请求内容或任何敏感业务详情；每次访问本身也会被审计。
+
+`GET /api/admin/users` 只返回账号 ID、邮箱、展示名、账号类型、全局 capability、状态、创建时间和最近会话时间。密码哈希、Bearer token、token 哈希、会话 ID、画像及案件资料绝不会通过该接口返回。筛选和排序参数均为服务端白名单。
+
+`PATCH /api/admin/users/{user_id}/status` 只接受 `active`、`disabled` 或 `locked`，并要求提供审核理由。将账号设为 `disabled` 或 `locked` 时，服务端在同一事务中撤销其全部活跃会话，因此既有 token 立即失效；重新设为 `active` 不会恢复已撤销的旧会话，用户必须重新登录。为避免管理员误锁自己，管理员不能修改自己的账号状态。审计仅记录操作人、变更前后状态、撤销会话数和理由长度，不保存理由原文或凭据。

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1269,6 +1269,80 @@ paths:
         "409": { $ref: "#/components/responses/Conflict" }
         "500": { $ref: "#/components/responses/InternalError" }
 
+  /api/admin/audit-events:
+    get:
+      tags: [Admin]
+      operationId: listAdminAuditEvents
+      summary: List sanitized audit events
+      description: Admin capability only. Supports bounded filtering by case, entity type, event action, and RFC 3339 time range. The response intentionally excludes metadata_json and all raw sensitive payloads. Every access is audited.
+      security: [{ bearerAuth: [] }]
+      x-account-types: [member]
+      x-global-capabilities: [admin]
+      x-data-classification: restricted-audit
+      parameters:
+        - { name: case_id, in: query, schema: { type: string, format: uuid } }
+        - { name: entity_type, in: query, schema: { type: string, maxLength: 128 } }
+        - { name: action, in: query, schema: { type: string, maxLength: 128 } }
+        - { name: from, in: query, schema: { type: string, format: date-time } }
+        - { name: to, in: query, schema: { type: string, format: date-time } }
+        - { name: page, in: query, schema: { type: integer, minimum: 1, default: 1 } }
+        - { name: page_size, in: query, schema: { type: integer, minimum: 1, maximum: 100, default: 25 } }
+        - { name: sort, in: query, schema: { type: string, enum: [created_at, action, entity_type], default: created_at } }
+        - { name: order, in: query, schema: { type: string, enum: [asc, desc], default: desc } }
+      responses:
+        "200": { description: Sanitized audit event page, content: { application/json: { schema: { $ref: "#/components/schemas/AdminAuditEventPage" } } } }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+
+  /api/admin/users:
+    get:
+      tags: [Admin]
+      operationId: listAdminUsers
+      summary: List account status without credentials
+      description: Admin capability only. Returns account identity, account type, global capabilities, status, creation time, and last session time. Password hashes, session tokens, profiles, and case data are never returned. Every access is audited.
+      security: [{ bearerAuth: [] }]
+      x-account-types: [member]
+      x-global-capabilities: [admin]
+      x-data-classification: restricted-admin
+      parameters:
+        - { name: account_type, in: query, schema: { type: string, enum: [member, learner] } }
+        - { name: status, in: query, schema: { type: string, enum: [active, disabled, locked] } }
+        - { name: page, in: query, schema: { type: integer, minimum: 1, default: 1 } }
+        - { name: page_size, in: query, schema: { type: integer, minimum: 1, maximum: 100, default: 25 } }
+        - { name: sort, in: query, schema: { type: string, enum: [created_at, email, last_session_at], default: created_at } }
+        - { name: order, in: query, schema: { type: string, enum: [asc, desc], default: desc } }
+      responses:
+        "200": { description: Sanitized account page, content: { application/json: { schema: { $ref: "#/components/schemas/AdminUserPage" } } } }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+
+  /api/admin/users/{user_id}/status:
+    parameters:
+      - name: user_id
+        in: path
+        required: true
+        schema: { type: string, format: uuid }
+    patch:
+      tags: [Admin]
+      operationId: updateAdminUserStatus
+      summary: Enable, disable, or lock an account
+      description: Admin capability only. Only active, disabled, and locked are accepted. Disabling or locking revokes every active session in the same transaction. The audit records actor, previous and next status, revocation count, and reason length; it never stores the reason text or credentials.
+      security: [{ bearerAuth: [] }]
+      x-account-types: [member]
+      x-global-capabilities: [admin]
+      x-data-classification: restricted-admin
+      requestBody:
+        required: true
+        content: { application/json: { schema: { $ref: "#/components/schemas/UpdateAdminUserStatusRequest" } } }
+      responses:
+        "200": { description: Updated sanitized account, content: { application/json: { schema: { $ref: "#/components/schemas/AdminUser" } } } }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
 components:
   securitySchemes:
     bearerAuth:
@@ -2603,6 +2677,61 @@ components:
         provider_model: { type: [string, "null"], description: Always null for the rule-based draft generator. }
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
+
+    UpdateAdminUserStatusRequest:
+      type: object
+      additionalProperties: false
+      required: [status, reason]
+      properties:
+        status: { type: string, enum: [active, disabled, locked] }
+        reason: { type: string, minLength: 1, maxLength: 1000 }
+
+    AdminUser:
+      type: object
+      additionalProperties: false
+      required: [id, email, display_name, account_type, global_capabilities, status, created_at, last_session_at]
+      properties:
+        id: { type: string, format: uuid }
+        email: { type: string, format: email }
+        display_name: { type: string }
+        account_type: { $ref: "#/components/schemas/AccountType" }
+        global_capabilities: { type: array, items: { $ref: "#/components/schemas/GlobalCapability" } }
+        status: { type: string, enum: [active, disabled, locked] }
+        created_at: { type: string, format: date-time }
+        last_session_at: { type: [string, "null"], format: date-time }
+
+    AdminUserPage:
+      type: object
+      additionalProperties: false
+      required: [items, page, page_size, total]
+      properties:
+        items: { type: array, items: { $ref: "#/components/schemas/AdminUser" } }
+        page: { type: integer, minimum: 1 }
+        page_size: { type: integer, minimum: 1, maximum: 100 }
+        total: { type: integer, minimum: 0 }
+
+    AdminAuditEvent:
+      type: object
+      additionalProperties: false
+      required: [id, case_id, actor_user_id, action, entity_type, entity_id, created_at]
+      properties:
+        id: { type: string, format: uuid }
+        case_id: { type: [string, "null"], format: uuid }
+        actor_user_id: { type: string, format: uuid }
+        action: { type: string }
+        entity_type: { type: string }
+        entity_id: { type: string }
+        created_at: { type: string, format: date-time }
+
+    AdminAuditEventPage:
+      type: object
+      additionalProperties: false
+      required: [items, page, page_size, total]
+      properties:
+        items: { type: array, items: { $ref: "#/components/schemas/AdminAuditEvent" } }
+        page: { type: integer, minimum: 1 }
+        page_size: { type: integer, minimum: 1, maximum: 100 }
+        total: { type: integer, minimum: 0 }
 
     CaseSummary:
       type: object

--- a/migration/sql/mysql/down/0026_remove_locked_user_status.sql
+++ b/migration/sql/mysql/down/0026_remove_locked_user_status.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users DROP CHECK users_status_check;
+-- statement-break
+ALTER TABLE users ADD CONSTRAINT users_status_check CHECK (status IN ('active', 'disabled'));

--- a/migration/sql/mysql/up/0026_add_locked_user_status.sql
+++ b/migration/sql/mysql/up/0026_add_locked_user_status.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users DROP CHECK users_chk_2;
+-- statement-break
+ALTER TABLE users ADD CONSTRAINT users_status_check CHECK (status IN ('active', 'disabled', 'locked'));

--- a/migration/sql/postgres/down/0026_remove_locked_user_status.sql
+++ b/migration/sql/postgres/down/0026_remove_locked_user_status.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_status_check;
+-- statement-break
+ALTER TABLE users ADD CONSTRAINT users_status_check CHECK (status IN ('active', 'disabled'));

--- a/migration/sql/postgres/up/0026_add_locked_user_status.sql
+++ b/migration/sql/postgres/up/0026_add_locked_user_status.sql
@@ -1,0 +1,3 @@
+ALTER TABLE users DROP CONSTRAINT IF EXISTS users_status_check;
+-- statement-break
+ALTER TABLE users ADD CONSTRAINT users_status_check CHECK (status IN ('active', 'disabled', 'locked'));

--- a/migration/sql/sqlite/down/0026_remove_locked_user_status.sql
+++ b/migration/sql/sqlite/down/0026_remove_locked_user_status.sql
@@ -1,0 +1,23 @@
+PRAGMA foreign_keys = OFF;
+-- statement-break
+CREATE TABLE users_without_locked_status (
+    id TEXT PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    display_name TEXT NOT NULL,
+    account_type TEXT NOT NULL CHECK (account_type IN ('member', 'learner')),
+    password_hash TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('active', 'disabled')),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+-- statement-break
+INSERT INTO users_without_locked_status (id, email, display_name, account_type, password_hash, status, created_at, updated_at)
+SELECT id, email, display_name, account_type, password_hash, status, created_at, updated_at FROM users;
+-- statement-break
+DROP TABLE users;
+-- statement-break
+ALTER TABLE users_without_locked_status RENAME TO users;
+-- statement-break
+CREATE INDEX idx_users_account_type_status ON users(account_type, status);
+-- statement-break
+PRAGMA foreign_keys = ON;

--- a/migration/sql/sqlite/up/0026_add_locked_user_status.sql
+++ b/migration/sql/sqlite/up/0026_add_locked_user_status.sql
@@ -1,0 +1,23 @@
+PRAGMA foreign_keys = OFF;
+-- statement-break
+CREATE TABLE users_with_locked_status (
+    id TEXT PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    display_name TEXT NOT NULL,
+    account_type TEXT NOT NULL CHECK (account_type IN ('member', 'learner')),
+    password_hash TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('active', 'disabled', 'locked')),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+-- statement-break
+INSERT INTO users_with_locked_status (id, email, display_name, account_type, password_hash, status, created_at, updated_at)
+SELECT id, email, display_name, account_type, password_hash, status, created_at, updated_at FROM users;
+-- statement-break
+DROP TABLE users;
+-- statement-break
+ALTER TABLE users_with_locked_status RENAME TO users;
+-- statement-break
+CREATE INDEX idx_users_account_type_status ON users(account_type, status);
+-- statement-break
+PRAGMA foreign_keys = ON;

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -25,6 +25,7 @@ mod m0022_create_summary_drafts;
 mod m0023_create_clue_drafts;
 mod m0024_enforce_single_published_summary_draft;
 mod m0025_create_archive_drafts;
+mod m0026_add_locked_user_status;
 
 use sea_orm_migration::sea_orm::{DbBackend, Statement};
 
@@ -59,6 +60,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0023_create_clue_drafts::Migration),
             Box::new(m0024_enforce_single_published_summary_draft::Migration),
             Box::new(m0025_create_archive_drafts::Migration),
+            Box::new(m0026_add_locked_user_status::Migration),
         ]
     }
 }
@@ -282,6 +284,21 @@ mod tests {
         ),
     ];
 
+    const LOCKED_USER_STATUS_SCRIPTS: &[(&str, &str)] = &[
+        (
+            "sqlite",
+            include_str!("../sql/sqlite/up/0026_add_locked_user_status.sql"),
+        ),
+        (
+            "postgres",
+            include_str!("../sql/postgres/up/0026_add_locked_user_status.sql"),
+        ),
+        (
+            "mysql",
+            include_str!("../sql/mysql/up/0026_add_locked_user_status.sql"),
+        ),
+    ];
+
     #[tokio::test]
     async fn sqlite_migrations_support_up_down_up() {
         let database = Database::connect("sqlite::memory:")
@@ -335,6 +352,44 @@ mod tests {
                 .expect("archive draft query should succeed")
                 .is_some()
         );
+    }
+
+    #[tokio::test]
+    async fn sqlite_locked_user_status_migration_enforces_and_preserves_locked_accounts() {
+        let database = Database::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite connection should succeed");
+        Migrator::up(&database, Some(25))
+            .await
+            .expect("schema before locked status migration should succeed");
+        insert_member_and_session(&database, "locked-account").await;
+        assert!(
+            database
+                .execute_unprepared(
+                    "UPDATE users SET status = 'locked' WHERE id = 'locked-account-user'",
+                )
+                .await
+                .is_err()
+        );
+
+        Migrator::up(&database, Some(1))
+            .await
+            .expect("locked status migration should succeed");
+        database
+            .execute_unprepared(
+                "UPDATE users SET status = 'locked' WHERE id = 'locked-account-user'",
+            )
+            .await
+            .expect("locked status should be accepted after migration");
+        assert!(Migrator::down(&database, Some(1)).await.is_err());
+        let locked = database
+            .query_one(Statement::from_string(
+                sea_orm_migration::sea_orm::DbBackend::Sqlite,
+                "SELECT 1 FROM users WHERE id = 'locked-account-user' AND status = 'locked'",
+            ))
+            .await
+            .expect("locked account query should succeed");
+        assert!(locked.is_some());
     }
 
     #[tokio::test]
@@ -891,6 +946,21 @@ mod tests {
                     "{name} archive draft schema must declare {required}"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn locked_user_status_is_constrained_across_dialects() {
+        for (name, script) in LOCKED_USER_STATUS_SCRIPTS {
+            let normalized = script.to_ascii_lowercase();
+            assert!(
+                normalized.contains("locked"),
+                "{name} must permit locked users"
+            );
+            assert!(
+                normalized.contains("status"),
+                "{name} must constrain user status"
+            );
         }
     }
 

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -299,6 +299,21 @@ mod tests {
         ),
     ];
 
+    const LOCKED_USER_STATUS_DOWN_SCRIPTS: &[(&str, &str)] = &[
+        (
+            "sqlite",
+            include_str!("../sql/sqlite/down/0026_remove_locked_user_status.sql"),
+        ),
+        (
+            "postgres",
+            include_str!("../sql/postgres/down/0026_remove_locked_user_status.sql"),
+        ),
+        (
+            "mysql",
+            include_str!("../sql/mysql/down/0026_remove_locked_user_status.sql"),
+        ),
+    ];
+
     #[tokio::test]
     async fn sqlite_migrations_support_up_down_up() {
         let database = Database::connect("sqlite::memory:")
@@ -951,16 +966,51 @@ mod tests {
 
     #[test]
     fn locked_user_status_is_constrained_across_dialects() {
-        for (name, script) in LOCKED_USER_STATUS_SCRIPTS {
-            let normalized = script.to_ascii_lowercase();
+        for ((name, up_script), (down_name, down_script)) in LOCKED_USER_STATUS_SCRIPTS
+            .iter()
+            .zip(LOCKED_USER_STATUS_DOWN_SCRIPTS)
+        {
+            assert_eq!(
+                name, down_name,
+                "up and down scripts must use the same dialect"
+            );
+            let up = up_script.to_ascii_lowercase();
+            let down = down_script.to_ascii_lowercase();
             assert!(
-                normalized.contains("locked"),
-                "{name} must permit locked users"
+                up.contains("check (status in ('active', 'disabled', 'locked'))"),
+                "{name} up migration must constrain users.status to active, disabled, and locked"
             );
             assert!(
-                normalized.contains("status"),
-                "{name} must constrain user status"
+                down.contains("check (status in ('active', 'disabled'))"),
+                "{name} down migration must restore the active/disabled users.status constraint"
             );
+            assert!(
+                !down.contains("'locked'"),
+                "{name} down migration must remove locked from the users.status constraint"
+            );
+            if *name == "sqlite" {
+                for (script_name, script, table_name) in [
+                    ("up", up.as_str(), "users_with_locked_status"),
+                    ("down", down.as_str(), "users_without_locked_status"),
+                ] {
+                    assert!(
+                        script.contains(&format!("create table {table_name}")),
+                        "sqlite {script_name} migration must rebuild users with its target status constraint"
+                    );
+                    assert!(
+                        script.contains("drop table users") && script.contains("rename to users"),
+                        "sqlite {script_name} migration must replace the users table"
+                    );
+                }
+            } else {
+                for (script_name, script) in [("up", up.as_str()), ("down", down.as_str())] {
+                    assert!(
+                        script.contains("alter table users")
+                            && script.contains("users_status_check"),
+                        "{name} {script_name} migration must replace the named users.status constraint"
+                    );
+                }
+            }
         }
     }
 

--- a/migration/src/m0026_add_locked_user_status.rs
+++ b/migration/src/m0026_add_locked_user_status.rs
@@ -1,0 +1,48 @@
+use sea_orm_migration::prelude::*;
+
+use crate::{ensure_rollback_is_safe, execute_script, sql_for_backend};
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m0026_add_locked_user_status"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        execute_script(
+            manager,
+            sql_for_backend(
+                manager,
+                include_str!("../sql/sqlite/up/0026_add_locked_user_status.sql"),
+                include_str!("../sql/postgres/up/0026_add_locked_user_status.sql"),
+                include_str!("../sql/mysql/up/0026_add_locked_user_status.sql"),
+            ),
+        )
+        .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        ensure_rollback_is_safe(
+            manager,
+            &[(
+                "locked users exist",
+                "SELECT 1 FROM users WHERE status = 'locked' LIMIT 1",
+            )],
+        )
+        .await?;
+        execute_script(
+            manager,
+            sql_for_backend(
+                manager,
+                include_str!("../sql/sqlite/down/0026_remove_locked_user_status.sql"),
+                include_str!("../sql/postgres/down/0026_remove_locked_user_status.sql"),
+                include_str!("../sql/mysql/down/0026_remove_locked_user_status.sql"),
+            ),
+        )
+        .await
+    }
+}

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -79,6 +79,77 @@ pub struct LoginResponse {
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
+pub struct AdminAuditEventQuery {
+    pub case_id: Option<String>,
+    pub entity_type: Option<String>,
+    pub action: Option<String>,
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub page: Option<u64>,
+    pub page_size: Option<u64>,
+    pub sort: Option<String>,
+    pub order: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AdminUserQuery {
+    pub account_type: Option<String>,
+    pub status: Option<String>,
+    pub page: Option<u64>,
+    pub page_size: Option<u64>,
+    pub sort: Option<String>,
+    pub order: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UpdateAdminUserStatusRequest {
+    pub status: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AdminAuditEventResponse {
+    pub id: String,
+    pub case_id: Option<String>,
+    pub actor_user_id: String,
+    pub action: String,
+    pub entity_type: String,
+    pub entity_id: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AdminAuditEventPage {
+    pub items: Vec<AdminAuditEventResponse>,
+    pub page: u64,
+    pub page_size: u64,
+    pub total: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AdminUserResponse {
+    pub id: String,
+    pub email: String,
+    pub display_name: String,
+    pub account_type: AccountType,
+    pub global_capabilities: Vec<GlobalCapability>,
+    pub status: String,
+    pub created_at: String,
+    pub last_session_at: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AdminUserPage {
+    pub items: Vec<AdminUserResponse>,
+    pub page: u64,
+    pub page_size: u64,
+    pub total: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CreateCaseRequest {
     pub display_name: String,
     pub age: Option<i16>,

--- a/src/api/routes/admin.rs
+++ b/src/api/routes/admin.rs
@@ -1,0 +1,51 @@
+use actix_web::{HttpResponse, web};
+
+use crate::{
+    app_state::AppState,
+    error::ApiError,
+    models::{
+        AdminAuditEventQuery, AdminUserQuery, AuthenticatedUser, UpdateAdminUserStatusRequest,
+    },
+    services::admin_service,
+};
+
+pub fn configure(config: &mut web::ServiceConfig) {
+    config.service(
+        web::scope("/admin")
+            .route("/audit-events", web::get().to(list_audit_events))
+            .route("/users", web::get().to(list_users))
+            .route(
+                "/users/{user_id}/status",
+                web::patch().to(update_user_status),
+            ),
+    );
+}
+
+async fn list_audit_events(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    query: web::Query<AdminAuditEventQuery>,
+) -> Result<HttpResponse, ApiError> {
+    Ok(HttpResponse::Ok()
+        .json(admin_service::list_audit_events(&state.db, &auth, query.into_inner()).await?))
+}
+
+async fn list_users(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    query: web::Query<AdminUserQuery>,
+) -> Result<HttpResponse, ApiError> {
+    Ok(HttpResponse::Ok()
+        .json(admin_service::list_users(&state.db, &auth, query.into_inner()).await?))
+}
+
+async fn update_user_status(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    user_id: web::Path<String>,
+    request: web::Json<UpdateAdminUserStatusRequest>,
+) -> Result<HttpResponse, ApiError> {
+    Ok(HttpResponse::Ok().json(
+        admin_service::update_user_status(&state.db, &auth, &user_id, request.into_inner()).await?,
+    ))
+}

--- a/src/api/routes/mod.rs
+++ b/src/api/routes/mod.rs
@@ -1,3 +1,4 @@
+mod admin;
 mod auth;
 mod cases;
 mod clues;
@@ -44,6 +45,7 @@ pub fn configure(config: &mut web::ServiceConfig) {
             .wrap(ApiSessionAuthentication)
             .service(health::get_health)
             .configure(auth::configure)
+            .configure(admin::configure)
             .configure(user_profiles::configure)
             .configure(cases::configure)
             .configure(intake_sessions::configure)

--- a/src/application/services/admin_service.rs
+++ b/src/application/services/admin_service.rs
@@ -1,0 +1,571 @@
+use std::collections::HashMap;
+
+use chrono::DateTime;
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, IntoActiveModel,
+    PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, Set, TransactionTrait,
+};
+use serde_json::json;
+
+use crate::{
+    entities::{audit_events, auth_sessions, user_global_capabilities, users},
+    error::ApiError,
+    models::{
+        AdminAuditEventPage, AdminAuditEventQuery, AdminAuditEventResponse, AdminUserPage,
+        AdminUserQuery, AdminUserResponse, AuthenticatedUser, UpdateAdminUserStatusRequest,
+    },
+    roles::{AccountType, GlobalCapability},
+    services::case_service,
+};
+
+const MAX_PAGE_SIZE: u64 = 100;
+const MAX_FILTER_LENGTH: usize = 128;
+const USER_STATUSES: &[&str] = &["active", "disabled", "locked"];
+
+pub async fn list_audit_events(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    query: AdminAuditEventQuery,
+) -> Result<AdminAuditEventPage, ApiError> {
+    require_admin(auth)?;
+    let query = ValidatedAuditQuery::try_from(query)?;
+    let transaction = db.begin().await?;
+    let mut records = audit_events::Entity::find();
+    if let Some(case_id) = &query.case_id {
+        records = records.filter(audit_events::Column::CaseId.eq(case_id));
+    }
+    if let Some(entity_type) = &query.entity_type {
+        records = records.filter(audit_events::Column::EntityType.eq(entity_type));
+    }
+    if let Some(action) = &query.action {
+        records = records.filter(audit_events::Column::Action.eq(action));
+    }
+    if let Some(from) = &query.from {
+        records = records.filter(audit_events::Column::CreatedAt.gte(from));
+    }
+    if let Some(to) = &query.to {
+        records = records.filter(audit_events::Column::CreatedAt.lte(to));
+    }
+    records = match query.sort.as_str() {
+        "created_at" => records.order_by(audit_events::Column::CreatedAt, query.order.clone()),
+        "action" => records.order_by(audit_events::Column::Action, query.order.clone()),
+        "entity_type" => records.order_by(audit_events::Column::EntityType, query.order.clone()),
+        _ => return Err(ApiError::Internal),
+    }
+    .order_by(audit_events::Column::Id, query.order.clone());
+    let total = records.clone().count(&transaction).await?;
+    let items = records
+        .offset(query.offset()?)
+        .limit(query.page_size)
+        .all(&transaction)
+        .await?
+        .into_iter()
+        .map(audit_event_response)
+        .collect();
+    write_admin_audit(
+        &transaction,
+        auth,
+        "admin.audit_events_listed",
+        "admin_audit_query",
+        auth.session_id.clone(),
+        json!({
+            "case_filter_applied": query.case_id.is_some(),
+            "entity_type_filter_applied": query.entity_type.is_some(),
+            "action_filter_applied": query.action.is_some(),
+            "time_range_filter_applied": query.from.is_some() || query.to.is_some(),
+            "page": query.page,
+            "page_size": query.page_size,
+            "sort": query.sort,
+            "order": order_name(&query.order),
+        }),
+    )
+    .await?;
+    transaction.commit().await?;
+    Ok(AdminAuditEventPage {
+        items,
+        page: query.page,
+        page_size: query.page_size,
+        total,
+    })
+}
+
+pub async fn list_users(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    query: AdminUserQuery,
+) -> Result<AdminUserPage, ApiError> {
+    require_admin(auth)?;
+    let query = ValidatedUserQuery::try_from(query)?;
+    let transaction = db.begin().await?;
+    let mut records = users::Entity::find();
+    if let Some(account_type) = &query.account_type {
+        records = records.filter(users::Column::AccountType.eq(account_type));
+    }
+    if let Some(status) = &query.status {
+        records = records.filter(users::Column::Status.eq(status));
+    }
+    let records = records.all(&transaction).await?;
+    let user_ids = records
+        .iter()
+        .map(|user| user.id.clone())
+        .collect::<Vec<_>>();
+    let capabilities = capabilities_for_users(&transaction, &user_ids).await?;
+    let last_sessions = last_sessions_for_users(&transaction, &user_ids).await?;
+    let mut items = records
+        .into_iter()
+        .map(|user| {
+            let user_id = user.id.clone();
+            admin_user_response(
+                user,
+                capabilities.get(&user_id).cloned().unwrap_or_default(),
+                last_sessions.get(&user_id).cloned(),
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    sort_users(&mut items, &query);
+    let total = u64::try_from(items.len()).map_err(|_| ApiError::Internal)?;
+    let offset = query.offset()?;
+    let end = offset
+        .saturating_add(query.page_size as usize)
+        .min(items.len());
+    let items = items
+        .into_iter()
+        .skip(offset)
+        .take(end.saturating_sub(offset))
+        .collect();
+    write_admin_audit(
+        &transaction,
+        auth,
+        "admin.users_listed",
+        "admin_user_query",
+        auth.session_id.clone(),
+        json!({
+            "account_type_filter_applied": query.account_type.is_some(),
+            "status_filter_applied": query.status.is_some(),
+            "page": query.page,
+            "page_size": query.page_size,
+            "sort": query.sort,
+            "order": order_name(&query.order),
+        }),
+    )
+    .await?;
+    transaction.commit().await?;
+    Ok(AdminUserPage {
+        items,
+        page: query.page,
+        page_size: query.page_size,
+        total,
+    })
+}
+
+pub async fn update_user_status(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    user_id: &str,
+    request: UpdateAdminUserStatusRequest,
+) -> Result<AdminUserResponse, ApiError> {
+    require_admin(auth)?;
+    let next_status = validate_status_change(&request)?;
+    if user_id == auth.id {
+        return Err(ApiError::Validation(
+            "an administrator cannot change their own account status".to_owned(),
+        ));
+    }
+    let transaction = db.begin().await?;
+    let existing = users::Entity::find_by_id(user_id)
+        .one(&transaction)
+        .await?
+        .ok_or_else(|| ApiError::NotFound("user was not found".to_owned()))?;
+    let previous_status = existing.status.clone();
+    let changed = previous_status != next_status;
+    if changed {
+        let mut active = existing.clone().into_active_model();
+        active.status = Set(next_status.clone());
+        active.updated_at = Set(now());
+        active.update(&transaction).await?;
+    }
+    let revoked_sessions = if next_status == "active" {
+        0
+    } else {
+        revoke_active_sessions(&transaction, user_id).await?
+    };
+    write_admin_audit(
+        &transaction,
+        auth,
+        "admin.user_status_changed",
+        "user",
+        user_id.to_owned(),
+        json!({
+            "previous_status": previous_status,
+            "next_status": next_status,
+            "changed": changed,
+            "revoked_session_count": revoked_sessions,
+            "reason_length": request.reason.trim().chars().count(),
+        }),
+    )
+    .await?;
+    transaction.commit().await?;
+    load_admin_user(db, user_id).await
+}
+
+fn require_admin(auth: &AuthenticatedUser) -> Result<(), ApiError> {
+    auth.global_capabilities
+        .contains(&GlobalCapability::Admin)
+        .then_some(())
+        .ok_or_else(|| {
+            ApiError::Forbidden("only administrators can perform this action".to_owned())
+        })
+}
+
+fn audit_event_response(model: audit_events::Model) -> AdminAuditEventResponse {
+    AdminAuditEventResponse {
+        id: model.id,
+        case_id: model.case_id,
+        actor_user_id: model.actor,
+        action: model.action,
+        entity_type: model.entity_type,
+        entity_id: model.entity_id,
+        created_at: model.created_at,
+    }
+}
+
+async fn load_admin_user(
+    db: &DatabaseConnection,
+    user_id: &str,
+) -> Result<AdminUserResponse, ApiError> {
+    let user = users::Entity::find_by_id(user_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| ApiError::NotFound("user was not found".to_owned()))?;
+    let capabilities = capabilities_for_users(db, std::slice::from_ref(&user.id)).await?;
+    let last_sessions = last_sessions_for_users(db, std::slice::from_ref(&user.id)).await?;
+    admin_user_response(
+        user.clone(),
+        capabilities.get(&user.id).cloned().unwrap_or_default(),
+        last_sessions.get(&user.id).cloned(),
+    )
+}
+
+async fn capabilities_for_users<C: sea_orm::ConnectionTrait>(
+    db: &C,
+    user_ids: &[String],
+) -> Result<HashMap<String, Vec<GlobalCapability>>, ApiError> {
+    if user_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let mut grouped = HashMap::<String, Vec<GlobalCapability>>::new();
+    for capability in user_global_capabilities::Entity::find()
+        .filter(user_global_capabilities::Column::UserId.is_in(user_ids.iter().cloned()))
+        .order_by_asc(user_global_capabilities::Column::Capability)
+        .all(db)
+        .await?
+    {
+        let parsed = GlobalCapability::try_from(capability.capability.as_str()).map_err(|error| {
+            ApiError::Database(sea_orm::DbErr::Custom(format!(
+                "user_global_capabilities.capability violates the capability constraint: {error}"
+            )))
+        })?;
+        grouped.entry(capability.user_id).or_default().push(parsed);
+    }
+    Ok(grouped)
+}
+
+async fn last_sessions_for_users<C: sea_orm::ConnectionTrait>(
+    db: &C,
+    user_ids: &[String],
+) -> Result<HashMap<String, String>, ApiError> {
+    if user_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    Ok(auth_sessions::Entity::find()
+        .filter(auth_sessions::Column::UserId.is_in(user_ids.iter().cloned()))
+        .order_by_desc(auth_sessions::Column::LastUsedAt)
+        .all(db)
+        .await?
+        .into_iter()
+        .fold(HashMap::new(), |mut latest, session| {
+            latest
+                .entry(session.user_id)
+                .or_insert(session.last_used_at);
+            latest
+        }))
+}
+
+fn admin_user_response(
+    user: users::Model,
+    global_capabilities: Vec<GlobalCapability>,
+    last_session_at: Option<String>,
+) -> Result<AdminUserResponse, ApiError> {
+    let account_type = AccountType::try_from(user.account_type.as_str()).map_err(|error| {
+        ApiError::Database(sea_orm::DbErr::Custom(format!(
+            "users.account_type violates the account type constraint: {error}"
+        )))
+    })?;
+    Ok(AdminUserResponse {
+        id: user.id,
+        email: user.email,
+        display_name: user.display_name,
+        account_type,
+        global_capabilities,
+        status: user.status,
+        created_at: user.created_at,
+        last_session_at,
+    })
+}
+
+async fn revoke_active_sessions<C: sea_orm::ConnectionTrait>(
+    db: &C,
+    user_id: &str,
+) -> Result<u64, ApiError> {
+    let result = auth_sessions::Entity::update_many()
+        .col_expr(
+            auth_sessions::Column::RevokedAt,
+            sea_orm::sea_query::Expr::value(now()),
+        )
+        .filter(auth_sessions::Column::UserId.eq(user_id))
+        .filter(auth_sessions::Column::RevokedAt.is_null())
+        .exec(db)
+        .await?;
+    Ok(result.rows_affected)
+}
+
+async fn write_admin_audit<C: sea_orm::ConnectionTrait>(
+    db: &C,
+    auth: &AuthenticatedUser,
+    action: &str,
+    entity_type: &str,
+    entity_id: String,
+    metadata: serde_json::Value,
+) -> Result<(), ApiError> {
+    case_service::write_audit(
+        db,
+        None,
+        auth,
+        action,
+        entity_type,
+        entity_id,
+        Some(metadata),
+    )
+    .await
+}
+
+fn validate_status_change(request: &UpdateAdminUserStatusRequest) -> Result<String, ApiError> {
+    let status = request.status.trim().to_lowercase();
+    if !USER_STATUSES.contains(&status.as_str()) {
+        return Err(ApiError::Validation("status is unsupported".to_owned()));
+    }
+    let reason = request.reason.trim();
+    if reason.is_empty() || reason.chars().count() > 1_000 {
+        return Err(ApiError::Validation(
+            "reason must contain between 1 and 1000 characters".to_owned(),
+        ));
+    }
+    Ok(status)
+}
+
+fn validate_identifier_filter(
+    label: &str,
+    value: Option<String>,
+) -> Result<Option<String>, ApiError> {
+    value
+        .map(|value| {
+            let value = value.trim().to_owned();
+            if value.is_empty()
+                || value.chars().count() > MAX_FILTER_LENGTH
+                || !value.chars().all(|character| {
+                    character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.')
+                })
+            {
+                return Err(ApiError::Validation(format!("{label} is invalid")));
+            }
+            Ok(value)
+        })
+        .transpose()
+}
+
+fn validate_timestamp_filter(
+    label: &str,
+    value: Option<String>,
+) -> Result<Option<String>, ApiError> {
+    value
+        .map(|value| {
+            let value = value.trim().to_owned();
+            DateTime::parse_from_rfc3339(&value).map_err(|_| {
+                ApiError::Validation(format!("{label} must be an RFC 3339 timestamp"))
+            })?;
+            Ok(value)
+        })
+        .transpose()
+}
+
+#[derive(Clone)]
+struct ValidatedAuditQuery {
+    case_id: Option<String>,
+    entity_type: Option<String>,
+    action: Option<String>,
+    from: Option<String>,
+    to: Option<String>,
+    page: u64,
+    page_size: u64,
+    sort: String,
+    order: sea_orm::Order,
+}
+
+impl ValidatedAuditQuery {
+    fn offset(&self) -> Result<u64, ApiError> {
+        self.page
+            .checked_sub(1)
+            .and_then(|page| page.checked_mul(self.page_size))
+            .ok_or_else(|| ApiError::Validation("page is too large".to_owned()))
+    }
+}
+
+impl TryFrom<AdminAuditEventQuery> for ValidatedAuditQuery {
+    type Error = ApiError;
+
+    fn try_from(value: AdminAuditEventQuery) -> Result<Self, Self::Error> {
+        let (page, page_size) = validate_pagination(value.page, value.page_size)?;
+        let sort = validate_sort(value.sort, &["created_at", "action", "entity_type"])?;
+        let order = validate_order(value.order)?;
+        let from = validate_timestamp_filter("from", value.from)?;
+        let to = validate_timestamp_filter("to", value.to)?;
+        if from
+            .as_ref()
+            .zip(to.as_ref())
+            .is_some_and(|(from, to)| from > to)
+        {
+            return Err(ApiError::Validation("from must not be after to".to_owned()));
+        }
+        Ok(Self {
+            case_id: validate_identifier_filter("case_id", value.case_id)?,
+            entity_type: validate_identifier_filter("entity_type", value.entity_type)?,
+            action: validate_identifier_filter("action", value.action)?,
+            from,
+            to,
+            page,
+            page_size,
+            sort,
+            order,
+        })
+    }
+}
+
+#[derive(Clone)]
+struct ValidatedUserQuery {
+    account_type: Option<String>,
+    status: Option<String>,
+    page: u64,
+    page_size: u64,
+    sort: String,
+    order: sea_orm::Order,
+}
+
+impl ValidatedUserQuery {
+    fn offset(&self) -> Result<usize, ApiError> {
+        let offset = self
+            .page
+            .checked_sub(1)
+            .and_then(|page| page.checked_mul(self.page_size))
+            .ok_or_else(|| ApiError::Validation("page is too large".to_owned()))?;
+        usize::try_from(offset).map_err(|_| ApiError::Validation("page is too large".to_owned()))
+    }
+}
+
+impl TryFrom<AdminUserQuery> for ValidatedUserQuery {
+    type Error = ApiError;
+
+    fn try_from(value: AdminUserQuery) -> Result<Self, Self::Error> {
+        let (page, page_size) = validate_pagination(value.page, value.page_size)?;
+        let account_type = value.account_type.map(|value| value.trim().to_lowercase());
+        if account_type
+            .as_deref()
+            .is_some_and(|value| !matches!(value, "member" | "learner"))
+        {
+            return Err(ApiError::Validation(
+                "account_type is unsupported".to_owned(),
+            ));
+        }
+        let status = value.status.map(|value| value.trim().to_lowercase());
+        if status
+            .as_deref()
+            .is_some_and(|value| !USER_STATUSES.contains(&value))
+        {
+            return Err(ApiError::Validation("status is unsupported".to_owned()));
+        }
+        Ok(Self {
+            account_type,
+            status,
+            page,
+            page_size,
+            sort: validate_sort(value.sort, &["created_at", "email", "last_session_at"])?,
+            order: validate_order(value.order)?,
+        })
+    }
+}
+
+fn validate_pagination(page: Option<u64>, page_size: Option<u64>) -> Result<(u64, u64), ApiError> {
+    let page = page.unwrap_or(1);
+    let page_size = page_size.unwrap_or(25);
+    if page == 0 {
+        return Err(ApiError::Validation("page must be at least 1".to_owned()));
+    }
+    if page_size == 0 || page_size > MAX_PAGE_SIZE {
+        return Err(ApiError::Validation(format!(
+            "page_size must be between 1 and {MAX_PAGE_SIZE}"
+        )));
+    }
+    Ok((page, page_size))
+}
+
+fn validate_sort(value: Option<String>, allowed: &[&str]) -> Result<String, ApiError> {
+    let sort = value
+        .unwrap_or_else(|| "created_at".to_owned())
+        .trim()
+        .to_lowercase();
+    allowed
+        .contains(&sort.as_str())
+        .then_some(sort)
+        .ok_or_else(|| ApiError::Validation("sort is unsupported".to_owned()))
+}
+
+fn validate_order(value: Option<String>) -> Result<sea_orm::Order, ApiError> {
+    match value
+        .unwrap_or_else(|| "desc".to_owned())
+        .trim()
+        .to_lowercase()
+        .as_str()
+    {
+        "asc" => Ok(sea_orm::Order::Asc),
+        "desc" => Ok(sea_orm::Order::Desc),
+        _ => Err(ApiError::Validation("order is unsupported".to_owned())),
+    }
+}
+
+fn order_name(order: &sea_orm::Order) -> &'static str {
+    match order {
+        sea_orm::Order::Asc => "asc",
+        sea_orm::Order::Desc => "desc",
+        sea_orm::Order::Field(_) => "field",
+    }
+}
+
+fn sort_users(items: &mut [AdminUserResponse], query: &ValidatedUserQuery) {
+    items.sort_by(|left, right| {
+        let primary = match query.sort.as_str() {
+            "created_at" => left.created_at.cmp(&right.created_at),
+            "email" => left.email.cmp(&right.email),
+            "last_session_at" => left.last_session_at.cmp(&right.last_session_at),
+            _ => std::cmp::Ordering::Equal,
+        };
+        let primary = if query.order == sea_orm::Order::Desc {
+            primary.reverse()
+        } else {
+            primary
+        };
+        primary.then_with(|| left.id.cmp(&right.id))
+    });
+}
+
+fn now() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}

--- a/src/application/services/admin_service.rs
+++ b/src/application/services/admin_service.rs
@@ -389,11 +389,12 @@ fn validate_timestamp_filter(
 ) -> Result<Option<String>, ApiError> {
     value
         .map(|value| {
-            let value = value.trim().to_owned();
-            DateTime::parse_from_rfc3339(&value).map_err(|_| {
+            let timestamp = DateTime::parse_from_rfc3339(value.trim()).map_err(|_| {
                 ApiError::Validation(format!("{label} must be an RFC 3339 timestamp"))
             })?;
-            Ok(value)
+            Ok(timestamp
+                .with_timezone(&chrono::Utc)
+                .to_rfc3339_opts(chrono::SecondsFormat::Millis, true))
         })
         .transpose()
 }
@@ -568,4 +569,44 @@ fn sort_users(items: &mut [AdminUserResponse], query: &ValidatedUserQuery) {
 
 fn now() -> String {
     chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ValidatedAuditQuery;
+    use crate::models::AdminAuditEventQuery;
+
+    fn audit_query(from: &str, to: &str) -> AdminAuditEventQuery {
+        AdminAuditEventQuery {
+            case_id: None,
+            entity_type: None,
+            action: None,
+            from: Some(from.to_owned()),
+            to: Some(to.to_owned()),
+            page: None,
+            page_size: None,
+            sort: None,
+            order: None,
+        }
+    }
+
+    #[test]
+    fn audit_time_filters_compare_canonical_utc_timestamps() {
+        let query = ValidatedAuditQuery::try_from(audit_query(
+            "2026-01-01T05:00:00+05:00",
+            "2026-01-01T00:30:00Z",
+        ))
+        .expect("chronologically ordered timestamps with different offsets should be accepted");
+        assert_eq!(query.from.as_deref(), Some("2026-01-01T00:00:00.000Z"));
+        assert_eq!(query.to.as_deref(), Some("2026-01-01T00:30:00.000Z"));
+
+        assert!(
+            ValidatedAuditQuery::try_from(audit_query(
+                "2026-01-01T00:30:00Z",
+                "2026-01-01T05:00:00+05:00",
+            ))
+            .is_err(),
+            "chronologically reversed timestamps must be rejected after UTC normalization"
+        );
+    }
 }

--- a/src/application/services/mod.rs
+++ b/src/application/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod admin_service;
 pub mod auth_service;
 pub mod case_collaboration_service;
 pub mod case_resource_service;

--- a/tests/api/admin_api.rs
+++ b/tests/api/admin_api.rs
@@ -6,7 +6,17 @@ use angui::entities::{audit_events, auth_sessions};
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use serde_json::{Value, json};
 
-use crate::support::{ADMIN, FAMILY, TestContext, VOLUNTEER, assert_error};
+use crate::support::{ADMIN, FAMILY, LEARNER, TestContext, VOLUNTEER, assert_error};
+
+fn assert_user_items_redact_credentials(response: &Value) {
+    let items = response["items"]
+        .as_array()
+        .expect("admin user response items should be an array");
+    for item in items {
+        assert!(item.get("password_hash").is_none());
+        assert!(item.get("token_hash").is_none());
+    }
+}
 
 #[actix_web::test]
 async fn admin_endpoints_enforce_capability_redact_data_and_revoke_disabled_sessions() {
@@ -30,7 +40,7 @@ async fn admin_endpoints_enforce_capability_redact_data_and_revoke_disabled_sess
     let users = test::call_service(
         &app,
         test::TestRequest::get()
-            .uri("/api/admin/users?status=active&sort=email&order=asc&page=1&page_size=3")
+            .uri("/api/admin/users?status=active&sort=email&order=asc&page=1&page_size=100")
             .insert_header((header::AUTHORIZATION, format!("Bearer {admin_token}")))
             .to_request(),
     )
@@ -38,20 +48,48 @@ async fn admin_endpoints_enforce_capability_redact_data_and_revoke_disabled_sess
     assert_eq!(users.status(), StatusCode::OK);
     let users: Value = test::read_body_json(users).await;
     assert_eq!(users["page"], 1);
-    assert_eq!(users["page_size"], 3);
+    assert_eq!(users["page_size"], 100);
     assert!(
         users["items"]
             .as_array()
-            .is_some_and(|items| !items.is_empty())
+            .is_some_and(|items| items.len() > 1),
+        "the active-user query should exercise redaction across multiple user entries"
     );
-    assert!(users.get("password_hash").is_none());
-    assert!(!users.to_string().contains("token_hash"));
+    assert_user_items_redact_credentials(&users);
     let family_entry = users["items"]
         .as_array()
         .and_then(|items| items.iter().find(|item| item["id"] == family.id))
         .expect("family user should be in the first page of demo accounts");
     assert_eq!(family_entry["status"], "active");
     assert!(family_entry["last_session_at"].is_string());
+
+    let learner_page = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/api/admin/users?account_type=learner&page_size=100")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {admin_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(learner_page.status(), StatusCode::OK);
+    let learner_page: Value = test::read_body_json(learner_page).await;
+    assert_eq!(learner_page["items"].as_array().map(Vec::len), Some(1));
+    assert_eq!(learner_page["items"][0]["email"], LEARNER);
+    assert_user_items_redact_credentials(&learner_page);
+
+    let locked_page = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/api/admin/users?status=locked&page_size=100")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {admin_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(locked_page.status(), StatusCode::OK);
+    let locked_page: Value = test::read_body_json(locked_page).await;
+    assert_eq!(locked_page["items"].as_array().map(Vec::len), Some(0));
+    assert_user_items_redact_credentials(&locked_page);
+
     assert!(
         audit_events::Entity::find()
             .filter(audit_events::Column::Action.eq("admin.users_listed"))

--- a/tests/api/admin_api.rs
+++ b/tests/api/admin_api.rs
@@ -1,0 +1,197 @@
+use actix_web::{
+    http::{StatusCode, header},
+    test,
+};
+use angui::entities::{audit_events, auth_sessions};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
+use serde_json::{Value, json};
+
+use crate::support::{ADMIN, FAMILY, TestContext, VOLUNTEER, assert_error};
+
+#[actix_web::test]
+async fn admin_endpoints_enforce_capability_redact_data_and_revoke_disabled_sessions() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    let family = context.authenticated(FAMILY).await;
+    let family_token = context.token(FAMILY).await;
+    let admin_token = context.token(ADMIN).await;
+    let app = crate::init_api_app!(&context);
+
+    let denied = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/api/admin/users")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {family_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_error(denied, StatusCode::FORBIDDEN, "forbidden").await;
+
+    let users = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/api/admin/users?status=active&sort=email&order=asc&page=1&page_size=3")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {admin_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(users.status(), StatusCode::OK);
+    let users: Value = test::read_body_json(users).await;
+    assert_eq!(users["page"], 1);
+    assert_eq!(users["page_size"], 3);
+    assert!(
+        users["items"]
+            .as_array()
+            .is_some_and(|items| !items.is_empty())
+    );
+    assert!(users.get("password_hash").is_none());
+    assert!(!users.to_string().contains("token_hash"));
+    let family_entry = users["items"]
+        .as_array()
+        .and_then(|items| items.iter().find(|item| item["id"] == family.id))
+        .expect("family user should be in the first page of demo accounts");
+    assert_eq!(family_entry["status"], "active");
+    assert!(family_entry["last_session_at"].is_string());
+    assert!(
+        audit_events::Entity::find()
+            .filter(audit_events::Column::Action.eq("admin.users_listed"))
+            .one(&context.database)
+            .await
+            .expect("admin users list audit query should succeed")
+            .is_some()
+    );
+
+    let audit_events_page = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/api/admin/audit-events?action=admin.users_listed&sort=created_at&order=desc")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {admin_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(audit_events_page.status(), StatusCode::OK);
+    let audit_events_page: Value = test::read_body_json(audit_events_page).await;
+    assert!(audit_events_page["items"].as_array().is_some_and(|items| {
+        items
+            .iter()
+            .all(|item| item["action"] == "admin.users_listed")
+    }));
+    assert!(
+        audit_events_page["items"]
+            .as_array()
+            .is_some_and(|items| items.iter().all(|item| item.get("metadata_json").is_none()))
+    );
+    assert!(
+        audit_events::Entity::find()
+            .filter(audit_events::Column::Action.eq("admin.audit_events_listed"))
+            .one(&context.database)
+            .await
+            .expect("admin audit event list access should be audited")
+            .is_some()
+    );
+
+    let admin_cannot_read_case = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/cases/{case_id}"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {admin_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_error(admin_cannot_read_case, StatusCode::NOT_FOUND, "not_found").await;
+
+    let invalid_status = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&format!("/api/admin/users/{}/status", family.id))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {admin_token}")))
+            .set_json(json!({ "status": "deleted", "reason": "fictional invalid transition" }))
+            .to_request(),
+    )
+    .await;
+    assert_error(invalid_status, StatusCode::BAD_REQUEST, "validation_error").await;
+
+    let disabled = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&format!("/api/admin/users/{}/status", family.id))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {admin_token}")))
+            .set_json(json!({ "status": "disabled", "reason": "fictional account review" }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(disabled.status(), StatusCode::OK);
+    let disabled: Value = test::read_body_json(disabled).await;
+    assert_eq!(disabled["status"], "disabled");
+    assert!(
+        auth_sessions::Entity::find()
+            .filter(auth_sessions::Column::UserId.eq(&family.id))
+            .filter(auth_sessions::Column::RevokedAt.is_null())
+            .one(&context.database)
+            .await
+            .expect("revoked family sessions query should succeed")
+            .is_none()
+    );
+    let disabled_token = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/api/auth/me")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {family_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_error(disabled_token, StatusCode::UNAUTHORIZED, "unauthorized").await;
+    let status_audit = audit_events::Entity::find()
+        .filter(audit_events::Column::EntityId.eq(&family.id))
+        .filter(audit_events::Column::Action.eq("admin.user_status_changed"))
+        .one(&context.database)
+        .await
+        .expect("status audit query should succeed")
+        .expect("status update should be audited");
+    let metadata = status_audit.metadata_json.expect("status audit metadata");
+    assert!(metadata.contains("previous_status"));
+    assert!(metadata.contains("reason_length"));
+    assert!(!metadata.contains("fictional account review"));
+
+    let reactivated = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&format!("/api/admin/users/{}/status", family.id))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {admin_token}")))
+            .set_json(json!({ "status": "active", "reason": "fictional reactivation" }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(reactivated.status(), StatusCode::OK);
+    let restored_token = context.token(FAMILY).await;
+    let locked = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&format!("/api/admin/users/{}/status", family.id))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {admin_token}")))
+            .set_json(json!({ "status": "locked", "reason": "fictional lock review" }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(locked.status(), StatusCode::OK);
+    let locked_token = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/cases")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {restored_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_error(locked_token, StatusCode::UNAUTHORIZED, "unauthorized").await;
+
+    let volunteer_token = context.token(VOLUNTEER).await;
+    let non_admin_audit = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/api/admin/audit-events")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {volunteer_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_error(non_admin_audit, StatusCode::FORBIDDEN, "forbidden").await;
+}

--- a/tests/api/admin_api.rs
+++ b/tests/api/admin_api.rs
@@ -23,6 +23,7 @@ async fn admin_endpoints_enforce_capability_redact_data_and_revoke_disabled_sess
     let context = TestContext::new().await;
     let case_id = context.create_case().await;
     let family = context.authenticated(FAMILY).await;
+    let admin = context.authenticated(ADMIN).await;
     let family_token = context.token(FAMILY).await;
     let admin_token = context.token(ADMIN).await;
     let app = crate::init_api_app!(&context);
@@ -148,6 +149,44 @@ async fn admin_endpoints_enforce_capability_redact_data_and_revoke_disabled_sess
     )
     .await;
     assert_error(invalid_status, StatusCode::BAD_REQUEST, "validation_error").await;
+
+    let empty_reason = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&format!("/api/admin/users/{}/status", family.id))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {admin_token}")))
+            .set_json(json!({ "status": "disabled", "reason": "   " }))
+            .to_request(),
+    )
+    .await;
+    assert_error(empty_reason, StatusCode::BAD_REQUEST, "validation_error").await;
+
+    let overlong_reason = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&format!("/api/admin/users/{}/status", family.id))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {admin_token}")))
+            .set_json(json!({ "status": "disabled", "reason": "x".repeat(1_001) }))
+            .to_request(),
+    )
+    .await;
+    assert_error(overlong_reason, StatusCode::BAD_REQUEST, "validation_error").await;
+
+    let self_status_change = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&format!("/api/admin/users/{}/status", admin.id))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {admin_token}")))
+            .set_json(json!({ "status": "disabled", "reason": "fictional self status change" }))
+            .to_request(),
+    )
+    .await;
+    assert_error(
+        self_status_change,
+        StatusCode::BAD_REQUEST,
+        "validation_error",
+    )
+    .await;
 
     let disabled = test::call_service(
         &app,

--- a/tests/api/authentication_guards.rs
+++ b/tests/api/authentication_guards.rs
@@ -40,6 +40,9 @@ async fn every_protected_endpoint_rejects_missing_and_invalid_bearer_tokens() {
     assert_unauthorized!(app, get, "/api/users/me/profile");
     assert_unauthorized!(app, patch, "/api/users/me/profile");
     assert_unauthorized!(app, post, "/api/auth/logout");
+    assert_unauthorized!(app, get, "/api/admin/audit-events");
+    assert_unauthorized!(app, get, "/api/admin/users");
+    assert_unauthorized!(app, patch, "/api/admin/users/not-used/status");
     assert_unauthorized!(app, get, "/api/cases");
     assert_unauthorized!(app, post, "/api/cases");
     assert_unauthorized!(app, get, "/api/cases/not-used");

--- a/tests/api/mod.rs
+++ b/tests/api/mod.rs
@@ -1,3 +1,4 @@
+mod admin_api;
 mod auth_login_post;
 mod auth_logout_post;
 mod auth_me_get;

--- a/tests/api/openapi_intake_contract.rs
+++ b/tests/api/openapi_intake_contract.rs
@@ -343,6 +343,78 @@ fn case_collaboration_openapi_contract_covers_public_progress_drafts_and_pois() 
 }
 
 #[test]
+fn admin_openapi_contract_limits_access_and_sensitive_fields() {
+    for (path, operation_id, schema_name, expected_parameters) in [
+        (
+            "/api/admin/audit-events:\n",
+            "operationId: listAdminAuditEvents",
+            "#/components/schemas/AdminAuditEventPage",
+            ["name: case_id", "name: from", "name: to", "name: sort"],
+        ),
+        (
+            "/api/admin/users:\n",
+            "operationId: listAdminUsers",
+            "#/components/schemas/AdminUserPage",
+            [
+                "name: status",
+                "name: account_type",
+                "name: sort",
+                "name: order",
+            ],
+        ),
+        (
+            "/api/admin/users/{user_id}/status:\n",
+            "operationId: updateAdminUserStatus",
+            "#/components/schemas/UpdateAdminUserStatusRequest",
+            [
+                "name: user_id",
+                "x-global-capabilities: [admin]",
+                "requestBody:",
+                "patch:",
+            ],
+        ),
+    ] {
+        let operation = operation(path);
+        for expected in [operation_id, "x-global-capabilities: [admin]", schema_name] {
+            assert!(
+                operation.contains(expected),
+                "OpenAPI operation {path} must declare {expected:?}"
+            );
+        }
+        for expected in expected_parameters {
+            assert!(
+                operation.contains(expected),
+                "OpenAPI operation {path} must declare {expected:?}"
+            );
+        }
+    }
+
+    let audit_event = schema("AdminAuditEvent");
+    assert!(!audit_event.contains("metadata_json"));
+    assert_schema_contains(
+        "AdminAuditEvent",
+        &["actor_user_id:", "action:", "entity_type:", "created_at:"],
+    );
+
+    let admin_user = schema("AdminUser");
+    assert!(!admin_user.contains("password_hash"));
+    assert!(!admin_user.contains("token_hash"));
+    assert_schema_contains(
+        "AdminUser",
+        &[
+            "global_capabilities:",
+            "status:",
+            "created_at:",
+            "last_session_at:",
+        ],
+    );
+    assert_schema_contains(
+        "UpdateAdminUserStatusRequest",
+        &["enum: [active, disabled, locked]", "reason:"],
+    );
+}
+
+#[test]
 fn clue_attachment_openapi_contract_keeps_evidence_case_restricted() {
     let attachment_operation = operation("/api/clues/{clue_id}/attachments:\n");
     for expected in [


### PR DESCRIPTION
## Summary
- Add admin-only, paginated audit-event and sanitized account listing APIs.
- Add transactional active/disabled/locked account status updates that revoke active sessions.
- Add safe SQLite, PostgreSQL, and MySQL locked-status migrations plus API/OpenAPI coverage.

## Validation
- cargo test -p migration --lib
- cargo clippy --all-targets -- -D warnings
- cargo test --test api_contract

Closes #53
Closes #61
Closes #62

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增管理员审计事件分页查询与脱敏筛选（支持限定条件与时间范围）。
  - 新增管理员用户列表查询（仅返回账户状态信息，隐藏敏感凭据与资料）。
  - 新增管理员对用户启用/停用/锁定的状态变更；停用/锁定会立即撤销全部活跃会话，启用不恢复旧会话，并生成审计记录。
- **文档**
  - 更新 API 文档与 OpenAPI：新增管理端点、请求/响应结构与字段可见性规则。
- **数据库与迁移**
  - 扩展用户状态约束，新增 `locked` 取值，并提供回滚能力。
- **测试**
  - 新增管理端到端与合约校验用例，覆盖鉴权、脱敏、审计落库与会话撤销行为。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->