### PR TITLE
style(frontend): format TSX and split long JSX

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,19 +1,19 @@
-import { render, screen, waitFor } from '@testing-library/react'
-import { MemoryRouter } from 'react-router'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import App from './App'
-import type { AuthContextValue } from './auth/auth-context'
-import type { GlobalCapability } from './api/auth'
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import App from "./App";
+import type { AuthContextValue } from "./auth/auth-context";
+import type { GlobalCapability } from "./api/auth";
 
 const mocked = vi.hoisted(() => ({
   auth: null as AuthContextValue | null,
   listCases: vi.fn().mockResolvedValue([]),
   getCase: vi.fn(),
   getCaseResourceConfiguration: vi.fn(),
-}))
+}));
 
-vi.mock('./auth/useAuth', () => ({ useAuth: () => mocked.auth }))
-vi.mock('./api/cases', () => ({
+vi.mock("./auth/useAuth", () => ({ useAuth: () => mocked.auth }));
+vi.mock("./api/cases", () => ({
   listCases: (...args: unknown[]) => mocked.listCases(...args),
   getCase: (...args: unknown[]) => mocked.getCase(...args),
   createCase: vi.fn(),
@@ -22,18 +22,27 @@ vi.mock('./api/cases', () => ({
   reviewClue: vi.fn(),
   updateCaseStatus: vi.fn(),
   updateElderProfile: vi.fn(),
-  getCaseResourceConfiguration: (...args: unknown[]) => mocked.getCaseResourceConfiguration(...args),
-}))
-vi.mock('./components/ServiceStatus', () => ({ ServiceStatus: () => <span>服务状态</span> }))
+  getCaseResourceConfiguration: (...args: unknown[]) =>
+    mocked.getCaseResourceConfiguration(...args),
+}));
+vi.mock("./components/ServiceStatus", () => ({
+  ServiceStatus: () => <span>服务状态</span>,
+}));
 
 function setAuth(
-  accountType: NonNullable<AuthContextValue['user']>['account_type'] | null,
+  accountType: NonNullable<AuthContextValue["user"]>["account_type"] | null,
   globalCapabilities: readonly GlobalCapability[] = [],
 ) {
   mocked.auth = {
-    token: accountType ? 'test-session' : null,
+    token: accountType ? "test-session" : null,
     user: accountType
-      ? { id: `${accountType}-1`, email: `${accountType}@demo.invalid`, display_name: '模拟用户', account_type: accountType, global_capabilities: [...globalCapabilities] }
+      ? {
+          id: `${accountType}-1`,
+          email: `${accountType}@demo.invalid`,
+          display_name: "模拟用户",
+          account_type: accountType,
+          global_capabilities: [...globalCapabilities],
+        }
       : null,
     isLoading: false,
     isLoggingOut: false,
@@ -41,65 +50,92 @@ function setAuth(
     login: vi.fn(),
     logout: vi.fn(),
     refreshUser: vi.fn(),
-  }
+  };
 }
 
-function renderApp(path = '/') {
-  return render(<MemoryRouter initialEntries={[path]}><App /></MemoryRouter>)
+function renderApp(path = "/") {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <App />
+    </MemoryRouter>,
+  );
 }
 
-describe('application role routing', () => {
+describe("application role routing", () => {
   beforeEach(() => {
-    mocked.listCases.mockResolvedValue([])
-    mocked.getCase.mockReset()
-  })
+    mocked.listCases.mockResolvedValue([]);
+    mocked.getCase.mockReset();
+  });
 
-  it('shows the login page without a session', () => {
-    setAuth(null)
-    renderApp()
-    expect(screen.getByText('账号登录')).toBeInTheDocument()
-  })
+  it("shows the login page without a session", () => {
+    setAuth(null);
+    renderApp();
+    expect(screen.getByText("账号登录")).toBeInTheDocument();
+  });
 
-  it('shows only operational workspaces that match the account capabilities', async () => {
-    setAuth('member', ['commander', 'volunteer'])
-    renderApp()
-    await waitFor(() => expect(screen.getByText('行动总览')).toBeInTheDocument())
-    for (const workspace of ['指挥端', '志愿者端']) {
-      expect(screen.getByRole('link', { name: workspace })).toBeInTheDocument()
+  it("shows only operational workspaces that match the account capabilities", async () => {
+    setAuth("member", ["commander", "volunteer"]);
+    renderApp();
+    await waitFor(() =>
+      expect(screen.getByText("行动总览")).toBeInTheDocument(),
+    );
+    for (const workspace of ["指挥端", "志愿者端"]) {
+      expect(screen.getByRole("link", { name: workspace })).toBeInTheDocument();
     }
-    expect(screen.queryByRole('link', { name: '家属端' })).not.toBeInTheDocument()
-  })
+    expect(
+      screen.queryByRole("link", { name: "家属端" }),
+    ).not.toBeInTheDocument();
+  });
 
-  it('redirects a commander away from the family workspace', async () => {
-    setAuth('member', ['commander'])
-    renderApp('/family')
-    expect(await screen.findByText('行动总览')).toBeInTheDocument()
-    expect(screen.queryByRole('link', { name: '家属端' })).not.toBeInTheDocument()
-  })
-
-  it.each([
-    ['/command', ['commander'], '案件列表'],
-    ['/volunteer', ['volunteer'], '我的任务'],
-    ['/family', [], '案件列表'],
-  ] as const)('allows an operational account with %s capability to open the workspace route', async (path, capabilities, pageName) => {
-    setAuth('member', capabilities)
-    renderApp(path)
-    expect(await screen.findByRole(path === '/volunteer' ? 'heading' : 'region', { name: pageName })).toBeInTheDocument()
-  })
+  it("redirects a commander away from the family workspace", async () => {
+    setAuth("member", ["commander"]);
+    renderApp("/family");
+    expect(await screen.findByText("行动总览")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "家属端" }),
+    ).not.toBeInTheDocument();
+  });
 
   it.each([
-    ['family account', [], '/command'],
-    ['volunteer account', ['volunteer'], '/command'],
-  ] as const)('redirects a %s away from the command workspace', async (_description, capabilities, path) => {
-    setAuth('member', capabilities)
-    renderApp(path)
-    expect(await screen.findByText('行动总览')).toBeInTheDocument()
-    expect(screen.queryByRole('link', { name: '指挥端' })).not.toBeInTheDocument()
-  })
+    ["/command", ["commander"], "案件列表"],
+    ["/volunteer", ["volunteer"], "我的任务"],
+    ["/family", [], "案件列表"],
+  ] as const)(
+    "allows an operational account with %s capability to open the workspace route",
+    async (path, capabilities, pageName) => {
+      setAuth("member", capabilities);
+      renderApp(path);
+      expect(
+        await screen.findByRole(path === "/volunteer" ? "heading" : "region", {
+          name: pageName,
+        }),
+      ).toBeInTheDocument();
+    },
+  );
 
-  it.each(['learner'] as const)('does not imply case access for %s accounts', async (role) => {
-    setAuth(role)
-    renderApp()
-    expect(await screen.findByText('新人账号暂未获得案件权限')).toBeInTheDocument()
-  })
-})
+  it.each([
+    ["family account", [], "/command"],
+    ["volunteer account", ["volunteer"], "/command"],
+  ] as const)(
+    "redirects a %s away from the command workspace",
+    async (_description, capabilities, path) => {
+      setAuth("member", capabilities);
+      renderApp(path);
+      expect(await screen.findByText("行动总览")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("link", { name: "指挥端" }),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  it.each(["learner"] as const)(
+    "does not imply case access for %s accounts",
+    async (role) => {
+      setAuth(role);
+      renderApp();
+      expect(
+        await screen.findByText("新人账号暂未获得案件权限"),
+      ).toBeInTheDocument();
+    },
+  );
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,43 +1,51 @@
-import { Spinner } from '@heroui/react'
-import { Navigate, Route, Routes } from 'react-router'
-import type { ReactNode } from 'react'
-import { useAuth } from './auth/useAuth'
-import { AppShell } from './components/AppShell'
-import { CaseWorkspacePage } from './pages/CaseWorkspacePage'
-import { DashboardPage } from './pages/DashboardPage'
-import { LoginPage } from './pages/LoginPage'
-import { ProfilePage } from './pages/ProfilePage'
-import { VolunteerWorkspacePage } from './pages/VolunteerWorkspacePage'
+import { Spinner } from "@heroui/react";
+import { Navigate, Route, Routes } from "react-router";
+import type { ReactNode } from "react";
+import { useAuth } from "./auth/useAuth";
+import { AppShell } from "./components/AppShell";
+import { CaseWorkspacePage } from "./pages/CaseWorkspacePage";
+import { DashboardPage } from "./pages/DashboardPage";
+import { LoginPage } from "./pages/LoginPage";
+import { ProfilePage } from "./pages/ProfilePage";
+import { VolunteerWorkspacePage } from "./pages/VolunteerWorkspacePage";
 
 function CaseRoleRoute({
   capability,
   familyOnly,
   children,
 }: {
-  capability?: 'commander' | 'volunteer'
-  familyOnly?: boolean
-  children: ReactNode
+  capability?: "commander" | "volunteer";
+  familyOnly?: boolean;
+  children: ReactNode;
 }) {
-  const { user } = useAuth()
-  const isFamilyOnlyMember = user?.account_type === 'member' && user.global_capabilities.length === 0
-  return user?.account_type === 'member' && (!capability || user.global_capabilities.includes(capability)) && (!familyOnly || isFamilyOnlyMember)
-    ? children
-    : <Navigate to="/" replace />
+  const { user } = useAuth();
+  const isFamilyOnlyMember =
+    user?.account_type === "member" && user.global_capabilities.length === 0;
+  return user?.account_type === "member" &&
+    (!capability || user.global_capabilities.includes(capability)) &&
+    (!familyOnly || isFamilyOnlyMember) ? (
+    children
+  ) : (
+    <Navigate to="/" replace />
+  );
 }
 
 function App() {
-  const { user, isLoading } = useAuth()
+  const { user, isLoading } = useAuth();
 
   if (isLoading) {
     return (
-      <main className="grid min-h-screen place-items-center bg-canvas" aria-label="正在恢复会话">
+      <main
+        className="grid min-h-screen place-items-center bg-canvas"
+        aria-label="正在恢复会话"
+      >
         <Spinner size="lg" />
       </main>
-    )
+    );
   }
 
   if (!user) {
-    return <LoginPage />
+    return <LoginPage />;
   }
 
   return (
@@ -72,7 +80,7 @@ function App() {
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,58 +1,65 @@
-import { apiRequest } from './client'
+import { apiRequest } from "./client";
 
-export type AccountType = 'member' | 'learner'
-export type GlobalCapability = 'commander' | 'volunteer' | 'admin'
+export type AccountType = "member" | "learner";
+export type GlobalCapability = "commander" | "volunteer" | "admin";
 
 export interface AuthUser {
-  id: string
-  email: string
-  display_name: string
-  account_type: AccountType
-  global_capabilities: GlobalCapability[]
+  id: string;
+  email: string;
+  display_name: string;
+  account_type: AccountType;
+  global_capabilities: GlobalCapability[];
 }
 
 export interface LoginResponse {
-  token: string
-  expires_at: string
-  user: AuthUser
+  token: string;
+  expires_at: string;
+  user: AuthUser;
 }
 
 export interface UserPreferences {
-  locale: 'zh-CN' | 'en-US'
-  reduced_motion: boolean
+  locale: "zh-CN" | "en-US";
+  reduced_motion: boolean;
 }
 
 export interface UserProfile extends AuthUser {
-  team_name: string | null
-  avatar_reference: string | null
-  preferences: UserPreferences
+  team_name: string | null;
+  avatar_reference: string | null;
+  preferences: UserPreferences;
 }
 
 export interface UpdateUserProfilePayload {
-  display_name?: string
-  avatar_reference?: string
-  preferences?: UserPreferences
+  display_name?: string;
+  avatar_reference?: string;
+  preferences?: UserPreferences;
 }
 
 export function login(email: string, password: string): Promise<LoginResponse> {
-  return apiRequest<LoginResponse>('/auth/login', {
-    method: 'POST',
+  return apiRequest<LoginResponse>("/auth/login", {
+    method: "POST",
     body: JSON.stringify({ email, password }),
-  })
+  });
 }
 
 export function getCurrentUser(token: string): Promise<AuthUser> {
-  return apiRequest<AuthUser>('/auth/me', {}, token)
+  return apiRequest<AuthUser>("/auth/me", {}, token);
 }
 
 export function logout(token: string): Promise<void> {
-  return apiRequest<void>('/auth/logout', { method: 'POST' }, token)
+  return apiRequest<void>("/auth/logout", { method: "POST" }, token);
 }
 
 export function getMyProfile(token: string): Promise<UserProfile> {
-  return apiRequest<UserProfile>('/users/me/profile', {}, token)
+  return apiRequest<UserProfile>("/users/me/profile", {}, token);
 }
 
-export function updateMyProfile(token: string, payload: UpdateUserProfilePayload): Promise<UserProfile> {
-  return apiRequest<UserProfile>('/users/me/profile', { method: 'PATCH', body: JSON.stringify(payload) }, token)
+export function updateMyProfile(
+  token: string,
+  payload: UpdateUserProfilePayload,
+): Promise<UserProfile> {
+  return apiRequest<UserProfile>(
+    "/users/me/profile",
+    { method: "PATCH", body: JSON.stringify(payload) },
+    token,
+  );
 }

--- a/frontend/src/api/cases.test.ts
+++ b/frontend/src/api/cases.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from "vitest";
 import {
   addCaseMember,
   createCase,
@@ -10,133 +10,174 @@ import {
   listCases,
   reviewClue,
   updateCaseStatus,
-} from './cases'
+} from "./cases";
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+    headers: { "Content-Type": "application/json" },
+  });
 }
 
 function requestOptions(call: unknown[]) {
-  return call[1] as RequestInit
+  return call[1] as RequestInit;
 }
 
-describe('case API contract', () => {
-  it('uses the documented collection and detail endpoints', async () => {
-    const fetchMock = vi.fn()
+describe("case API contract", () => {
+  it("uses the documented collection and detail endpoints", async () => {
+    const fetchMock = vi
+      .fn()
       .mockResolvedValueOnce(jsonResponse(200, []))
-      .mockResolvedValueOnce(jsonResponse(200, { id: 'case-1' }))
-    vi.stubGlobal('fetch', fetchMock)
+      .mockResolvedValueOnce(jsonResponse(200, { id: "case-1" }));
+    vi.stubGlobal("fetch", fetchMock);
 
-    await listCases('test-session')
-    await getCase('test-session', 'case-1')
+    await listCases("test-session");
+    await getCase("test-session", "case-1");
 
-    expect(fetchMock.mock.calls.map(([path]) => path)).toEqual(['/api/cases', '/api/cases/case-1'])
-  })
+    expect(fetchMock.mock.calls.map(([path]) => path)).toEqual([
+      "/api/cases",
+      "/api/cases/case-1",
+    ]);
+  });
 
-  it('uses the role-filtered map-view endpoint', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, { items: [] }))
-    vi.stubGlobal('fetch', fetchMock)
+  it("uses the role-filtered map-view endpoint", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(200, { items: [] }));
+    vi.stubGlobal("fetch", fetchMock);
 
-    await getCaseMapView('test-session', 'case-1')
+    await getCaseMapView("test-session", "case-1");
 
-    expect(fetchMock.mock.calls[0][0]).toBe('/api/cases/case-1/map-view')
-  })
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/cases/case-1/map-view");
+  });
 
-  it('passes queue filters and pagination to the documented clue timeline endpoint', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(200, { items: [], page: 2, page_size: 25, total: 26 }))
-    vi.stubGlobal('fetch', fetchMock)
+  it("passes queue filters and pagination to the documented clue timeline endpoint", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse(200, { items: [], page: 2, page_size: 25, total: 26 }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
 
-    await listCaseClues('test-session', 'case-1', {
+    await listCaseClues("test-session", "case-1", {
       page: 2,
       page_size: 25,
-      status: 'pending_review',
-      source_type: 'field_report',
-      sort: 'occurred_at',
-      order: 'asc',
-    })
+      status: "pending_review",
+      source_type: "field_report",
+      sort: "occurred_at",
+      order: "asc",
+    });
 
-    expect(fetchMock.mock.calls[0][0]).toBe('/api/cases/case-1/clues?page=2&page_size=25&status=pending_review&source_type=field_report&sort=occurred_at&order=asc')
-  })
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "/api/cases/case-1/clues?page=2&page_size=25&status=pending_review&source_type=field_report&sort=occurred_at&order=asc",
+    );
+  });
 
-  it('sends a documented case creation request', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(201, { id: 'case-1' }))
-    vi.stubGlobal('fetch', fetchMock)
+  it("sends a documented case creation request", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(201, { id: "case-1" }));
+    vi.stubGlobal("fetch", fetchMock);
 
-    await createCase('test-session', {
-      display_name: '模拟老人 A',
+    await createCase("test-session", {
+      display_name: "模拟老人 A",
       age: 76,
       gender: null,
       physical_description: null,
       clothing_description: null,
       health_notes: null,
       last_seen_at: null,
-      last_seen_location: '模拟公园北门',
-    })
+      last_seen_location: "模拟公园北门",
+    });
 
-    const [path, options] = fetchMock.mock.calls[0]
-    expect(path).toBe('/api/cases')
-    expect(requestOptions([path, options]).method).toBe('POST')
-    expect(JSON.parse(String(requestOptions([path, options]).body))).toMatchObject({
-      display_name: '模拟老人 A',
-      last_seen_location: '模拟公园北门',
-    })
-  })
+    const [path, options] = fetchMock.mock.calls[0];
+    expect(path).toBe("/api/cases");
+    expect(requestOptions([path, options]).method).toBe("POST");
+    expect(
+      JSON.parse(String(requestOptions([path, options]).body)),
+    ).toMatchObject({
+      display_name: "模拟老人 A",
+      last_seen_location: "模拟公园北门",
+    });
+  });
 
-  it('sends member, clue, review, and status mutations to their documented endpoints', async () => {
-    const fetchMock = vi.fn()
-      .mockResolvedValueOnce(jsonResponse(201, { user_id: 'member-1' }))
-      .mockResolvedValueOnce(jsonResponse(201, { id: 'clue-1' }))
-      .mockResolvedValueOnce(jsonResponse(200, { id: 'clue-1', status: 'confirmed' }))
-      .mockResolvedValueOnce(jsonResponse(200, { id: 'case-1', status: 'resolved' }))
-    vi.stubGlobal('fetch', fetchMock)
+  it("sends member, clue, review, and status mutations to their documented endpoints", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(201, { user_id: "member-1" }))
+      .mockResolvedValueOnce(jsonResponse(201, { id: "clue-1" }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, { id: "clue-1", status: "confirmed" }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, { id: "case-1", status: "resolved" }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
 
-    await addCaseMember('test-session', 'case-1', 'volunteer@demo.invalid', 'volunteer')
-    await createClue('test-session', 'case-1', {
-      source: 'volunteer',
-      content: '模拟线索',
+    await addCaseMember(
+      "test-session",
+      "case-1",
+      "volunteer@demo.invalid",
+      "volunteer",
+    );
+    await createClue("test-session", "case-1", {
+      source: "volunteer",
+      content: "模拟线索",
       occurred_at: null,
       location_text: null,
-    })
-    await reviewClue('test-session', 'clue-1', { status: 'confirmed', reason: 'Reviewed source record' })
-    await updateCaseStatus('test-session', 'case-1', 'resolved')
+    });
+    await reviewClue("test-session", "clue-1", {
+      status: "confirmed",
+      reason: "Reviewed source record",
+    });
+    await updateCaseStatus("test-session", "case-1", "resolved");
 
     expect(fetchMock.mock.calls.map(([path]) => path)).toEqual([
-      '/api/cases/case-1/members',
-      '/api/cases/case-1/clues',
-      '/api/clues/clue-1/review',
-      '/api/cases/case-1/status',
-    ])
-    expect(fetchMock.mock.calls.map(requestOptions).map((options) => options.method)).toEqual([
-      'POST',
-      'POST',
-      'PATCH',
-      'PATCH',
-    ])
+      "/api/cases/case-1/members",
+      "/api/cases/case-1/clues",
+      "/api/clues/clue-1/review",
+      "/api/cases/case-1/status",
+    ]);
     expect(
-      fetchMock.mock.calls.map((call) => JSON.parse(String(requestOptions(call).body))),
+      fetchMock.mock.calls.map(requestOptions).map((options) => options.method),
+    ).toEqual(["POST", "POST", "PATCH", "PATCH"]);
+    expect(
+      fetchMock.mock.calls.map((call) =>
+        JSON.parse(String(requestOptions(call).body)),
+      ),
     ).toEqual([
-      { email: 'volunteer@demo.invalid', case_role: 'volunteer' },
-      { source: 'volunteer', content: '模拟线索', occurred_at: null, location_text: null },
-      { status: 'confirmed', reason: 'Reviewed source record' },
-      { status: 'resolved' },
-    ])
-  })
+      { email: "volunteer@demo.invalid", case_role: "volunteer" },
+      {
+        source: "volunteer",
+        content: "模拟线索",
+        occurred_at: null,
+        location_text: null,
+      },
+      { status: "confirmed", reason: "Reviewed source record" },
+      { status: "resolved" },
+    ]);
+  });
 
-  it('preserves an explicit empty summary draft content so the server can reject it', async () => {
-    const fetchMock = vi.fn()
-      .mockResolvedValueOnce(jsonResponse(201, { id: 'summary-1' }))
-      .mockResolvedValueOnce(jsonResponse(400, { error: { code: 'validation_error', message: 'content is required' } }))
-    vi.stubGlobal('fetch', fetchMock)
+  it("preserves an explicit empty summary draft content so the server can reject it", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(201, { id: "summary-1" }))
+      .mockResolvedValueOnce(
+        jsonResponse(400, {
+          error: { code: "validation_error", message: "content is required" },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
 
-    await createSummaryDraft('test-session', 'case-1')
-    await expect(createSummaryDraft('test-session', 'case-1', '')).rejects.toMatchObject({ status: 400 })
+    await createSummaryDraft("test-session", "case-1");
+    await expect(
+      createSummaryDraft("test-session", "case-1", ""),
+    ).rejects.toMatchObject({ status: 400 });
 
-    expect(fetchMock.mock.calls.map((call) => JSON.parse(String(requestOptions(call).body)))).toEqual([
-      {},
-      { content: '' },
-    ])
-  })
-})
+    expect(
+      fetchMock.mock.calls.map((call) =>
+        JSON.parse(String(requestOptions(call).body)),
+      ),
+    ).toEqual([{}, { content: "" }]);
+  });
+});

--- a/frontend/src/api/cases.ts
+++ b/frontend/src/api/cases.ts
@@ -1,259 +1,449 @@
-import { ApiClientError, apiRequest } from './client'
-import type { AccountType, GlobalCapability } from './auth'
+import { ApiClientError, apiRequest } from "./client";
+import type { AccountType, GlobalCapability } from "./auth";
 
-export type CaseRole = 'family' | 'commander' | 'volunteer'
-export type CaseStatus = 'active' | 'resolved' | 'closed'
+export type CaseRole = "family" | "commander" | "volunteer";
+export type CaseStatus = "active" | "resolved" | "closed";
 export type ClueReviewStatus =
-  | 'needs_verification'
-  | 'confirmed'
-  | 'rejected'
-  | 'expired'
-  | 'duplicate'
-  | 'conflicting'
-  | 'insufficient_information'
-export type ClueStatus = 'pending_review' | ClueReviewStatus
-export type ClueSourceType = 'manual_report' | 'field_report' | 'chat_draft' | 'ai_draft'
-export type PublicClueSourceType = 'manual_report' | 'field_report'
-export type LocationPrecision = 'exact' | 'approximate' | 'unknown'
+  | "needs_verification"
+  | "confirmed"
+  | "rejected"
+  | "expired"
+  | "duplicate"
+  | "conflicting"
+  | "insufficient_information";
+export type ClueStatus = "pending_review" | ClueReviewStatus;
+export type ClueSourceType =
+  "manual_report" | "field_report" | "chat_draft" | "ai_draft";
+export type PublicClueSourceType = "manual_report" | "field_report";
+export type LocationPrecision = "exact" | "approximate" | "unknown";
 
 export interface CaseListItem {
-  id: string
-  case_code: string
-  status: CaseStatus
-  access_role: CaseRole
-  display_name: string
-  last_seen_at: string | null
-  last_seen_location: string | null
-  created_at: string
-  updated_at: string
+  id: string;
+  case_code: string;
+  status: CaseStatus;
+  access_role: CaseRole;
+  display_name: string;
+  last_seen_at: string | null;
+  last_seen_location: string | null;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface ElderProfile {
-  id: string
-  display_name: string
-  age: number | null
-  gender: string | null
-  physical_description: string | null
-  clothing_description: string | null
-  health_notes: string | null
-  last_seen_at: string | null
-  last_seen_location: string | null
+  id: string;
+  display_name: string;
+  age: number | null;
+  gender: string | null;
+  physical_description: string | null;
+  clothing_description: string | null;
+  health_notes: string | null;
+  last_seen_at: string | null;
+  last_seen_location: string | null;
 }
 
 export interface Clue {
-  id: string
-  case_id: string
-  status: ClueStatus
-  source: string
-  source_type: ClueSourceType
-  content: string
-  raw_record_reference: string | null
-  occurred_at: string | null
-  reported_at: string
-  confirmed_at: string | null
-  location_text: string | null
-  location_precision: LocationPrecision | null
-  next_action: string | null
-  linked_task_reference: string | null
-  related_clue_id: string | null
-  relationship_type: 'duplicate_of' | 'conflicts_with' | null
-  review_reason: string | null
-  attachment_ids: string[]
-  created_at: string
-  updated_at: string
-  reviewed_at: string | null
-  is_own_submission: boolean
+  id: string;
+  case_id: string;
+  status: ClueStatus;
+  source: string;
+  source_type: ClueSourceType;
+  content: string;
+  raw_record_reference: string | null;
+  occurred_at: string | null;
+  reported_at: string;
+  confirmed_at: string | null;
+  location_text: string | null;
+  location_precision: LocationPrecision | null;
+  next_action: string | null;
+  linked_task_reference: string | null;
+  related_clue_id: string | null;
+  relationship_type: "duplicate_of" | "conflicts_with" | null;
+  review_reason: string | null;
+  attachment_ids: string[];
+  created_at: string;
+  updated_at: string;
+  reviewed_at: string | null;
+  is_own_submission: boolean;
 }
 
 export interface ClueTimelineQuery {
-  page?: number
-  page_size?: number
-  status?: ClueStatus
-  source_type?: ClueSourceType
-  sort?: 'created_at' | 'occurred_at'
-  order?: 'asc' | 'desc'
+  page?: number;
+  page_size?: number;
+  status?: ClueStatus;
+  source_type?: ClueSourceType;
+  sort?: "created_at" | "occurred_at";
+  order?: "asc" | "desc";
 }
 
 export interface ClueTimelinePage {
-  items: Clue[]
-  page: number
-  page_size: number
-  total: number
+  items: Clue[];
+  page: number;
+  page_size: number;
+  total: number;
 }
 
 export interface CaseDetail {
-  id: string
-  case_code: string
-  status: CaseStatus
-  access_role: CaseRole
-  family_contact_emails?: string[]
-  elder_profile: ElderProfile
-  clues: Clue[]
-  places: CasePlace[]
-  attachments: CaseAttachment[]
-  created_at: string
-  updated_at: string
+  id: string;
+  case_code: string;
+  status: CaseStatus;
+  access_role: CaseRole;
+  family_contact_emails?: string[];
+  elder_profile: ElderProfile;
+  clues: Clue[];
+  places: CasePlace[];
+  attachments: CaseAttachment[];
+  created_at: string;
+  updated_at: string;
 }
 
-export type PlaceType = string
-export type PlaceVisibility = 'public' | 'confirmed' | 'internal'
+export type PlaceType = string;
+export type PlaceVisibility = "public" | "confirmed" | "internal";
 
 export interface CasePlace {
-  id: string
-  case_id: string
-  name: string
-  place_type: PlaceType
-  address: string
-  longitude: number | null
-  latitude: number | null
-  source: CaseRole
-  visibility: PlaceVisibility
-  review_status: 'pending_review' | 'confirmed' | 'rejected'
-  created_at: string
-  updated_at: string
-  is_own_submission: boolean
+  id: string;
+  case_id: string;
+  name: string;
+  place_type: PlaceType;
+  address: string;
+  longitude: number | null;
+  latitude: number | null;
+  source: CaseRole;
+  visibility: PlaceVisibility;
+  review_status: "pending_review" | "confirmed" | "rejected";
+  created_at: string;
+  updated_at: string;
+  is_own_submission: boolean;
 }
 
 export interface CaseAttachment {
-  id: string
-  case_id: string
-  original_filename: string
-  content_type: 'image/jpeg' | 'image/png'
-  byte_size: number
-  source: string
-  review_status: 'pending_review' | 'confirmed' | 'rejected'
-  created_at: string
-  updated_at: string
-  is_own_submission: boolean
+  id: string;
+  case_id: string;
+  original_filename: string;
+  content_type: "image/jpeg" | "image/png";
+  byte_size: number;
+  source: string;
+  review_status: "pending_review" | "confirmed" | "rejected";
+  created_at: string;
+  updated_at: string;
+  is_own_submission: boolean;
 }
 
 export interface CreateCasePlacePayload {
-  name: string
-  place_type: PlaceType
-  address: string
-  longitude: number | null
-  latitude: number | null
-  visibility: PlaceVisibility
+  name: string;
+  place_type: PlaceType;
+  address: string;
+  longitude: number | null;
+  latitude: number | null;
+  visibility: PlaceVisibility;
 }
 
 export interface CaseResourceConfiguration {
-  attachment_max_image_bytes: number
-  attachment_max_per_case: number
-  case_place_types: string[]
+  attachment_max_image_bytes: number;
+  attachment_max_per_case: number;
+  case_place_types: string[];
 }
 
 export interface CreateCasePayload {
-  display_name: string
-  age: number | null
-  gender: string | null
-  physical_description: string | null
-  clothing_description: string | null
-  health_notes: string | null
-  last_seen_at: string | null
-  last_seen_location: string | null
+  display_name: string;
+  age: number | null;
+  gender: string | null;
+  physical_description: string | null;
+  clothing_description: string | null;
+  health_notes: string | null;
+  last_seen_at: string | null;
+  last_seen_location: string | null;
 }
 
 export interface UpdateElderProfilePayload {
-  display_name?: string
-  age?: number
-  gender?: string
-  physical_description?: string
-  clothing_description?: string
-  health_notes?: string
-  last_seen_at?: string
-  last_seen_location?: string
+  display_name?: string;
+  age?: number;
+  gender?: string;
+  physical_description?: string;
+  clothing_description?: string;
+  health_notes?: string;
+  last_seen_at?: string;
+  last_seen_location?: string;
 }
 
 export interface CaseMember {
-  user_id: string
-  email: string
-  display_name: string
-  account_type: AccountType
-  global_capabilities: GlobalCapability[]
-  case_role: CaseRole
+  user_id: string;
+  email: string;
+  display_name: string;
+  account_type: AccountType;
+  global_capabilities: GlobalCapability[];
+  case_role: CaseRole;
 }
 
 export interface CreateCluePayload {
-  source: string
-  content: string
-  occurred_at: string | null
-  location_text: string | null
-  source_type?: PublicClueSourceType
-  raw_record_reference?: string | null
-  location_precision?: LocationPrecision | null
-  next_action?: string | null
-  linked_task_reference?: string | null
-  attachment_ids?: string[]
+  source: string;
+  content: string;
+  occurred_at: string | null;
+  location_text: string | null;
+  source_type?: PublicClueSourceType;
+  raw_record_reference?: string | null;
+  location_precision?: LocationPrecision | null;
+  next_action?: string | null;
+  linked_task_reference?: string | null;
+  attachment_ids?: string[];
 }
 
 export interface ReviewCluePayload {
-  status: ClueReviewStatus
-  reason: string
-  related_clue_id?: string | null
-  relationship_type?: 'duplicate_of' | 'conflicts_with' | null
-  next_action?: string | null
-  linked_task_reference?: string | null
+  status: ClueReviewStatus;
+  reason: string;
+  related_clue_id?: string | null;
+  relationship_type?: "duplicate_of" | "conflicts_with" | null;
+  next_action?: string | null;
+  linked_task_reference?: string | null;
 }
 
-export interface PublicProgressItem { clue_id: string; progress_type: 'confirmed_update' | 'family_follow_up'; review_status: string; updated_at: string }
-export interface CasePublicProgress { case_id: string; status: CaseStatus; generated_at: string; confirmed_progress: PublicProgressItem[]; requested_family_information: PublicProgressItem[]; safety_and_contact_reminders: string[] }
-export interface ClueDraft { id: string; case_id: string; status: 'draft' | 'pending_review'; content: string; source_type: PublicClueSourceType; raw_record_reference: string | null; occurred_at: string | null; location_text: string | null; uncertainty_notice: string; template_version: string; provider_model: string | null; degradation_status: string }
-export interface SummaryDraft { id: string; case_id: string; status: 'draft' | 'pending_review' | 'published' | 'rejected' | 'withdrawn' | 'superseded'; content: string; source_scope: string[]; template_version: string; provider_model: string | null; generated_at: string; reviewed_at: string | null; review_reason: string | null; created_at: string; updated_at: string; publication_eligible: boolean }
-export interface CasePoi { id: string; name: string; category: string; address: string | null; longitude: number | null; latitude: number | null }
-export interface CasePois { items: CasePoi[]; source: string; degradation_status: string; fallback_message: string | null }
-export type CaseMapObjectType = 'last_seen' | 'place' | 'clue' | 'task'
-export type MapLocationPrecision = 'exact' | 'approximate' | 'unknown'
-export interface CaseMapItem {
-  id: string
-  object_type: CaseMapObjectType
-  display_name: string | null
-  longitude: number | null
-  latitude: number | null
-  location_text: string | null
-  location_precision: MapLocationPrecision
-  source: string
-  occurred_at: string | null
-  reported_at: string | null
-  review_status: string
-  related_task_id: string | null
-  updated_at: string
+export interface PublicProgressItem {
+  clue_id: string;
+  progress_type: "confirmed_update" | "family_follow_up";
+  review_status: string;
+  updated_at: string;
 }
-export interface CommandIntakeCase { id: string; case_code: string; created_at: string; last_seen_at: string | null; area_hint: string | null; elder_age: number | null }
-export interface CaseMapView { items: CaseMapItem[] }
-export interface CaseSummaryClue { clue_id: string; content: string; occurred_at: string | null; location_text: string | null; review_status: string }
-export interface CaseSummary { case_id: string; access_role: CaseRole; generated_at: string; source_scope: string[]; last_confirmed_information: CaseSummaryClue | null; confirmed_clues: CaseSummaryClue[]; pending_verification: CaseSummaryClue[]; excluded_directions: CaseSummaryClue[]; current_focus: Array<{ label: string; detail: string }>; task_status: Array<{ task_id: string; title: string; status: string; due_at: string }>; safety_reminders: string[] }
-export type TaskStatus = 'pending_claim' | 'assigned' | 'accepted' | 'active' | 'blocked' | 'completed' | 'cancelled'
-export interface TaskCollaborator { volunteer_user_id: string; assigned_by_user_id: string; assigned_at: string }
-export interface CaseTask { id: string; case_id: string; source_clue_id: string | null; title: string; objective: string; area_text: string; latitude: number | null; longitude: number | null; due_at: string; background: string | null; risk_level: string; risk_notes: string; safety_briefing: string; expected_feedback: string; status: TaskStatus; result_summary: string | null; assigned_volunteer_user_id: string | null; assigned_at: string | null; collaborators: TaskCollaborator[]; created_at: string; updated_at: string }
-export interface TaskApplication { id: string; task_id: string; volunteer_user_id: string; status: 'pending' | 'approved' | 'rejected' | 'withdrawn'; note: string | null; reviewed_by_user_id: string | null; reviewed_at: string | null; review_reason: string | null; created_at: string; updated_at: string }
-export interface TaskCollaborationLocation { volunteer_user_id: string; latitude: number; longitude: number; accuracy_meters: number; captured_at: string }
-export interface TaskListPage { items: CaseTask[]; page: number; page_size: number; total: number }
-export interface CreateTaskPayload { source_clue_id: string; volunteer_user_id?: string; volunteer_user_ids?: string[]; title: string; objective: string; area_text: string; latitude: number | null; longitude: number | null; due_at: string; background: string; risk_level: 'low' | 'medium' | 'high'; risk_notes: string; safety_briefing: string; expected_feedback: string }
-export interface TaskNavigation { task_id: string; area_text: string; navigation_url: string | null; route_summary: string; source: string; degradation_status: string; fallback_message: string | null; updated_at: string }
-export interface TaskSafetyBriefing { task_id: string; risk_level: string; notices: string[]; emergency_stop_message: string; source: string; degradation_status: string; updated_at: string }
-export interface TaskLocationReportReceipt { id: string; source: string; captured_at: string; retention_expires_at: string; created_at: string }
+export interface CasePublicProgress {
+  case_id: string;
+  status: CaseStatus;
+  generated_at: string;
+  confirmed_progress: PublicProgressItem[];
+  requested_family_information: PublicProgressItem[];
+  safety_and_contact_reminders: string[];
+}
+export interface ClueDraft {
+  id: string;
+  case_id: string;
+  status: "draft" | "pending_review";
+  content: string;
+  source_type: PublicClueSourceType;
+  raw_record_reference: string | null;
+  occurred_at: string | null;
+  location_text: string | null;
+  uncertainty_notice: string;
+  template_version: string;
+  provider_model: string | null;
+  degradation_status: string;
+}
+export interface SummaryDraft {
+  id: string;
+  case_id: string;
+  status:
+    | "draft"
+    | "pending_review"
+    | "published"
+    | "rejected"
+    | "withdrawn"
+    | "superseded";
+  content: string;
+  source_scope: string[];
+  template_version: string;
+  provider_model: string | null;
+  generated_at: string;
+  reviewed_at: string | null;
+  review_reason: string | null;
+  created_at: string;
+  updated_at: string;
+  publication_eligible: boolean;
+}
+export interface CasePoi {
+  id: string;
+  name: string;
+  category: string;
+  address: string | null;
+  longitude: number | null;
+  latitude: number | null;
+}
+export interface CasePois {
+  items: CasePoi[];
+  source: string;
+  degradation_status: string;
+  fallback_message: string | null;
+}
+export type CaseMapObjectType = "last_seen" | "place" | "clue" | "task";
+export type MapLocationPrecision = "exact" | "approximate" | "unknown";
+export interface CaseMapItem {
+  id: string;
+  object_type: CaseMapObjectType;
+  display_name: string | null;
+  longitude: number | null;
+  latitude: number | null;
+  location_text: string | null;
+  location_precision: MapLocationPrecision;
+  source: string;
+  occurred_at: string | null;
+  reported_at: string | null;
+  review_status: string;
+  related_task_id: string | null;
+  updated_at: string;
+}
+export interface CommandIntakeCase {
+  id: string;
+  case_code: string;
+  created_at: string;
+  last_seen_at: string | null;
+  area_hint: string | null;
+  elder_age: number | null;
+}
+export interface CaseMapView {
+  items: CaseMapItem[];
+}
+export interface CaseSummaryClue {
+  clue_id: string;
+  content: string;
+  occurred_at: string | null;
+  location_text: string | null;
+  review_status: string;
+}
+export interface CaseSummary {
+  case_id: string;
+  access_role: CaseRole;
+  generated_at: string;
+  source_scope: string[];
+  last_confirmed_information: CaseSummaryClue | null;
+  confirmed_clues: CaseSummaryClue[];
+  pending_verification: CaseSummaryClue[];
+  excluded_directions: CaseSummaryClue[];
+  current_focus: Array<{ label: string; detail: string }>;
+  task_status: Array<{
+    task_id: string;
+    title: string;
+    status: string;
+    due_at: string;
+  }>;
+  safety_reminders: string[];
+}
+export type TaskStatus =
+  | "pending_claim"
+  | "assigned"
+  | "accepted"
+  | "active"
+  | "blocked"
+  | "completed"
+  | "cancelled";
+export interface TaskCollaborator {
+  volunteer_user_id: string;
+  assigned_by_user_id: string;
+  assigned_at: string;
+}
+export interface CaseTask {
+  id: string;
+  case_id: string;
+  source_clue_id: string | null;
+  title: string;
+  objective: string;
+  area_text: string;
+  latitude: number | null;
+  longitude: number | null;
+  due_at: string;
+  background: string | null;
+  risk_level: string;
+  risk_notes: string;
+  safety_briefing: string;
+  expected_feedback: string;
+  status: TaskStatus;
+  result_summary: string | null;
+  assigned_volunteer_user_id: string | null;
+  assigned_at: string | null;
+  collaborators: TaskCollaborator[];
+  created_at: string;
+  updated_at: string;
+}
+export interface TaskApplication {
+  id: string;
+  task_id: string;
+  volunteer_user_id: string;
+  status: "pending" | "approved" | "rejected" | "withdrawn";
+  note: string | null;
+  reviewed_by_user_id: string | null;
+  reviewed_at: string | null;
+  review_reason: string | null;
+  created_at: string;
+  updated_at: string;
+}
+export interface TaskCollaborationLocation {
+  volunteer_user_id: string;
+  latitude: number;
+  longitude: number;
+  accuracy_meters: number;
+  captured_at: string;
+}
+export interface TaskListPage {
+  items: CaseTask[];
+  page: number;
+  page_size: number;
+  total: number;
+}
+export interface CreateTaskPayload {
+  source_clue_id: string;
+  volunteer_user_id?: string;
+  volunteer_user_ids?: string[];
+  title: string;
+  objective: string;
+  area_text: string;
+  latitude: number | null;
+  longitude: number | null;
+  due_at: string;
+  background: string;
+  risk_level: "low" | "medium" | "high";
+  risk_notes: string;
+  safety_briefing: string;
+  expected_feedback: string;
+}
+export interface TaskNavigation {
+  task_id: string;
+  area_text: string;
+  navigation_url: string | null;
+  route_summary: string;
+  source: string;
+  degradation_status: string;
+  fallback_message: string | null;
+  updated_at: string;
+}
+export interface TaskSafetyBriefing {
+  task_id: string;
+  risk_level: string;
+  notices: string[];
+  emergency_stop_message: string;
+  source: string;
+  degradation_status: string;
+  updated_at: string;
+}
+export interface TaskLocationReportReceipt {
+  id: string;
+  source: string;
+  captured_at: string;
+  retention_expires_at: string;
+  created_at: string;
+}
 
 export function listCases(token: string): Promise<CaseListItem[]> {
-  return apiRequest<CaseListItem[]>('/cases', {}, token)
+  return apiRequest<CaseListItem[]>("/cases", {}, token);
 }
 
 export function getCase(token: string, caseId: string): Promise<CaseDetail> {
-  return apiRequest<CaseDetail>(`/cases/${caseId}`, {}, token)
+  return apiRequest<CaseDetail>(`/cases/${caseId}`, {}, token);
 }
 
 export function getCaseResourceConfiguration(
   token: string,
   caseId: string,
 ): Promise<CaseResourceConfiguration> {
-  return apiRequest<CaseResourceConfiguration>(`/cases/${caseId}/resource-configuration`, {}, token)
+  return apiRequest<CaseResourceConfiguration>(
+    `/cases/${caseId}/resource-configuration`,
+    {},
+    token,
+  );
 }
 
-export function createCase(token: string, payload: CreateCasePayload): Promise<CaseDetail> {
+export function createCase(
+  token: string,
+  payload: CreateCasePayload,
+): Promise<CaseDetail> {
   return apiRequest<CaseDetail>(
-    '/cases',
-    { method: 'POST', body: JSON.stringify(payload) },
+    "/cases",
+    { method: "POST", body: JSON.stringify(payload) },
     token,
-  )
+  );
 }
 
 export function createClue(
@@ -263,95 +453,283 @@ export function createClue(
 ): Promise<Clue> {
   return apiRequest<Clue>(
     `/cases/${caseId}/clues`,
-    { method: 'POST', body: JSON.stringify(payload) },
+    { method: "POST", body: JSON.stringify(payload) },
     token,
-  )
+  );
 }
 
-export function getCasePublicProgress(token: string, caseId: string): Promise<CasePublicProgress> {
-  return apiRequest<CasePublicProgress>(`/cases/${caseId}/public-progress`, {}, token)
+export function getCasePublicProgress(
+  token: string,
+  caseId: string,
+): Promise<CasePublicProgress> {
+  return apiRequest<CasePublicProgress>(
+    `/cases/${caseId}/public-progress`,
+    {},
+    token,
+  );
 }
-export function listCommandIntake(token: string): Promise<CommandIntakeCase[]> { return apiRequest<CommandIntakeCase[]>('/cases/command-intake', {}, token) }
-export function acceptCommandCase(token: string, caseId: string): Promise<CaseDetail> { return apiRequest<CaseDetail>(`/cases/${caseId}/accept-command`, { method: 'POST' }, token) }
-
-export function getCaseMapView(token: string, caseId: string): Promise<CaseMapView> {
-  return apiRequest<CaseMapView>(`/cases/${caseId}/map-view`, {}, token)
+export function listCommandIntake(token: string): Promise<CommandIntakeCase[]> {
+  return apiRequest<CommandIntakeCase[]>("/cases/command-intake", {}, token);
 }
-
-export function getCaseSummary(token: string, caseId: string): Promise<CaseSummary> {
-  return apiRequest<CaseSummary>(`/cases/${caseId}/summary`, {}, token)
-}
-
-export function getLatestSummaryDraft(token: string, caseId: string): Promise<SummaryDraft | null> {
-  return apiRequest<SummaryDraft | null>(`/cases/${caseId}/summary-drafts`, {}, token)
-}
-
-export function listCaseTasks(token: string, caseId: string): Promise<TaskListPage> {
-  return apiRequest<TaskListPage>(`/cases/${caseId}/tasks`, {}, token)
-}
-
-export function listCaseMembers(token: string, caseId: string): Promise<CaseMember[]> {
-  return apiRequest<CaseMember[]>(`/cases/${caseId}/members`, {}, token)
+export function acceptCommandCase(
+  token: string,
+  caseId: string,
+): Promise<CaseDetail> {
+  return apiRequest<CaseDetail>(
+    `/cases/${caseId}/accept-command`,
+    { method: "POST" },
+    token,
+  );
 }
 
-export function createCaseTask(token: string, caseId: string, payload: CreateTaskPayload): Promise<CaseTask> {
-  return apiRequest<CaseTask>(`/cases/${caseId}/tasks`, { method: 'POST', body: JSON.stringify(payload) }, token)
+export function getCaseMapView(
+  token: string,
+  caseId: string,
+): Promise<CaseMapView> {
+  return apiRequest<CaseMapView>(`/cases/${caseId}/map-view`, {}, token);
 }
 
-export function updateTaskStatus(token: string, taskId: string, status: TaskStatus): Promise<CaseTask> {
-  return apiRequest<CaseTask>(`/tasks/${taskId}/status`, { method: 'PATCH', body: JSON.stringify({ status }) }, token)
+export function getCaseSummary(
+  token: string,
+  caseId: string,
+): Promise<CaseSummary> {
+  return apiRequest<CaseSummary>(`/cases/${caseId}/summary`, {}, token);
+}
+
+export function getLatestSummaryDraft(
+  token: string,
+  caseId: string,
+): Promise<SummaryDraft | null> {
+  return apiRequest<SummaryDraft | null>(
+    `/cases/${caseId}/summary-drafts`,
+    {},
+    token,
+  );
+}
+
+export function listCaseTasks(
+  token: string,
+  caseId: string,
+): Promise<TaskListPage> {
+  return apiRequest<TaskListPage>(`/cases/${caseId}/tasks`, {}, token);
+}
+
+export function listCaseMembers(
+  token: string,
+  caseId: string,
+): Promise<CaseMember[]> {
+  return apiRequest<CaseMember[]>(`/cases/${caseId}/members`, {}, token);
+}
+
+export function createCaseTask(
+  token: string,
+  caseId: string,
+  payload: CreateTaskPayload,
+): Promise<CaseTask> {
+  return apiRequest<CaseTask>(
+    `/cases/${caseId}/tasks`,
+    { method: "POST", body: JSON.stringify(payload) },
+    token,
+  );
+}
+
+export function updateTaskStatus(
+  token: string,
+  taskId: string,
+  status: TaskStatus,
+): Promise<CaseTask> {
+  return apiRequest<CaseTask>(
+    `/tasks/${taskId}/status`,
+    { method: "PATCH", body: JSON.stringify({ status }) },
+    token,
+  );
 }
 
 export function listMyTasks(token: string): Promise<CaseTask[]> {
-  return apiRequest<CaseTask[]>('/tasks/mine', {}, token)
+  return apiRequest<CaseTask[]>("/tasks/mine", {}, token);
 }
 
-export function applyForTask(token: string, taskId: string, note?: string): Promise<TaskApplication> {
-  return apiRequest<TaskApplication>(`/tasks/${taskId}/applications`, { method: 'POST', body: JSON.stringify(note?.trim() ? { note: note.trim() } : {}) }, token)
+export function applyForTask(
+  token: string,
+  taskId: string,
+  note?: string,
+): Promise<TaskApplication> {
+  return apiRequest<TaskApplication>(
+    `/tasks/${taskId}/applications`,
+    {
+      method: "POST",
+      body: JSON.stringify(note?.trim() ? { note: note.trim() } : {}),
+    },
+    token,
+  );
 }
 
-export function listTaskApplications(token: string, taskId: string): Promise<TaskApplication[]> {
-  return apiRequest<TaskApplication[]>(`/tasks/${taskId}/applications`, {}, token)
+export function listTaskApplications(
+  token: string,
+  taskId: string,
+): Promise<TaskApplication[]> {
+  return apiRequest<TaskApplication[]>(
+    `/tasks/${taskId}/applications`,
+    {},
+    token,
+  );
 }
 
-export function reviewTaskApplication(token: string, taskId: string, applicationId: string, action: 'approve' | 'reject', reason?: string): Promise<TaskApplication> {
-  return apiRequest<TaskApplication>(`/tasks/${taskId}/applications/${applicationId}`, { method: 'PATCH', body: JSON.stringify(reason?.trim() ? { action, reason: reason.trim() } : { action }) }, token)
+export function reviewTaskApplication(
+  token: string,
+  taskId: string,
+  applicationId: string,
+  action: "approve" | "reject",
+  reason?: string,
+): Promise<TaskApplication> {
+  return apiRequest<TaskApplication>(
+    `/tasks/${taskId}/applications/${applicationId}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(
+        reason?.trim() ? { action, reason: reason.trim() } : { action },
+      ),
+    },
+    token,
+  );
 }
 
-export function listTaskCollaborationLocations(token: string, taskId: string): Promise<TaskCollaborationLocation[]> {
-  return apiRequest<TaskCollaborationLocation[]>(`/tasks/${taskId}/collaboration-locations`, {}, token)
+export function listTaskCollaborationLocations(
+  token: string,
+  taskId: string,
+): Promise<TaskCollaborationLocation[]> {
+  return apiRequest<TaskCollaborationLocation[]>(
+    `/tasks/${taskId}/collaboration-locations`,
+    {},
+    token,
+  );
 }
 
-export function getTaskNavigation(token: string, taskId: string): Promise<TaskNavigation> {
-  return apiRequest<TaskNavigation>(`/tasks/${taskId}/navigation`, {}, token)
+export function getTaskNavigation(
+  token: string,
+  taskId: string,
+): Promise<TaskNavigation> {
+  return apiRequest<TaskNavigation>(`/tasks/${taskId}/navigation`, {}, token);
 }
 
-export function getTaskSafetyBriefing(token: string, taskId: string): Promise<TaskSafetyBriefing> {
-  return apiRequest<TaskSafetyBriefing>(`/tasks/${taskId}/safety-briefing`, {}, token)
+export function getTaskSafetyBriefing(
+  token: string,
+  taskId: string,
+): Promise<TaskSafetyBriefing> {
+  return apiRequest<TaskSafetyBriefing>(
+    `/tasks/${taskId}/safety-briefing`,
+    {},
+    token,
+  );
 }
 
-export function submitTaskLocationReport(token: string, taskId: string, payload: { source: 'simulated'; latitude: number; longitude: number; accuracy_meters: number; captured_at: string }, idempotencyKey = crypto.randomUUID()): Promise<TaskLocationReportReceipt> {
-  return apiRequest<TaskLocationReportReceipt>(`/tasks/${taskId}/location-reports`, { method: 'POST', headers: { 'Idempotency-Key': idempotencyKey }, body: JSON.stringify(payload) }, token)
+export function submitTaskLocationReport(
+  token: string,
+  taskId: string,
+  payload: {
+    source: "simulated";
+    latitude: number;
+    longitude: number;
+    accuracy_meters: number;
+    captured_at: string;
+  },
+  idempotencyKey = crypto.randomUUID(),
+): Promise<TaskLocationReportReceipt> {
+  return apiRequest<TaskLocationReportReceipt>(
+    `/tasks/${taskId}/location-reports`,
+    {
+      method: "POST",
+      headers: { "Idempotency-Key": idempotencyKey },
+      body: JSON.stringify(payload),
+    },
+    token,
+  );
 }
 
-export function submitTaskFeedback(token: string, taskId: string, payload: { content: string; occurred_at: string | null; location_text: string | null; location_precision: LocationPrecision | null }, idempotencyKey = crypto.randomUUID()): Promise<{ task_id: string; clue_id: string; status: 'pending_review'; submitted_at: string }> {
-  return apiRequest(`/tasks/${taskId}/feedback`, { method: 'POST', headers: { 'Idempotency-Key': idempotencyKey }, body: JSON.stringify(payload) }, token)
+export function submitTaskFeedback(
+  token: string,
+  taskId: string,
+  payload: {
+    content: string;
+    occurred_at: string | null;
+    location_text: string | null;
+    location_precision: LocationPrecision | null;
+  },
+  idempotencyKey = crypto.randomUUID(),
+): Promise<{
+  task_id: string;
+  clue_id: string;
+  status: "pending_review";
+  submitted_at: string;
+}> {
+  return apiRequest(
+    `/tasks/${taskId}/feedback`,
+    {
+      method: "POST",
+      headers: { "Idempotency-Key": idempotencyKey },
+      body: JSON.stringify(payload),
+    },
+    token,
+  );
 }
 
-export function createClueDraft(token: string, caseId: string, payload: { text: string; source_type?: PublicClueSourceType; raw_record_reference?: string }): Promise<ClueDraft[]> {
-  return apiRequest<ClueDraft[]>(`/cases/${caseId}/clue-drafts`, { method: 'POST', body: JSON.stringify(payload) }, token)
+export function createClueDraft(
+  token: string,
+  caseId: string,
+  payload: {
+    text: string;
+    source_type?: PublicClueSourceType;
+    raw_record_reference?: string;
+  },
+): Promise<ClueDraft[]> {
+  return apiRequest<ClueDraft[]>(
+    `/cases/${caseId}/clue-drafts`,
+    { method: "POST", body: JSON.stringify(payload) },
+    token,
+  );
 }
 
-export function listCasePois(token: string, caseId: string, category = 'hospital'): Promise<CasePois> {
-  return apiRequest<CasePois>(`/cases/${caseId}/pois?category=${encodeURIComponent(category)}`, {}, token)
+export function listCasePois(
+  token: string,
+  caseId: string,
+  category = "hospital",
+): Promise<CasePois> {
+  return apiRequest<CasePois>(
+    `/cases/${caseId}/pois?category=${encodeURIComponent(category)}`,
+    {},
+    token,
+  );
 }
 
-export function createSummaryDraft(token: string, caseId: string, content?: string): Promise<SummaryDraft> {
-  return apiRequest<SummaryDraft>(`/cases/${caseId}/summary-drafts`, { method: 'POST', body: JSON.stringify(content === undefined ? {} : { content }) }, token)
+export function createSummaryDraft(
+  token: string,
+  caseId: string,
+  content?: string,
+): Promise<SummaryDraft> {
+  return apiRequest<SummaryDraft>(
+    `/cases/${caseId}/summary-drafts`,
+    {
+      method: "POST",
+      body: JSON.stringify(content === undefined ? {} : { content }),
+    },
+    token,
+  );
 }
 
-export function reviewSummaryDraft(token: string, caseId: string, draftId: string, payload: { action: 'submit' | 'publish' | 'reject' | 'withdraw'; reason: string }): Promise<SummaryDraft> {
-  return apiRequest<SummaryDraft>(`/cases/${caseId}/summary-drafts/${draftId}/review`, { method: 'PATCH', body: JSON.stringify(payload) }, token)
+export function reviewSummaryDraft(
+  token: string,
+  caseId: string,
+  draftId: string,
+  payload: {
+    action: "submit" | "publish" | "reject" | "withdraw";
+    reason: string;
+  },
+): Promise<SummaryDraft> {
+  return apiRequest<SummaryDraft>(
+    `/cases/${caseId}/summary-drafts/${draftId}/review`,
+    { method: "PATCH", body: JSON.stringify(payload) },
+    token,
+  );
 }
 
 export function listCaseClues(
@@ -359,16 +737,28 @@ export function listCaseClues(
   caseId: string,
   query: ClueTimelineQuery = {},
 ): Promise<ClueTimelinePage> {
-  const parameters = new URLSearchParams()
+  const parameters = new URLSearchParams();
   for (const [key, value] of Object.entries(query)) {
-    if (value !== undefined) parameters.set(key, String(value))
+    if (value !== undefined) parameters.set(key, String(value));
   }
-  const suffix = parameters.size > 0 ? `?${parameters}` : ''
-  return apiRequest<ClueTimelinePage>(`/cases/${caseId}/clues${suffix}`, {}, token)
+  const suffix = parameters.size > 0 ? `?${parameters}` : "";
+  return apiRequest<ClueTimelinePage>(
+    `/cases/${caseId}/clues${suffix}`,
+    {},
+    token,
+  );
 }
 
-export function createCasePlace(token: string, caseId: string, payload: CreateCasePlacePayload): Promise<CasePlace> {
-  return apiRequest<CasePlace>(`/cases/${caseId}/places`, { method: 'POST', body: JSON.stringify(payload) }, token)
+export function createCasePlace(
+  token: string,
+  caseId: string,
+  payload: CreateCasePlacePayload,
+): Promise<CasePlace> {
+  return apiRequest<CasePlace>(
+    `/cases/${caseId}/places`,
+    { method: "POST", body: JSON.stringify(payload) },
+    token,
+  );
 }
 
 export function uploadCaseAttachment(
@@ -377,15 +767,27 @@ export function uploadCaseAttachment(
   file: File,
   maximumBytes: number,
 ): Promise<CaseAttachment> {
-  if (!['image/jpeg', 'image/png'].includes(file.type)) {
-    throw new ApiClientError(400, 'validation_error', '仅可上传 JPEG 或 PNG 图片。')
+  if (!["image/jpeg", "image/png"].includes(file.type)) {
+    throw new ApiClientError(
+      400,
+      "validation_error",
+      "仅可上传 JPEG 或 PNG 图片。",
+    );
   }
   if (file.size > maximumBytes) {
-    throw new ApiClientError(400, 'validation_error', `图片不能超过 ${maximumBytes} 字节。`)
+    throw new ApiClientError(
+      400,
+      "validation_error",
+      `图片不能超过 ${maximumBytes} 字节。`,
+    );
   }
-  const body = new FormData()
-  body.append('file', file, file.name)
-  return apiRequest<CaseAttachment>(`/cases/${caseId}/attachments`, { method: 'POST', body }, token)
+  const body = new FormData();
+  body.append("file", file, file.name);
+  return apiRequest<CaseAttachment>(
+    `/cases/${caseId}/attachments`,
+    { method: "POST", body },
+    token,
+  );
 }
 
 export function reviewClue(
@@ -395,9 +797,9 @@ export function reviewClue(
 ): Promise<Clue> {
   return apiRequest<Clue>(
     `/clues/${clueId}/review`,
-    { method: 'PATCH', body: JSON.stringify(payload) },
+    { method: "PATCH", body: JSON.stringify(payload) },
     token,
-  )
+  );
 }
 
 export function updateCaseStatus(
@@ -407,9 +809,9 @@ export function updateCaseStatus(
 ): Promise<CaseDetail> {
   return apiRequest<CaseDetail>(
     `/cases/${caseId}/status`,
-    { method: 'PATCH', body: JSON.stringify({ status }) },
+    { method: "PATCH", body: JSON.stringify({ status }) },
     token,
-  )
+  );
 }
 
 export function updateElderProfile(
@@ -419,9 +821,9 @@ export function updateElderProfile(
 ): Promise<CaseDetail> {
   return apiRequest<CaseDetail>(
     `/cases/${caseId}/elder-profile`,
-    { method: 'PATCH', body: JSON.stringify(payload) },
+    { method: "PATCH", body: JSON.stringify(payload) },
     token,
-  )
+  );
 }
 
 export function addCaseMember(
@@ -432,7 +834,7 @@ export function addCaseMember(
 ): Promise<CaseMember> {
   return apiRequest<CaseMember>(
     `/cases/${caseId}/members`,
-    { method: 'POST', body: JSON.stringify({ email, case_role: caseRole }) },
+    { method: "POST", body: JSON.stringify({ email, case_role: caseRole }) },
     token,
-  )
+  );
 }

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,64 +1,90 @@
-import { describe, expect, it, vi } from 'vitest'
-import { SESSION_EXPIRED_EVENT, apiRequest } from './client'
+import { describe, expect, it, vi } from "vitest";
+import { SESSION_EXPIRED_EVENT, apiRequest } from "./client";
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+    headers: { "Content-Type": "application/json" },
+  });
 }
 
-describe('apiRequest', () => {
+describe("apiRequest", () => {
   it.each([
-    [400, 'validation_error', '提交的信息不符合要求，请检查后重试。'],
-    [403, 'forbidden', '你没有执行此操作的权限。'],
-    [404, 'not_found', '未找到可访问的资源，它可能已不存在或你没有访问权限。'],
-    [409, 'conflict', '当前数据状态已变化，请刷新后再试。'],
-  ])('maps documented HTTP %i errors to user-safe messages', async (status, code, message) => {
+    [400, "validation_error", "提交的信息不符合要求，请检查后重试。"],
+    [403, "forbidden", "你没有执行此操作的权限。"],
+    [404, "not_found", "未找到可访问的资源，它可能已不存在或你没有访问权限。"],
+    [409, "conflict", "当前数据状态已变化，请刷新后再试。"],
+  ])(
+    "maps documented HTTP %i errors to user-safe messages",
+    async (status, code, message) => {
+      vi.stubGlobal(
+        "fetch",
+        vi
+          .fn()
+          .mockResolvedValue(
+            jsonResponse(status, {
+              error: { code, message: "internal state detail" },
+            }),
+          ),
+      );
+
+      await expect(apiRequest("/cases/example")).rejects.toMatchObject({
+        status,
+        code,
+        message,
+      });
+    },
+  );
+
+  it("keeps invalid-login messaging separate from an expired session", async () => {
     vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue(jsonResponse(status, { error: { code, message: 'internal state detail' } })),
-    )
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          jsonResponse(401, { error: { code: "unauthorized" } }),
+        ),
+    );
 
-    await expect(apiRequest('/cases/example')).rejects.toMatchObject({ status, code, message })
-  })
-
-  it('keeps invalid-login messaging separate from an expired session', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue(jsonResponse(401, { error: { code: 'unauthorized' } })),
-    )
-
-    await expect(apiRequest('/auth/login')).rejects.toMatchObject({
+    await expect(apiRequest("/auth/login")).rejects.toMatchObject({
       status: 401,
-      code: 'unauthorized',
-      message: '邮箱或密码错误，请重新输入。',
-    })
-  })
+      code: "unauthorized",
+      message: "邮箱或密码错误，请重新输入。",
+    });
+  });
 
-  it('clears an authenticated session signal when the server returns 401', async () => {
-    const expired = vi.fn()
-    window.addEventListener(SESSION_EXPIRED_EVENT, expired)
+  it("clears an authenticated session signal when the server returns 401", async () => {
+    const expired = vi.fn();
+    window.addEventListener(SESSION_EXPIRED_EVENT, expired);
     vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue(jsonResponse(401, { error: { code: 'unauthorized' } })),
-    )
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          jsonResponse(401, { error: { code: "unauthorized" } }),
+        ),
+    );
 
-    await expect(apiRequest('/cases', {}, 'test-session')).rejects.toMatchObject({
+    await expect(
+      apiRequest("/cases", {}, "test-session"),
+    ).rejects.toMatchObject({
       status: 401,
-      code: 'unauthorized',
-    })
-    expect(expired).toHaveBeenCalledOnce()
-    window.removeEventListener(SESSION_EXPIRED_EVENT, expired)
-  })
+      code: "unauthorized",
+    });
+    expect(expired).toHaveBeenCalledOnce();
+    window.removeEventListener(SESSION_EXPIRED_EVENT, expired);
+  });
 
-  it('reports network failures without exposing the transport error', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('socket details')))
+  it("reports network failures without exposing the transport error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new TypeError("socket details")),
+    );
 
-    await expect(apiRequest('/health')).rejects.toMatchObject({
+    await expect(apiRequest("/health")).rejects.toMatchObject({
       status: 0,
-      code: 'network_error',
-      message: '网络连接失败，请检查服务连接后重试。',
-    })
-  })
-})
+      code: "network_error",
+      message: "网络连接失败，请检查服务连接后重试。",
+    });
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,41 +1,51 @@
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '/api'
-export const SESSION_EXPIRED_EVENT = 'angui:session-expired'
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "/api";
+export const SESSION_EXPIRED_EVENT = "angui:session-expired";
 
 interface ApiErrorPayload {
   error?: {
-    code?: string
-    message?: string
-  }
+    code?: string;
+    message?: string;
+  };
 }
 
 export class ApiClientError extends Error {
-  status: number
-  code: string
+  status: number;
+  code: string;
 
   constructor(status: number, code: string, message: string) {
-    super(message)
-    this.name = 'ApiClientError'
-    this.status = status
-    this.code = code
+    super(message);
+    this.name = "ApiClientError";
+    this.status = status;
+    this.code = code;
   }
 }
 
-function userMessageFor(status: number, code: string, hasSession = false): string {
-  if (status === 0) return '网络连接失败，请检查服务连接后重试。'
-  if (status === 400 || code === 'validation_error') return '提交的信息不符合要求，请检查后重试。'
-  if (status === 401 || code === 'unauthorized') {
-    return hasSession ? '登录状态已失效，请重新登录。' : '邮箱或密码错误，请重新输入。'
+function userMessageFor(
+  status: number,
+  code: string,
+  hasSession = false,
+): string {
+  if (status === 0) return "网络连接失败，请检查服务连接后重试。";
+  if (status === 400 || code === "validation_error")
+    return "提交的信息不符合要求，请检查后重试。";
+  if (status === 401 || code === "unauthorized") {
+    return hasSession
+      ? "登录状态已失效，请重新登录。"
+      : "邮箱或密码错误，请重新输入。";
   }
-  if (status === 403 || code === 'forbidden') return '你没有执行此操作的权限。'
-  if (status === 404 || code === 'not_found') return '未找到可访问的资源，它可能已不存在或你没有访问权限。'
-  if (status === 409 || code === 'conflict') return '当前数据状态已变化，请刷新后再试。'
-  if (status === 429 || code === 'rate_limited') return '请求过于频繁，请稍后再试。'
-  return '服务暂时不可用，请稍后重试。'
+  if (status === 403 || code === "forbidden") return "你没有执行此操作的权限。";
+  if (status === 404 || code === "not_found")
+    return "未找到可访问的资源，它可能已不存在或你没有访问权限。";
+  if (status === 409 || code === "conflict")
+    return "当前数据状态已变化，请刷新后再试。";
+  if (status === 429 || code === "rate_limited")
+    return "请求过于频繁，请稍后再试。";
+  return "服务暂时不可用，请稍后重试。";
 }
 
 function notifySessionExpired() {
-  if (typeof window !== 'undefined') {
-    window.dispatchEvent(new Event(SESSION_EXPIRED_EVENT))
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(SESSION_EXPIRED_EVENT));
   }
 }
 
@@ -44,43 +54,51 @@ export async function apiRequest<T>(
   options: RequestInit = {},
   token?: string | null,
 ): Promise<T> {
-  const headers = new Headers(options.headers)
-  headers.set('Accept', 'application/json')
-  if (options.body && !(options.body instanceof FormData) && !headers.has('Content-Type')) {
-    headers.set('Content-Type', 'application/json')
+  const headers = new Headers(options.headers);
+  headers.set("Accept", "application/json");
+  if (
+    options.body &&
+    !(options.body instanceof FormData) &&
+    !headers.has("Content-Type")
+  ) {
+    headers.set("Content-Type", "application/json");
   }
   if (token) {
-    headers.set('Authorization', `Bearer ${token}`)
+    headers.set("Authorization", `Bearer ${token}`);
   }
 
-  let response: Response
+  let response: Response;
   try {
     response = await fetch(`${API_BASE_URL}${path}`, {
       ...options,
       headers,
-    })
+    });
   } catch {
-    throw new ApiClientError(0, 'network_error', userMessageFor(0, 'network_error'))
+    throw new ApiClientError(
+      0,
+      "network_error",
+      userMessageFor(0, "network_error"),
+    );
   }
 
   if (!response.ok) {
-    let payload: ApiErrorPayload = {}
+    let payload: ApiErrorPayload = {};
     try {
-      payload = (await response.json()) as ApiErrorPayload
+      payload = (await response.json()) as ApiErrorPayload;
     } catch {
       // The status code still provides a useful fallback when a proxy returns HTML.
     }
-    const code = payload.error?.code ?? 'request_failed'
-    if (response.status === 401 && token) notifySessionExpired()
+    const code = payload.error?.code ?? "request_failed";
+    if (response.status === 401 && token) notifySessionExpired();
     throw new ApiClientError(
       response.status,
       code,
       userMessageFor(response.status, code, Boolean(token)),
-    )
+    );
   }
 
   if (response.status === 204) {
-    return undefined as T
+    return undefined as T;
   }
-  return (await response.json()) as T
+  return (await response.json()) as T;
 }

--- a/frontend/src/api/health.ts
+++ b/frontend/src/api/health.ts
@@ -1,20 +1,20 @@
 export interface HealthResponse {
-  status: string
-  service: string
-  version: string
+  status: string;
+  service: string;
+  version: string;
 }
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '/api'
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "/api";
 
 export async function getHealth(signal?: AbortSignal): Promise<HealthResponse> {
   const response = await fetch(`${API_BASE_URL}/health`, {
-    headers: { Accept: 'application/json' },
+    headers: { Accept: "application/json" },
     signal,
-  })
+  });
 
   if (!response.ok) {
-    throw new Error(`Health check failed with status ${response.status}`)
+    throw new Error(`Health check failed with status ${response.status}`);
   }
 
-  return (await response.json()) as HealthResponse
+  return (await response.json()) as HealthResponse;
 }

--- a/frontend/src/api/intake.ts
+++ b/frontend/src/api/intake.ts
@@ -1,124 +1,128 @@
-import { apiRequest } from './client'
+import { apiRequest } from "./client";
 
 export interface IntakeQuestion {
-  field: string
-  prompt: string
-  required: boolean
+  field: string;
+  prompt: string;
+  required: boolean;
 }
 
 export interface IntakeSession {
-  id: string
-  status: 'collecting' | 'ready_for_confirmation'
-  missing_fields: string[]
-  phase: 'phase_one' | 'phase_two'
-  completed_phase_one_fields: string[]
-  missing_phase_one_fields: string[]
-  phase_transition_ready: boolean
-  next_question: IntakeQuestion | null
-  guidance_mode: 'rule_based'
-  privacy_notice: string
+  id: string;
+  status: "collecting" | "ready_for_confirmation";
+  missing_fields: string[];
+  phase: "phase_one" | "phase_two";
+  completed_phase_one_fields: string[];
+  missing_phase_one_fields: string[];
+  phase_transition_ready: boolean;
+  next_question: IntakeQuestion | null;
+  guidance_mode: "rule_based";
+  privacy_notice: string;
 }
 
-export type IntakeSessionUpdate = Omit<IntakeSession, 'id'>
+export type IntakeSessionUpdate = Omit<IntakeSession, "id">;
 
 export interface IntakeCandidateField {
-  field: string
-  value: string
-  source: 'family_provided' | 'ai_extracted'
-  status: 'draft'
-  generated_at: string
-  model: string | null
-  template_version: string | null
-  source_text: string
-  confidence: number | null
+  field: string;
+  value: string;
+  source: "family_provided" | "ai_extracted";
+  status: "draft";
+  generated_at: string;
+  model: string | null;
+  template_version: string | null;
+  source_text: string;
+  confidence: number | null;
 }
 
 export interface IntakeRouteEstimate {
-  distance_meters: number
-  available_seconds: number
-  minimum_seconds: number | null
-  basis: string
-  degraded: boolean
+  distance_meters: number;
+  available_seconds: number;
+  minimum_seconds: number | null;
+  basis: string;
+  degraded: boolean;
 }
 
 export interface IntakeAssessment {
-  field_path: string
-  conflict_type: string
-  severity: 'info' | 'warning' | 'blocking'
-  evidence_summary: string
-  suggested_action: string
-  route_estimate: IntakeRouteEstimate | null
+  field_path: string;
+  conflict_type: string;
+  severity: "info" | "warning" | "blocking";
+  evidence_summary: string;
+  suggested_action: string;
+  route_estimate: IntakeRouteEstimate | null;
 }
 
 export interface SubmitIntakeAnswerResponse extends IntakeSessionUpdate {
-  session_id: string
-  raw_answer: string
-  candidate_fields: IntakeCandidateField[]
-  assessments: IntakeAssessment[]
+  session_id: string;
+  raw_answer: string;
+  candidate_fields: IntakeCandidateField[];
+  assessments: IntakeAssessment[];
 }
 
 export interface IntakeProfileDraftFieldMetadata {
-  field: string
-  source_field: string
-  source: 'family_provided' | 'ai_extracted'
-  status: 'draft'
-  generated_at: string
+  field: string;
+  source_field: string;
+  source: "family_provided" | "ai_extracted";
+  status: "draft";
+  generated_at: string;
 }
 
 export interface IntakeDraftProfile {
-  physical_description: string | null
-  clothing_description: string | null
-  health_notes: string | null
-  mobility_notes: string | null
-  transportation_ability: string | null
-  frequent_locations: string | null
-  last_seen_information: string | null
-  behavior_habits: string | null
-  suspicious_motive: string | null
+  physical_description: string | null;
+  clothing_description: string | null;
+  health_notes: string | null;
+  mobility_notes: string | null;
+  transportation_ability: string | null;
+  frequent_locations: string | null;
+  last_seen_information: string | null;
+  behavior_habits: string | null;
+  suspicious_motive: string | null;
 }
 
 export interface IntakeDirectionHypothesis {
-  status: 'hypothesis'
-  description: string
-  uncertainty_notice: string
-  source_fields: string[]
-  generated_at: string
+  status: "hypothesis";
+  description: string;
+  uncertainty_notice: string;
+  source_fields: string[];
+  generated_at: string;
 }
 
 export interface IntakeDraft {
-  status: 'draft'
-  source_scope: string
-  generated_at: string
-  requires_human_confirmation: true
-  profile: IntakeDraftProfile
-  field_metadata: IntakeProfileDraftFieldMetadata[]
-  missing_fields: string[]
-  assessments: IntakeAssessment[]
-  confirmation_blocked_reasons: string[]
-  direction_hypotheses: IntakeDirectionHypothesis[]
+  status: "draft";
+  source_scope: string;
+  generated_at: string;
+  requires_human_confirmation: true;
+  profile: IntakeDraftProfile;
+  field_metadata: IntakeProfileDraftFieldMetadata[];
+  missing_fields: string[];
+  assessments: IntakeAssessment[];
+  confirmation_blocked_reasons: string[];
+  direction_hypotheses: IntakeDirectionHypothesis[];
 }
 
 export interface ConfirmedIntakeProfile {
-  display_name: string
-  age: number | null
-  gender: string | null
-  physical_description: string | null
-  clothing_description: string | null
-  health_notes: string | null
-  last_seen_at: string | null
-  last_seen_location: string
+  display_name: string;
+  age: number | null;
+  gender: string | null;
+  physical_description: string | null;
+  clothing_description: string | null;
+  health_notes: string | null;
+  last_seen_at: string | null;
+  last_seen_location: string;
 }
 
 export interface ConfirmIntakeResponse {
-  case_id: string
-  case_code: string
-  status: 'active' | 'resolved' | 'closed'
-  confirmation_status: 'human_confirmed'
-  confirmed_at: string
+  case_id: string;
+  case_code: string;
+  status: "active" | "resolved" | "closed";
+  confirmation_status: "human_confirmed";
+  confirmed_at: string;
 }
 
 export function createIntakeSession(token: string): Promise<IntakeSession> {
-  return apiRequest<IntakeSession>('/intake-sessions', { method: 'POST', body: JSON.stringify({}) }, token)
+  return apiRequest<IntakeSession>(
+    "/intake-sessions",
+    { method: "POST", body: JSON.stringify({}) },
+    token,
+  );
 }
 
 export function submitIntakeAnswer(
@@ -128,13 +132,20 @@ export function submitIntakeAnswer(
 ): Promise<SubmitIntakeAnswerResponse> {
   return apiRequest<SubmitIntakeAnswerResponse>(
     `/intake-sessions/${sessionId}/answers`,
-    { method: 'POST', body: JSON.stringify(payload) },
+    { method: "POST", body: JSON.stringify(payload) },
     token,
-  )
+  );
 }
 
-export function getIntakeDraft(token: string, sessionId: string): Promise<IntakeDraft> {
-  return apiRequest<IntakeDraft>(`/intake-sessions/${sessionId}/profile-draft`, {}, token)
+export function getIntakeDraft(
+  token: string,
+  sessionId: string,
+): Promise<IntakeDraft> {
+  return apiRequest<IntakeDraft>(
+    `/intake-sessions/${sessionId}/profile-draft`,
+    {},
+    token,
+  );
 }
 
 export function confirmIntakeSession(
@@ -144,7 +155,10 @@ export function confirmIntakeSession(
 ): Promise<ConfirmIntakeResponse> {
   return apiRequest<ConfirmIntakeResponse>(
     `/intake-sessions/${sessionId}/confirm`,
-    { method: 'POST', body: JSON.stringify({ human_confirmed: true, profile }) },
+    {
+      method: "POST",
+      body: JSON.stringify({ human_confirmed: true, profile }),
+    },
     token,
-  )
+  );
 }

--- a/frontend/src/auth/AuthContext.test.tsx
+++ b/frontend/src/auth/AuthContext.test.tsx
@@ -1,115 +1,208 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
-import { apiRequest } from '../api/client'
-import { AuthProvider } from './AuthContext'
-import { useAuth } from './useAuth'
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { apiRequest } from "../api/client";
+import { AuthProvider } from "./AuthContext";
+import { useAuth } from "./useAuth";
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { 'Content-Type': 'application/json' },
-  })
+    headers: { "Content-Type": "application/json" },
+  });
 }
 
 function AuthProbe() {
-  const { login, logout, sessionNotice, user } = useAuth()
+  const { login, logout, sessionNotice, user } = useAuth();
   return (
     <div>
-      <span>{user ? user.email : 'anonymous'}</span>
+      <span>{user ? user.email : "anonymous"}</span>
       {sessionNotice && <span role="status">{sessionNotice}</span>}
-      <button type="button" onClick={() => void login('family@demo.invalid', 'local-test-input').catch(() => undefined)}>登录</button>
-      <button type="button" onClick={() => void logout()}>退出</button>
+      <button
+        type="button"
+        onClick={() =>
+          void login("family@demo.invalid", "local-test-input").catch(
+            () => undefined,
+          )
+        }
+      >
+        登录
+      </button>
+      <button type="button" onClick={() => void logout()}>
+        退出
+      </button>
     </div>
-  )
+  );
 }
 
-describe('AuthProvider', () => {
-  it('logs in with the server response and restores a session after refresh', async () => {
-    const fetchMock = vi.fn()
-      .mockResolvedValueOnce(jsonResponse(200, {
-        token: 'session-created-by-test-server',
-        expires_at: '2026-07-24T00:00:00Z',
-        user: { id: 'family-1', email: 'family@demo.invalid', display_name: '模拟家属', account_type: 'member', global_capabilities: [] },
-      }))
-      .mockResolvedValueOnce(jsonResponse(200, {
-        id: 'family-1', email: 'family@demo.invalid', display_name: '模拟家属', account_type: 'member', global_capabilities: [],
-      }))
-      .mockResolvedValueOnce(jsonResponse(200, {
-        id: 'family-1', email: 'family@demo.invalid', display_name: '模拟家属', account_type: 'member', global_capabilities: [],
-      }))
-    vi.stubGlobal('fetch', fetchMock)
+describe("AuthProvider", () => {
+  it("logs in with the server response and restores a session after refresh", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          token: "session-created-by-test-server",
+          expires_at: "2026-07-24T00:00:00Z",
+          user: {
+            id: "family-1",
+            email: "family@demo.invalid",
+            display_name: "模拟家属",
+            account_type: "member",
+            global_capabilities: [],
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          id: "family-1",
+          email: "family@demo.invalid",
+          display_name: "模拟家属",
+          account_type: "member",
+          global_capabilities: [],
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          id: "family-1",
+          email: "family@demo.invalid",
+          display_name: "模拟家属",
+          account_type: "member",
+          global_capabilities: [],
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
 
-    const firstRender = render(<AuthProvider><AuthProbe /></AuthProvider>)
-    fireEvent.click(screen.getByRole('button', { name: '登录' }))
-    expect(await screen.findByText('family@demo.invalid')).toBeInTheDocument()
+    const firstRender = render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "登录" }));
+    expect(await screen.findByText("family@demo.invalid")).toBeInTheDocument();
 
-    firstRender.unmount()
-    render(<AuthProvider><AuthProbe /></AuthProvider>)
-    expect(await screen.findByText('family@demo.invalid')).toBeInTheDocument()
-    expect(fetchMock).toHaveBeenCalledTimes(3)
-  })
+    firstRender.unmount();
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+    expect(await screen.findByText("family@demo.invalid")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
 
-  it('keeps the login screen state on invalid credentials', async () => {
+  it("keeps the login screen state on invalid credentials", async () => {
     vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue(jsonResponse(401, { error: { code: 'unauthorized' } })),
-    )
-    render(<AuthProvider><AuthProbe /></AuthProvider>)
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          jsonResponse(401, { error: { code: "unauthorized" } }),
+        ),
+    );
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
 
-    fireEvent.click(screen.getByRole('button', { name: '登录' }))
-    await waitFor(() => expect(screen.getByText('anonymous')).toBeInTheDocument())
-    expect(sessionStorage.getItem('angui.session.token')).toBeNull()
-  })
+    fireEvent.click(screen.getByRole("button", { name: "登录" }));
+    await waitFor(() =>
+      expect(screen.getByText("anonymous")).toBeInTheDocument(),
+    );
+    expect(sessionStorage.getItem("angui.session.token")).toBeNull();
+  });
 
-  it('removes session data after logout', async () => {
-    sessionStorage.setItem('angui.session.token', 'existing-session')
-    const fetchMock = vi.fn()
-      .mockResolvedValueOnce(jsonResponse(200, {
-        id: 'family-1', email: 'family@demo.invalid', display_name: '模拟家属', account_type: 'member', global_capabilities: [],
-      }))
-      .mockResolvedValueOnce(new Response(null, { status: 204 }))
-    vi.stubGlobal('fetch', fetchMock)
-    render(<AuthProvider><AuthProbe /></AuthProvider>)
+  it("removes session data after logout", async () => {
+    sessionStorage.setItem("angui.session.token", "existing-session");
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          id: "family-1",
+          email: "family@demo.invalid",
+          display_name: "模拟家属",
+          account_type: "member",
+          global_capabilities: [],
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
 
-    expect(await screen.findByText('family@demo.invalid')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: '退出' }))
-    expect(await screen.findByText('anonymous')).toBeInTheDocument()
-    expect(sessionStorage.getItem('angui.session.token')).toBeNull()
-  })
+    expect(await screen.findByText("family@demo.invalid")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "退出" }));
+    expect(await screen.findByText("anonymous")).toBeInTheDocument();
+    expect(sessionStorage.getItem("angui.session.token")).toBeNull();
+  });
 
-  it('completes the local logout when remote revocation fails', async () => {
-    sessionStorage.setItem('angui.session.token', 'existing-session')
-    const fetchMock = vi.fn()
-      .mockResolvedValueOnce(jsonResponse(200, {
-        id: 'family-1', email: 'family@demo.invalid', display_name: '模拟家属', account_type: 'member', global_capabilities: [],
-      }))
-      .mockResolvedValueOnce(jsonResponse(503, { error: { code: 'service_unavailable' } }))
-    vi.stubGlobal('fetch', fetchMock)
-    render(<AuthProvider><AuthProbe /></AuthProvider>)
+  it("completes the local logout when remote revocation fails", async () => {
+    sessionStorage.setItem("angui.session.token", "existing-session");
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          id: "family-1",
+          email: "family@demo.invalid",
+          display_name: "模拟家属",
+          account_type: "member",
+          global_capabilities: [],
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(503, { error: { code: "service_unavailable" } }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
 
-    expect(await screen.findByText('family@demo.invalid')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: '退出' }))
+    expect(await screen.findByText("family@demo.invalid")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "退出" }));
 
-    expect(await screen.findByText('anonymous')).toBeInTheDocument()
-    expect(sessionStorage.getItem('angui.session.token')).toBeNull()
-  })
+    expect(await screen.findByText("anonymous")).toBeInTheDocument();
+    expect(sessionStorage.getItem("angui.session.token")).toBeNull();
+  });
 
-  it('removes stale session data when an authenticated request receives 401', async () => {
-    sessionStorage.setItem('angui.session.token', 'existing-session')
+  it("removes stale session data when an authenticated request receives 401", async () => {
+    sessionStorage.setItem("angui.session.token", "existing-session");
     vi.stubGlobal(
-      'fetch',
-      vi.fn()
-        .mockResolvedValueOnce(jsonResponse(200, {
-          id: 'family-1', email: 'family@demo.invalid', display_name: '模拟家属', account_type: 'member', global_capabilities: [],
-        }))
-        .mockResolvedValueOnce(jsonResponse(401, { error: { code: 'unauthorized' } })),
-    )
-    render(<AuthProvider><AuthProbe /></AuthProvider>)
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(200, {
+            id: "family-1",
+            email: "family@demo.invalid",
+            display_name: "模拟家属",
+            account_type: "member",
+            global_capabilities: [],
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse(401, { error: { code: "unauthorized" } }),
+        ),
+    );
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
 
-    expect(await screen.findByText('family@demo.invalid')).toBeInTheDocument()
-    await expect(apiRequest('/cases', {}, 'existing-session')).rejects.toMatchObject({ status: 401 })
-    await waitFor(() => expect(screen.getByText('anonymous')).toBeInTheDocument())
-    expect(screen.getByRole('status')).toHaveTextContent('登录状态已失效，请重新登录。')
-    expect(sessionStorage.getItem('angui.session.token')).toBeNull()
-  })
-})
+    expect(await screen.findByText("family@demo.invalid")).toBeInTheDocument();
+    await expect(
+      apiRequest("/cases", {}, "existing-session"),
+    ).rejects.toMatchObject({ status: 401 });
+    await waitFor(() =>
+      expect(screen.getByText("anonymous")).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "登录状态已失效，请重新登录。",
+    );
+    expect(sessionStorage.getItem("angui.session.token")).toBeNull();
+  });
+});

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -1,63 +1,66 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import type { ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
 import {
   getCurrentUser,
   login as requestLogin,
   logout as requestLogout,
-} from '../api/auth'
-import type { AuthUser } from '../api/auth'
-import { SESSION_EXPIRED_EVENT } from '../api/client'
-import { AuthContext } from './auth-context'
-import type { AuthContextValue } from './auth-context'
+} from "../api/auth";
+import type { AuthUser } from "../api/auth";
+import { SESSION_EXPIRED_EVENT } from "../api/client";
+import { AuthContext } from "./auth-context";
+import type { AuthContextValue } from "./auth-context";
 
-const TOKEN_KEY = 'angui.session.token'
+const TOKEN_KEY = "angui.session.token";
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-  const [token, setToken] = useState<string | null>(() => sessionStorage.getItem(TOKEN_KEY))
-  const [user, setUser] = useState<AuthUser | null>(null)
-  const [isLoading, setIsLoading] = useState(Boolean(token))
-  const [isLoggingOut, setIsLoggingOut] = useState(false)
-  const [sessionNotice, setSessionNotice] = useState<string | null>(null)
+  const [token, setToken] = useState<string | null>(() =>
+    sessionStorage.getItem(TOKEN_KEY),
+  );
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isLoading, setIsLoading] = useState(Boolean(token));
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const [sessionNotice, setSessionNotice] = useState<string | null>(null);
   const clearSession = useCallback((notice?: string) => {
-    sessionStorage.removeItem(TOKEN_KEY)
-    setToken(null)
-    setUser(null)
-    if (notice) setSessionNotice(notice)
-  }, [])
+    sessionStorage.removeItem(TOKEN_KEY);
+    setToken(null);
+    setUser(null);
+    if (notice) setSessionNotice(notice);
+  }, []);
 
   useEffect(() => {
     const handleSessionExpired = () => {
-      clearSession('登录状态已失效，请重新登录。')
-    }
-    window.addEventListener(SESSION_EXPIRED_EVENT, handleSessionExpired)
-    return () => window.removeEventListener(SESSION_EXPIRED_EVENT, handleSessionExpired)
-  }, [clearSession])
+      clearSession("登录状态已失效，请重新登录。");
+    };
+    window.addEventListener(SESSION_EXPIRED_EVENT, handleSessionExpired);
+    return () =>
+      window.removeEventListener(SESSION_EXPIRED_EVENT, handleSessionExpired);
+  }, [clearSession]);
 
   useEffect(() => {
     if (!token) {
-      setUser(null)
-      setIsLoading(false)
-      return
+      setUser(null);
+      setIsLoading(false);
+      return;
     }
 
-    let active = true
-    setIsLoading(true)
+    let active = true;
+    setIsLoading(true);
     getCurrentUser(token)
       .then((currentUser) => {
-        if (active) setUser(currentUser)
+        if (active) setUser(currentUser);
       })
       .catch(() => {
-        if (!active) return
-        clearSession()
+        if (!active) return;
+        clearSession();
       })
       .finally(() => {
-        if (active) setIsLoading(false)
-      })
+        if (active) setIsLoading(false);
+      });
 
     return () => {
-      active = false
-    }
-  }, [clearSession, token])
+      active = false;
+    };
+  }, [clearSession, token]);
 
   const value = useMemo<AuthContextValue>(
     () => ({
@@ -67,32 +70,32 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       isLoggingOut,
       sessionNotice,
       login: async (email, password) => {
-        const response = await requestLogin(email, password)
-        sessionStorage.setItem(TOKEN_KEY, response.token)
-        setSessionNotice(null)
-        setToken(response.token)
-        setUser(response.user)
+        const response = await requestLogin(email, password);
+        sessionStorage.setItem(TOKEN_KEY, response.token);
+        setSessionNotice(null);
+        setToken(response.token);
+        setUser(response.user);
       },
       logout: async () => {
-        if (!token) return
-        setIsLoggingOut(true)
+        if (!token) return;
+        setIsLoggingOut(true);
         try {
-          await requestLogout(token)
+          await requestLogout(token);
         } catch {
           // Remote revocation is best effort; always complete the local safety exit.
         } finally {
-          clearSession()
-          setIsLoggingOut(false)
+          clearSession();
+          setIsLoggingOut(false);
         }
       },
       refreshUser: async () => {
-        if (!token) return
-        const currentUser = await getCurrentUser(token)
-        setUser(currentUser)
+        if (!token) return;
+        const currentUser = await getCurrentUser(token);
+        setUser(currentUser);
       },
     }),
     [clearSession, isLoading, isLoggingOut, sessionNotice, token, user],
-  )
+  );
 
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }

--- a/frontend/src/auth/auth-context.ts
+++ b/frontend/src/auth/auth-context.ts
@@ -1,15 +1,15 @@
-import { createContext } from 'react'
-import type { AuthUser } from '../api/auth'
+import { createContext } from "react";
+import type { AuthUser } from "../api/auth";
 
 export interface AuthContextValue {
-  user: AuthUser | null
-  token: string | null
-  isLoading: boolean
-  isLoggingOut: boolean
-  sessionNotice: string | null
-  login: (email: string, password: string) => Promise<void>
-  logout: () => Promise<void>
-  refreshUser: () => Promise<void>
+  user: AuthUser | null;
+  token: string | null;
+  isLoading: boolean;
+  isLoggingOut: boolean;
+  sessionNotice: string | null;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+  refreshUser: () => Promise<void>;
 }
 
-export const AuthContext = createContext<AuthContextValue | null>(null)
+export const AuthContext = createContext<AuthContextValue | null>(null);

--- a/frontend/src/auth/useAuth.ts
+++ b/frontend/src/auth/useAuth.ts
@@ -1,11 +1,11 @@
-import { useContext } from 'react'
-import { AuthContext } from './auth-context'
-import type { AuthContextValue } from './auth-context'
+import { useContext } from "react";
+import { AuthContext } from "./auth-context";
+import type { AuthContextValue } from "./auth-context";
 
 export function useAuth(): AuthContextValue {
-  const value = useContext(AuthContext)
+  const value = useContext(AuthContext);
   if (!value) {
-    throw new Error('useAuth must be used inside AuthProvider')
+    throw new Error("useAuth must be used inside AuthProvider");
   }
-  return value
+  return value;
 }

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { Button, Chip, Spinner } from '@heroui/react'
+import { Button, Chip, Spinner } from "@heroui/react";
 import {
   HeartHandshake,
   LayoutDashboard,
@@ -6,48 +6,68 @@ import {
   Navigation,
   RadioTower,
   UserRound,
-} from 'lucide-react'
-import { NavLink, Outlet } from 'react-router'
-import brandMark from '../../../assets/brand/angui-mark.svg'
-import { useAuth } from '../auth/useAuth'
-import type { AccountType, GlobalCapability } from '../api/auth'
-import { ServiceStatus } from './ServiceStatus'
+} from "lucide-react";
+import { NavLink, Outlet } from "react-router";
+import brandMark from "../../../assets/brand/angui-mark.svg";
+import { useAuth } from "../auth/useAuth";
+import type { AccountType, GlobalCapability } from "../api/auth";
+import { ServiceStatus } from "./ServiceStatus";
 
 interface NavigationItem {
-  to: string
-  label: string
-  icon: typeof LayoutDashboard
-  end?: boolean
-  capability?: 'commander' | 'volunteer'
-  familyOnly?: boolean
+  to: string;
+  label: string;
+  icon: typeof LayoutDashboard;
+  end?: boolean;
+  capability?: "commander" | "volunteer";
+  familyOnly?: boolean;
 }
 
 const navigation: NavigationItem[] = [
-  { to: '/', label: '总览', icon: LayoutDashboard, end: true },
-  { to: '/family', label: '家属端', icon: HeartHandshake, familyOnly: true },
-  { to: '/command', label: '指挥端', icon: RadioTower, capability: 'commander' },
-  { to: '/volunteer', label: '志愿者端', icon: Navigation, capability: 'volunteer' },
-  { to: '/profile', label: '个人资料', icon: UserRound },
-]
+  { to: "/", label: "总览", icon: LayoutDashboard, end: true },
+  { to: "/family", label: "家属端", icon: HeartHandshake, familyOnly: true },
+  {
+    to: "/command",
+    label: "指挥端",
+    icon: RadioTower,
+    capability: "commander",
+  },
+  {
+    to: "/volunteer",
+    label: "志愿者端",
+    icon: Navigation,
+    capability: "volunteer",
+  },
+  { to: "/profile", label: "个人资料", icon: UserRound },
+];
 
 const roleLabels: Record<GlobalCapability, string> = {
-  commander: '指挥',
-  volunteer: '志愿者',
-  admin: '管理员',
-}
+  commander: "指挥",
+  volunteer: "志愿者",
+  admin: "管理员",
+};
 
-function identityLabel(accountType: AccountType, capabilities: GlobalCapability[]) {
-  const labels = capabilities.map((capability) => roleLabels[capability])
-  return labels.length > 0 ? `${accountType} / ${labels.join(' / ')}` : accountType
+function identityLabel(
+  accountType: AccountType,
+  capabilities: GlobalCapability[],
+) {
+  const labels = capabilities.map((capability) => roleLabels[capability]);
+  return labels.length > 0
+    ? `${accountType} / ${labels.join(" / ")}`
+    : accountType;
 }
 
 export function AppShell() {
-  const { user, logout, isLoggingOut } = useAuth()
-  const visibleNavigation = navigation.filter((item) => user && (
-    item.to === '/'
-    || item.to === '/profile'
-    || (user.account_type === 'member' && (!item.capability || user.global_capabilities.includes(item.capability)) && (!item.familyOnly || user.global_capabilities.length === 0))
-  ))
+  const { user, logout, isLoggingOut } = useAuth();
+  const visibleNavigation = navigation.filter(
+    (item) =>
+      user &&
+      (item.to === "/" ||
+        item.to === "/profile" ||
+        (user.account_type === "member" &&
+          (!item.capability ||
+            user.global_capabilities.includes(item.capability)) &&
+          (!item.familyOnly || user.global_capabilities.length === 0))),
+  );
 
   return (
     <div className="min-h-screen bg-canvas text-slate-700 lg:grid lg:grid-cols-[224px_minmax(0,1fr)]">
@@ -55,14 +75,20 @@ export function AppShell() {
         <div className="hidden min-h-12 items-center gap-3 px-2 pb-5 lg:flex">
           <img src={brandMark} className="size-10 rounded-md" alt="安归" />
           <div className="min-w-0">
-            <strong className="block text-lg leading-tight text-slate-950">安归</strong>
-            <span className="mt-0.5 block text-xs text-slate-500">协同工作台</span>
+            <strong className="block text-lg leading-tight text-slate-950">
+              安归
+            </strong>
+            <span className="mt-0.5 block text-xs text-slate-500">
+              协同工作台
+            </span>
           </div>
         </div>
 
         <nav
           className="grid h-full gap-1 lg:flex lg:h-auto lg:flex-col"
-          style={{ gridTemplateColumns: `repeat(${Math.max(visibleNavigation.length, 1)}, minmax(0, 1fr))` }}
+          style={{
+            gridTemplateColumns: `repeat(${Math.max(visibleNavigation.length, 1)}, minmax(0, 1fr))`,
+          }}
           aria-label="主要导航"
         >
           {visibleNavigation.map(({ to, label, icon: Icon, end }) => (
@@ -72,11 +98,11 @@ export function AppShell() {
               end={end}
               className={({ isActive }) =>
                 [
-                  'flex min-h-12 items-center justify-center gap-1 rounded-md px-1 text-xs font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600 lg:min-h-10 lg:justify-start lg:gap-3 lg:px-3 lg:text-sm',
+                  "flex min-h-12 items-center justify-center gap-1 rounded-md px-1 text-xs font-medium transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600 lg:min-h-10 lg:justify-start lg:gap-3 lg:px-3 lg:text-sm",
                   isActive
-                    ? 'bg-brand-50 text-brand-700'
-                    : 'text-slate-500 hover:bg-slate-100 hover:text-slate-950',
-                ].join(' ')
+                    ? "bg-brand-50 text-brand-700"
+                    : "text-slate-500 hover:bg-slate-100 hover:text-slate-950",
+                ].join(" ")
               }
             >
               <Icon size={18} aria-hidden="true" />
@@ -89,18 +115,35 @@ export function AppShell() {
           {user && (
             <div className="mb-3 min-w-0">
               <div className="flex items-center gap-2">
-                <strong className="truncate text-sm text-slate-950">{user.display_name}</strong>
+                <strong className="truncate text-sm text-slate-950">
+                  {user.display_name}
+                </strong>
                 <Chip size="sm" variant="soft">
-                  <Chip.Label>{identityLabel(user.account_type, user.global_capabilities)}</Chip.Label>
+                  <Chip.Label>
+                    {identityLabel(user.account_type, user.global_capabilities)}
+                  </Chip.Label>
                 </Chip>
               </div>
-              <span className="mt-1 block truncate text-xs text-slate-500">{user.email}</span>
+              <span className="mt-1 block truncate text-xs text-slate-500">
+                {user.email}
+              </span>
             </div>
           )}
           <ServiceStatus compact />
-          <Button className="mt-3" size="sm" variant="ghost" fullWidth isDisabled={isLoggingOut} onPress={() => void logout()}>
-            {isLoggingOut ? <Spinner size="sm" aria-label="正在退出登录" /> : <LogOut size={16} aria-hidden="true" />}
-            {isLoggingOut ? '正在退出' : '退出登录'}
+          <Button
+            className="mt-3"
+            size="sm"
+            variant="ghost"
+            fullWidth
+            isDisabled={isLoggingOut}
+            onPress={() => void logout()}
+          >
+            {isLoggingOut ? (
+              <Spinner size="sm" aria-label="正在退出登录" />
+            ) : (
+              <LogOut size={16} aria-hidden="true" />
+            )}
+            {isLoggingOut ? "正在退出" : "退出登录"}
           </Button>
         </div>
       </aside>
@@ -108,15 +151,32 @@ export function AppShell() {
       <main className="min-w-0 pb-16 lg:pb-0">
         <div className="flex min-h-14 items-center justify-between border-b border-slate-200 bg-white px-4 lg:hidden">
           <div className="min-w-0">
-            <strong className="block truncate text-sm text-slate-950">{user?.display_name}</strong>
-            <span className="block truncate text-xs text-slate-500">{user ? identityLabel(user.account_type, user.global_capabilities) : ''}</span>
+            <strong className="block truncate text-sm text-slate-950">
+              {user?.display_name}
+            </strong>
+            <span className="block truncate text-xs text-slate-500">
+              {user
+                ? identityLabel(user.account_type, user.global_capabilities)
+                : ""}
+            </span>
           </div>
-          <Button size="sm" variant="ghost" isIconOnly aria-label={isLoggingOut ? '正在退出登录' : '退出登录'} isDisabled={isLoggingOut} onPress={() => void logout()}>
-            {isLoggingOut ? <Spinner size="sm" /> : <LogOut size={17} aria-hidden="true" />}
+          <Button
+            size="sm"
+            variant="ghost"
+            isIconOnly
+            aria-label={isLoggingOut ? "正在退出登录" : "退出登录"}
+            isDisabled={isLoggingOut}
+            onPress={() => void logout()}
+          >
+            {isLoggingOut ? (
+              <Spinner size="sm" />
+            ) : (
+              <LogOut size={17} aria-hidden="true" />
+            )}
           </Button>
         </div>
         <Outlet />
       </main>
     </div>
-  )
+  );
 }

--- a/frontend/src/components/ContentState.tsx
+++ b/frontend/src/components/ContentState.tsx
@@ -1,30 +1,33 @@
-import { Button, Spinner } from '@heroui/react'
-import { CircleAlert, Inbox, RefreshCw, type LucideIcon } from 'lucide-react'
+import { Button, Spinner } from "@heroui/react";
+import { CircleAlert, Inbox, RefreshCw, type LucideIcon } from "lucide-react";
 
 interface Action {
-  label: string
-  onPress: () => void
+  label: string;
+  onPress: () => void;
 }
 
 interface EmptyStateProps {
-  title: string
-  description?: string
-  icon?: LucideIcon
-  action?: Action
+  title: string;
+  description?: string;
+  icon?: LucideIcon;
+  action?: Action;
 }
 
 interface ErrorStateProps {
-  message: string
-  onRetry?: () => void
+  message: string;
+  onRetry?: () => void;
 }
 
-export function LoadingState({ label = '正在加载' }: { label?: string }) {
+export function LoadingState({ label = "正在加载" }: { label?: string }) {
   return (
-    <div className="flex min-h-40 flex-col items-center justify-center gap-3 px-5 py-8" role="status">
+    <div
+      className="flex min-h-40 flex-col items-center justify-center gap-3 px-5 py-8"
+      role="status"
+    >
       <Spinner />
       <span className="text-sm text-slate-500">{label}</span>
     </div>
-  )
+  );
 }
 
 export function EmptyState({
@@ -35,34 +38,59 @@ export function EmptyState({
 }: EmptyStateProps) {
   return (
     <div className="flex min-h-48 flex-col items-center justify-center px-5 py-8 text-center">
-      <span className="grid size-10 place-items-center rounded-md bg-slate-100 text-slate-400" aria-hidden="true">
+      <span
+        className="grid size-10 place-items-center rounded-md bg-slate-100 text-slate-400"
+        aria-hidden="true"
+      >
         <Icon size={22} />
       </span>
       <strong className="mt-4 text-sm text-slate-950">{title}</strong>
-      {description && <span className="mt-1 max-w-md text-xs leading-5 text-slate-500">{description}</span>}
+      {description && (
+        <span className="mt-1 max-w-md text-xs leading-5 text-slate-500">
+          {description}
+        </span>
+      )}
       {action && (
-        <Button className="mt-4" size="sm" variant="secondary" onPress={action.onPress}>
+        <Button
+          className="mt-4"
+          size="sm"
+          variant="secondary"
+          onPress={action.onPress}
+        >
           {action.label}
         </Button>
       )}
     </div>
-  )
+  );
 }
 
 export function ErrorState({ message, onRetry }: ErrorStateProps) {
   return (
-    <div className="flex min-h-48 flex-col items-center justify-center px-5 py-8 text-center" role="alert">
-      <span className="grid size-10 place-items-center rounded-md bg-red-50 text-red-700" aria-hidden="true">
+    <div
+      className="flex min-h-48 flex-col items-center justify-center px-5 py-8 text-center"
+      role="alert"
+    >
+      <span
+        className="grid size-10 place-items-center rounded-md bg-red-50 text-red-700"
+        aria-hidden="true"
+      >
         <CircleAlert size={22} />
       </span>
       <strong className="mt-4 text-sm text-slate-950">暂时无法加载内容</strong>
-      <span className="mt-1 max-w-md text-xs leading-5 text-slate-500">{message}</span>
+      <span className="mt-1 max-w-md text-xs leading-5 text-slate-500">
+        {message}
+      </span>
       {onRetry && (
-        <Button className="mt-4" size="sm" variant="secondary" onPress={onRetry}>
+        <Button
+          className="mt-4"
+          size="sm"
+          variant="secondary"
+          onPress={onRetry}
+        >
           <RefreshCw size={15} aria-hidden="true" />
           重试
         </Button>
       )}
     </div>
-  )
+  );
 }

--- a/frontend/src/components/ServiceStatus.tsx
+++ b/frontend/src/components/ServiceStatus.tsx
@@ -1,57 +1,57 @@
-import { Button, Chip, Spinner, Tooltip } from '@heroui/react'
-import { CircleAlert, CircleCheck, RefreshCw } from 'lucide-react'
-import { useCallback, useEffect, useState } from 'react'
-import { getHealth, type HealthResponse } from '../api/health'
+import { Button, Chip, Spinner, Tooltip } from "@heroui/react";
+import { CircleAlert, CircleCheck, RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { getHealth, type HealthResponse } from "../api/health";
 
 type RequestState =
-  | { status: 'checking' }
-  | { status: 'online'; health: HealthResponse }
-  | { status: 'offline' }
+  | { status: "checking" }
+  | { status: "online"; health: HealthResponse }
+  | { status: "offline" };
 
 interface ServiceStatusProps {
-  compact?: boolean
+  compact?: boolean;
 }
 
 export function ServiceStatus({ compact = false }: ServiceStatusProps) {
-  const [state, setState] = useState<RequestState>({ status: 'checking' })
+  const [state, setState] = useState<RequestState>({ status: "checking" });
 
   const checkHealth = useCallback(async () => {
-    const controller = new AbortController()
-    const timeoutId = window.setTimeout(() => controller.abort(), 4000)
-    setState({ status: 'checking' })
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(() => controller.abort(), 4000);
+    setState({ status: "checking" });
 
     try {
-      const health = await getHealth(controller.signal)
-      setState({ status: 'online', health })
+      const health = await getHealth(controller.signal);
+      setState({ status: "online", health });
     } catch {
-      setState({ status: 'offline' })
+      setState({ status: "offline" });
     } finally {
-      window.clearTimeout(timeoutId)
+      window.clearTimeout(timeoutId);
     }
-  }, [])
+  }, []);
 
   useEffect(() => {
-    void checkHealth()
-  }, [checkHealth])
+    void checkHealth();
+  }, [checkHealth]);
 
-  if (state.status === 'checking') {
+  if (state.status === "checking") {
     return (
       <Chip color="accent" size="sm" variant="soft">
         <Spinner size="sm" color="accent" aria-hidden="true" />
         <Chip.Label>正在连接后端</Chip.Label>
       </Chip>
-    )
+    );
   }
 
-  if (state.status === 'online') {
+  if (state.status === "online") {
     return (
       <Chip color="success" size="sm" variant="soft">
         <CircleCheck size={15} aria-hidden="true" />
         <Chip.Label>
-          服务在线{compact ? '' : ` · v${state.health.version}`}
+          服务在线{compact ? "" : ` · v${state.health.version}`}
         </Chip.Label>
       </Chip>
-    )
+    );
   }
 
   return (
@@ -73,5 +73,5 @@ export function ServiceStatus({ compact = false }: ServiceStatusProps) {
         <Tooltip.Content>重新检查后端连接</Tooltip.Content>
       </Tooltip>
     </div>
-  )
+  );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -10,8 +10,15 @@
 }
 
 :root {
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
-    "Segoe UI", "Microsoft YaHei", sans-serif;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    "Microsoft YaHei",
+    sans-serif;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,11 +1,11 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import { BrowserRouter } from 'react-router'
-import './index.css'
-import App from './App.tsx'
-import { AuthProvider } from './auth/AuthContext.tsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router";
+import "./index.css";
+import App from "./App.tsx";
+import { AuthProvider } from "./auth/AuthContext.tsx";
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>
       <AuthProvider>
@@ -13,4 +13,4 @@ createRoot(document.getElementById('root')!).render(
       </AuthProvider>
     </BrowserRouter>
   </StrictMode>,
-)
+);

--- a/frontend/src/pages/CaseWorkspacePage.test.tsx
+++ b/frontend/src/pages/CaseWorkspacePage.test.tsx
@@ -1,10 +1,16 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
-import type { CaseDetail, CaseRole, CaseStatus, Clue } from '../api/cases'
-import { CaseWorkspacePage } from './CaseWorkspacePage'
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { CaseDetail, CaseRole, CaseStatus, Clue } from "../api/cases";
+import { CaseWorkspacePage } from "./CaseWorkspacePage";
 
 const mocked = vi.hoisted(() => ({
-  auth: { token: 'test-session' as string | null },
+  auth: { token: "test-session" as string | null },
   getCase: vi.fn(),
   getCaseMapView: vi.fn(),
   getCasePublicProgress: vi.fn(),
@@ -20,17 +26,20 @@ const mocked = vi.hoisted(() => ({
   listCaseMembers: vi.fn(),
   createCaseTask: vi.fn(),
   reviewClue: vi.fn(),
-}))
+}));
 
-vi.mock('../auth/useAuth', () => ({
+vi.mock("../auth/useAuth", () => ({
   useAuth: () => ({ token: mocked.auth.token }),
-}))
-vi.mock('../api/cases', () => ({
+}));
+vi.mock("../api/cases", () => ({
   getCase: (...args: unknown[]) => mocked.getCase(...args),
   getCaseMapView: (...args: unknown[]) => mocked.getCaseMapView(...args),
-  getCasePublicProgress: (...args: unknown[]) => mocked.getCasePublicProgress(...args),
-  getLatestSummaryDraft: (...args: unknown[]) => mocked.getLatestSummaryDraft(...args),
-  getCaseResourceConfiguration: (...args: unknown[]) => mocked.getCaseResourceConfiguration(...args),
+  getCasePublicProgress: (...args: unknown[]) =>
+    mocked.getCasePublicProgress(...args),
+  getLatestSummaryDraft: (...args: unknown[]) =>
+    mocked.getLatestSummaryDraft(...args),
+  getCaseResourceConfiguration: (...args: unknown[]) =>
+    mocked.getCaseResourceConfiguration(...args),
   listCases: (...args: unknown[]) => mocked.listCases(...args),
   listCommandIntake: (...args: unknown[]) => mocked.listCommandIntake(...args),
   acceptCommandCase: (...args: unknown[]) => mocked.acceptCommandCase(...args),
@@ -47,23 +56,23 @@ vi.mock('../api/cases', () => ({
   uploadCaseAttachment: vi.fn(),
   updateCaseStatus: vi.fn(),
   updateElderProfile: vi.fn(),
-}))
+}));
 
 function deferred<T>() {
-  let resolve!: (value: T) => void
-  let reject!: (reason?: unknown) => void
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
   const promise = new Promise<T>((nextResolve, nextReject) => {
-    resolve = nextResolve
-    reject = nextReject
-  })
-  return { promise, resolve, reject }
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
 }
 
 function detail(
   id: string,
   displayName: string,
-  accessRole: CaseRole = 'family',
-  status: CaseStatus = 'active',
+  accessRole: CaseRole = "family",
+  status: CaseStatus = "active",
 ): CaseDetail {
   return {
     id,
@@ -84,374 +93,484 @@ function detail(
     clues: [],
     places: [],
     attachments: [],
-    created_at: '2026-07-24T00:00:00Z',
-    updated_at: '2026-07-24T00:00:00Z',
-  }
+    created_at: "2026-07-24T00:00:00Z",
+    updated_at: "2026-07-24T00:00:00Z",
+  };
 }
 
-describe('CaseWorkspacePage', () => {
-  it('lets a commander accept a minimal pending case before viewing it', async () => {
-    mocked.listCases.mockResolvedValue([])
-    mocked.listCommandIntake.mockResolvedValue([{ id: 'pending-case', case_code: 'AG-PENDING', created_at: '2026-07-24T00:00:00Z', last_seen_at: null, area_hint: 'Fictional north gate', elder_age: 76 }])
-    mocked.acceptCommandCase.mockResolvedValue(detail('pending-case', 'Accepted case', 'commander'))
+describe("CaseWorkspacePage", () => {
+  it("lets a commander accept a minimal pending case before viewing it", async () => {
+    mocked.listCases.mockResolvedValue([]);
+    mocked.listCommandIntake.mockResolvedValue([
+      {
+        id: "pending-case",
+        case_code: "AG-PENDING",
+        created_at: "2026-07-24T00:00:00Z",
+        last_seen_at: null,
+        area_hint: "Fictional north gate",
+        elder_age: 76,
+      },
+    ]);
+    mocked.acceptCommandCase.mockResolvedValue(
+      detail("pending-case", "Accepted case", "commander"),
+    );
 
-    render(<CaseWorkspacePage mode="commander" />)
+    render(<CaseWorkspacePage mode="commander" />);
 
-    expect(await screen.findByText('AG-PENDING')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: '受理案件' }))
-    await waitFor(() => expect(mocked.acceptCommandCase).toHaveBeenCalledWith('test-session', 'pending-case'))
-  })
+    expect(await screen.findByText("AG-PENDING")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "受理案件" }));
+    await waitFor(() =>
+      expect(mocked.acceptCommandCase).toHaveBeenCalledWith(
+        "test-session",
+        "pending-case",
+      ),
+    );
+  });
 
-  it('renders role-filtered map records as a usable text fallback', async () => {
-    mocked.listCases.mockResolvedValue([{ id: 'case-command', case_code: 'AG-COMMAND', status: 'active', access_role: 'commander', display_name: 'Commander case', last_seen_at: null, last_seen_location: null, created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z' }])
-    mocked.getCase.mockResolvedValue(detail('case-command', 'Commander case', 'commander'))
-    mocked.getCaseResourceConfiguration.mockResolvedValue({ attachment_max_image_bytes: 5 * 1024 * 1024, attachment_max_per_case: 12, case_place_types: ['frequent'] })
-    mocked.getCaseMapView.mockResolvedValue({ items: [
-      { id: 'place-text', object_type: 'place', display_name: 'Fictional market', longitude: null, latitude: null, location_text: 'North gate, fictional park', location_precision: 'unknown', source: 'commander', occurred_at: null, reported_at: '2026-07-24T00:00:00Z', review_status: 'confirmed', related_task_id: null, updated_at: '2026-07-24T00:00:00Z' },
-    ] })
-    mocked.listCaseClues.mockResolvedValue({ items: [], page: 1, page_size: 25, total: 0 })
-
-    render(<CaseWorkspacePage mode="commander" />)
-
-    expect(await screen.findByText('Fictional market')).toBeInTheDocument()
-    expect(screen.getByText('North gate, fictional park')).toBeInTheDocument()
-    expect(screen.getByText('仅文字地点')).toBeInTheDocument()
-    expect(mocked.getCaseMapView).toHaveBeenCalledWith('test-session', 'case-command')
-  })
-
-  it('does not let an earlier detail request overwrite the most recently selected case', async () => {
-    const firstRequest = deferred<CaseDetail>()
-    const secondRequest = deferred<CaseDetail>()
+  it("renders role-filtered map records as a usable text fallback", async () => {
     mocked.listCases.mockResolvedValue([
       {
-        id: 'case-1', case_code: 'AG-1', status: 'active', access_role: 'family', display_name: '案件甲',
-        last_seen_at: null, last_seen_location: null, created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z',
+        id: "case-command",
+        case_code: "AG-COMMAND",
+        status: "active",
+        access_role: "commander",
+        display_name: "Commander case",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
       },
-      {
-        id: 'case-2', case_code: 'AG-2', status: 'active', access_role: 'family', display_name: '案件乙',
-        last_seen_at: null, last_seen_location: null, created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z',
-      },
-    ])
-    mocked.getCase.mockImplementation((_token: string, caseId: string) => (
-      caseId === 'case-1' ? firstRequest.promise : secondRequest.promise
-    ))
+    ]);
+    mocked.getCase.mockResolvedValue(
+      detail("case-command", "Commander case", "commander"),
+    );
     mocked.getCaseResourceConfiguration.mockResolvedValue({
       attachment_max_image_bytes: 5 * 1024 * 1024,
       attachment_max_per_case: 12,
-      case_place_types: ['frequent'],
-    })
+      case_place_types: ["frequent"],
+    });
+    mocked.getCaseMapView.mockResolvedValue({
+      items: [
+        {
+          id: "place-text",
+          object_type: "place",
+          display_name: "Fictional market",
+          longitude: null,
+          latitude: null,
+          location_text: "North gate, fictional park",
+          location_precision: "unknown",
+          source: "commander",
+          occurred_at: null,
+          reported_at: "2026-07-24T00:00:00Z",
+          review_status: "confirmed",
+          related_task_id: null,
+          updated_at: "2026-07-24T00:00:00Z",
+        },
+      ],
+    });
+    mocked.listCaseClues.mockResolvedValue({
+      items: [],
+      page: 1,
+      page_size: 25,
+      total: 0,
+    });
 
-    render(<CaseWorkspacePage mode="family" />)
-    await waitFor(() => expect(mocked.getCase).toHaveBeenCalledWith('test-session', 'case-1'))
+    render(<CaseWorkspacePage mode="commander" />);
 
-    fireEvent.click(screen.getByText('案件乙'))
-    await waitFor(() => expect(mocked.getCase).toHaveBeenCalledWith('test-session', 'case-2'))
+    expect(await screen.findByText("Fictional market")).toBeInTheDocument();
+    expect(screen.getByText("North gate, fictional park")).toBeInTheDocument();
+    expect(screen.getByText("仅文字地点")).toBeInTheDocument();
+    expect(mocked.getCaseMapView).toHaveBeenCalledWith(
+      "test-session",
+      "case-command",
+    );
+  });
+
+  it("does not let an earlier detail request overwrite the most recently selected case", async () => {
+    const firstRequest = deferred<CaseDetail>();
+    const secondRequest = deferred<CaseDetail>();
+    mocked.listCases.mockResolvedValue([
+      {
+        id: "case-1",
+        case_code: "AG-1",
+        status: "active",
+        access_role: "family",
+        display_name: "案件甲",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
+      },
+      {
+        id: "case-2",
+        case_code: "AG-2",
+        status: "active",
+        access_role: "family",
+        display_name: "案件乙",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
+      },
+    ]);
+    mocked.getCase.mockImplementation((_token: string, caseId: string) =>
+      caseId === "case-1" ? firstRequest.promise : secondRequest.promise,
+    );
+    mocked.getCaseResourceConfiguration.mockResolvedValue({
+      attachment_max_image_bytes: 5 * 1024 * 1024,
+      attachment_max_per_case: 12,
+      case_place_types: ["frequent"],
+    });
+
+    render(<CaseWorkspacePage mode="family" />);
+    await waitFor(() =>
+      expect(mocked.getCase).toHaveBeenCalledWith("test-session", "case-1"),
+    );
+
+    fireEvent.click(screen.getByText("案件乙"));
+    await waitFor(() =>
+      expect(mocked.getCase).toHaveBeenCalledWith("test-session", "case-2"),
+    );
 
     await act(async () => {
-      secondRequest.resolve(detail('case-2', '最新案件详情'))
-      await secondRequest.promise
-    })
-    expect(screen.getByRole('heading', { name: '最新案件详情' })).toBeInTheDocument()
+      secondRequest.resolve(detail("case-2", "最新案件详情"));
+      await secondRequest.promise;
+    });
+    expect(
+      screen.getByRole("heading", { name: "最新案件详情" }),
+    ).toBeInTheDocument();
 
     await act(async () => {
-      firstRequest.reject(new Error('过期请求'))
-      await firstRequest.promise.catch(() => undefined)
-    })
-    expect(screen.getByRole('heading', { name: '最新案件详情' })).toBeInTheDocument()
-    expect(screen.queryByText('过期请求')).not.toBeInTheDocument()
-  })
+      firstRequest.reject(new Error("过期请求"));
+      await firstRequest.promise.catch(() => undefined);
+    });
+    expect(
+      screen.getByRole("heading", { name: "最新案件详情" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("过期请求")).not.toBeInTheDocument();
+  });
 
-  it('discards a stale family public-progress response after switching cases', async () => {
-    vi.clearAllMocks()
-    const firstProgress = deferred<Record<string, unknown>>()
-    const secondProgress = deferred<Record<string, unknown>>()
+  it("discards a stale family public-progress response after switching cases", async () => {
+    vi.clearAllMocks();
+    const firstProgress = deferred<Record<string, unknown>>();
+    const secondProgress = deferred<Record<string, unknown>>();
     mocked.listCases.mockResolvedValue([
-      { id: 'case-1', case_code: 'AG-1', status: 'active', access_role: 'family', display_name: 'Case one', last_seen_at: null, last_seen_location: null, created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z' },
-      { id: 'case-2', case_code: 'AG-2', status: 'active', access_role: 'family', display_name: 'Case two', last_seen_at: null, last_seen_location: null, created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z' },
-    ])
-    mocked.getCase.mockImplementation((_token: string, caseId: string) => Promise.resolve(detail(caseId, caseId === 'case-1' ? 'Case one' : 'Case two')))
-    mocked.getCaseResourceConfiguration.mockResolvedValue({ attachment_max_image_bytes: 5 * 1024 * 1024, attachment_max_per_case: 12, case_place_types: ['frequent'] })
-    mocked.getCasePublicProgress.mockImplementation((_token: string, caseId: string) => (
-      caseId === 'case-1' ? firstProgress.promise : secondProgress.promise
-    ))
+      {
+        id: "case-1",
+        case_code: "AG-1",
+        status: "active",
+        access_role: "family",
+        display_name: "Case one",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
+      },
+      {
+        id: "case-2",
+        case_code: "AG-2",
+        status: "active",
+        access_role: "family",
+        display_name: "Case two",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
+      },
+    ]);
+    mocked.getCase.mockImplementation((_token: string, caseId: string) =>
+      Promise.resolve(
+        detail(caseId, caseId === "case-1" ? "Case one" : "Case two"),
+      ),
+    );
+    mocked.getCaseResourceConfiguration.mockResolvedValue({
+      attachment_max_image_bytes: 5 * 1024 * 1024,
+      attachment_max_per_case: 12,
+      case_place_types: ["frequent"],
+    });
+    mocked.getCasePublicProgress.mockImplementation(
+      (_token: string, caseId: string) =>
+        caseId === "case-1" ? firstProgress.promise : secondProgress.promise,
+    );
 
-    render(<CaseWorkspacePage mode="family" />)
+    render(<CaseWorkspacePage mode="family" />);
 
-    await screen.findByRole('heading', { name: 'Case one' })
-    await waitFor(() => expect(mocked.getCasePublicProgress).toHaveBeenCalledWith('test-session', 'case-1'))
-    fireEvent.click(screen.getByText('Case two'))
-    await screen.findByRole('heading', { name: 'Case two' })
-    await waitFor(() => expect(mocked.getCasePublicProgress).toHaveBeenCalledWith('test-session', 'case-2'))
+    await screen.findByRole("heading", { name: "Case one" });
+    await waitFor(() =>
+      expect(mocked.getCasePublicProgress).toHaveBeenCalledWith(
+        "test-session",
+        "case-1",
+      ),
+    );
+    fireEvent.click(screen.getByText("Case two"));
+    await screen.findByRole("heading", { name: "Case two" });
+    await waitFor(() =>
+      expect(mocked.getCasePublicProgress).toHaveBeenCalledWith(
+        "test-session",
+        "case-2",
+      ),
+    );
 
     await act(async () => {
-      secondProgress.resolve({ case_id: 'case-2', status: 'active', generated_at: '2026-07-24T00:00:00Z', confirmed_progress: [{ clue_id: 'new', progress_type: 'confirmed_update', review_status: 'confirmed', updated_at: '2026-07-24T00:00:00Z' }], requested_family_information: [], safety_and_contact_reminders: [] })
-      await secondProgress.promise
-    })
-    expect(await screen.findByText('已确认一项案件进展。')).toBeInTheDocument()
+      secondProgress.resolve({
+        case_id: "case-2",
+        status: "active",
+        generated_at: "2026-07-24T00:00:00Z",
+        confirmed_progress: [
+          {
+            clue_id: "new",
+            progress_type: "confirmed_update",
+            review_status: "confirmed",
+            updated_at: "2026-07-24T00:00:00Z",
+          },
+        ],
+        requested_family_information: [],
+        safety_and_contact_reminders: [],
+      });
+      await secondProgress.promise;
+    });
+    expect(await screen.findByText("已确认一项案件进展。")).toBeInTheDocument();
 
     await act(async () => {
-      firstProgress.reject(new Error('stale public progress failure'))
-      await firstProgress.promise.catch(() => undefined)
-    })
-    expect(screen.getByText('已确认一项案件进展。')).toBeInTheDocument()
-    expect(screen.queryByText('stale public progress failure')).not.toBeInTheDocument()
-  })
+      firstProgress.reject(new Error("stale public progress failure"));
+      await firstProgress.promise.catch(() => undefined);
+    });
+    expect(screen.getByText("已确认一项案件进展。")).toBeInTheDocument();
+    expect(
+      screen.queryByText("stale public progress failure"),
+    ).not.toBeInTheDocument();
+  });
 
-  it('lets an authorized commander invite the demo volunteer to an active case', async () => {
+  it("lets an authorized commander invite the demo volunteer to an active case", async () => {
     mocked.listCases.mockResolvedValue([
       {
-        id: 'case-command', case_code: 'AG-COMMAND', status: 'active', access_role: 'commander', display_name: '指挥案件',
-        last_seen_at: null, last_seen_location: null, created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z',
+        id: "case-command",
+        case_code: "AG-COMMAND",
+        status: "active",
+        access_role: "commander",
+        display_name: "指挥案件",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
       },
-    ])
-    mocked.getCase.mockResolvedValue(detail('case-command', '指挥案件', 'commander'))
+    ]);
+    mocked.getCase.mockResolvedValue(
+      detail("case-command", "指挥案件", "commander"),
+    );
     mocked.getCaseResourceConfiguration.mockResolvedValue({
       attachment_max_image_bytes: 5 * 1024 * 1024,
       attachment_max_per_case: 12,
-      case_place_types: ['frequent'],
-    })
-    mocked.addCaseMember.mockResolvedValue({})
+      case_place_types: ["frequent"],
+    });
+    mocked.addCaseMember.mockResolvedValue({});
 
-    render(<CaseWorkspacePage mode="commander" />)
+    render(<CaseWorkspacePage mode="commander" />);
 
-    await screen.findByRole('heading', { name: '指挥案件' })
-    fireEvent.change(screen.getByPlaceholderText('成员邮箱'), { target: { value: 'volunteer@demo.invalid' } })
-    fireEvent.click(screen.getByRole('button', { name: '添加案件成员' }))
+    await screen.findByRole("heading", { name: "指挥案件" });
+    fireEvent.change(screen.getByPlaceholderText("成员邮箱"), {
+      target: { value: "volunteer@demo.invalid" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "添加案件成员" }));
 
-    await waitFor(() => expect(mocked.addCaseMember).toHaveBeenCalledWith(
-      'test-session',
-      'case-command',
-      'volunteer@demo.invalid',
-      'volunteer',
-    ))
-  })
+    await waitFor(() =>
+      expect(mocked.addCaseMember).toHaveBeenCalledWith(
+        "test-session",
+        "case-command",
+        "volunteer@demo.invalid",
+        "volunteer",
+      ),
+    );
+  });
 
-  it('lets a family member invite either a family member or commander, but not a volunteer', async () => {
+  it("lets a family member invite either a family member or commander, but not a volunteer", async () => {
     mocked.listCases.mockResolvedValue([
       {
-        id: 'case-family', case_code: 'AG-FAMILY', status: 'active', access_role: 'family', display_name: '家属案件',
-        last_seen_at: null, last_seen_location: null, created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z',
+        id: "case-family",
+        case_code: "AG-FAMILY",
+        status: "active",
+        access_role: "family",
+        display_name: "家属案件",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
       },
-    ])
-    mocked.getCase.mockResolvedValue(detail('case-family', '家属案件', 'family'))
+    ]);
+    mocked.getCase.mockResolvedValue(
+      detail("case-family", "家属案件", "family"),
+    );
     mocked.getCaseResourceConfiguration.mockResolvedValue({
       attachment_max_image_bytes: 5 * 1024 * 1024,
       attachment_max_per_case: 12,
-      case_place_types: ['frequent'],
-    })
-    mocked.addCaseMember.mockResolvedValue({})
+      case_place_types: ["frequent"],
+    });
+    mocked.addCaseMember.mockResolvedValue({});
 
-    render(<CaseWorkspacePage mode="family" />)
+    render(<CaseWorkspacePage mode="family" />);
 
-    await screen.findByRole('heading', { name: '家属案件' })
-    const roleSelect = screen.getByRole('combobox', { name: '成员角色' })
-    expect(screen.getByRole('option', { name: '家属' })).toBeInTheDocument()
-    expect(screen.getByRole('option', { name: '指挥' })).toBeInTheDocument()
-    expect(screen.queryByRole('option', { name: '志愿者' })).not.toBeInTheDocument()
+    await screen.findByRole("heading", { name: "家属案件" });
+    const roleSelect = screen.getByRole("combobox", { name: "成员角色" });
+    expect(screen.getByRole("option", { name: "家属" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "指挥" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "志愿者" }),
+    ).not.toBeInTheDocument();
 
-    fireEvent.change(roleSelect, { target: { value: 'family' } })
-    fireEvent.change(screen.getByPlaceholderText('成员邮箱'), { target: { value: 'family-member@demo.invalid' } })
-    fireEvent.click(screen.getByRole('button', { name: '添加案件成员' }))
+    fireEvent.change(roleSelect, { target: { value: "family" } });
+    fireEvent.change(screen.getByPlaceholderText("成员邮箱"), {
+      target: { value: "family-member@demo.invalid" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "添加案件成员" }));
 
-    await waitFor(() => expect(mocked.addCaseMember).toHaveBeenCalledWith(
-      'test-session',
-      'case-family',
-      'family-member@demo.invalid',
-      'family',
-    ))
-  })
+    await waitFor(() =>
+      expect(mocked.addCaseMember).toHaveBeenCalledWith(
+        "test-session",
+        "case-family",
+        "family-member@demo.invalid",
+        "family",
+      ),
+    );
+  });
 
-  it('does not expose closed-case controls that create supplementary information', async () => {
+  it("does not expose closed-case controls that create supplementary information", async () => {
     mocked.listCases.mockResolvedValue([
       {
-        id: 'case-closed', case_code: 'AG-CLOSED', status: 'closed', access_role: 'commander', display_name: '已关闭案件',
-        last_seen_at: null, last_seen_location: null, created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z',
+        id: "case-closed",
+        case_code: "AG-CLOSED",
+        status: "closed",
+        access_role: "commander",
+        display_name: "已关闭案件",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
       },
-    ])
-    mocked.getCase.mockResolvedValue(detail('case-closed', '已关闭案件', 'commander', 'closed'))
+    ]);
+    mocked.getCase.mockResolvedValue(
+      detail("case-closed", "已关闭案件", "commander", "closed"),
+    );
     mocked.getCaseResourceConfiguration.mockResolvedValue({
       attachment_max_image_bytes: 5 * 1024 * 1024,
       attachment_max_per_case: 12,
-      case_place_types: ['frequent'],
-    })
+      case_place_types: ["frequent"],
+    });
 
-    render(<CaseWorkspacePage mode="commander" />)
+    render(<CaseWorkspacePage mode="commander" />);
 
-    await screen.findByRole('heading', { name: '已关闭案件' })
-    expect(screen.queryByRole('button', { name: '提交线索' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: '提交地点' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: '上传图片' })).not.toBeInTheDocument()
-    expect(screen.getByRole('combobox', { name: '案件状态' })).toBeDisabled()
-  })
+    await screen.findByRole("heading", { name: "已关闭案件" });
+    expect(
+      screen.queryByRole("button", { name: "提交线索" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "提交地点" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "上传图片" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "案件状态" })).toBeDisabled();
+  });
 
-  it('does not expose clue submission for a resolved case', async () => {
+  it("does not expose clue submission for a resolved case", async () => {
     mocked.listCases.mockResolvedValue([
       {
-        id: 'case-resolved', case_code: 'AG-RESOLVED', status: 'resolved', access_role: 'commander', display_name: '已找到案件',
-        last_seen_at: null, last_seen_location: null, created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z',
+        id: "case-resolved",
+        case_code: "AG-RESOLVED",
+        status: "resolved",
+        access_role: "commander",
+        display_name: "已找到案件",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
       },
-    ])
-    mocked.getCase.mockResolvedValue(detail('case-resolved', '已找到案件', 'commander', 'resolved'))
+    ]);
+    mocked.getCase.mockResolvedValue(
+      detail("case-resolved", "已找到案件", "commander", "resolved"),
+    );
     mocked.getCaseResourceConfiguration.mockResolvedValue({
       attachment_max_image_bytes: 5 * 1024 * 1024,
       attachment_max_per_case: 12,
-      case_place_types: ['frequent'],
-    })
+      case_place_types: ["frequent"],
+    });
 
-    render(<CaseWorkspacePage mode="commander" />)
+    render(<CaseWorkspacePage mode="commander" />);
 
-    await screen.findByRole('heading', { name: '已找到案件' })
-    expect(screen.queryByRole('button', { name: '提交线索' })).not.toBeInTheDocument()
-  })
+    await screen.findByRole("heading", { name: "已找到案件" });
+    expect(
+      screen.queryByRole("button", { name: "提交线索" }),
+    ).not.toBeInTheDocument();
+  });
 
-  it('clears nearby resource results when the selected category changes', async () => {
-    vi.clearAllMocks()
-    mocked.listCases.mockResolvedValue([{ id: 'case-command', case_code: 'AG-COMMAND', status: 'active', access_role: 'commander', display_name: 'Commander case', last_seen_at: null, last_seen_location: null, created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z' }])
-    mocked.getCase.mockResolvedValue(detail('case-command', 'Commander case', 'commander'))
-    mocked.getCaseResourceConfiguration.mockResolvedValue({ attachment_max_image_bytes: 5 * 1024 * 1024, attachment_max_per_case: 12, case_place_types: ['frequent'] })
-    mocked.listCaseClues.mockResolvedValue({ items: [], page: 1, page_size: 25, total: 0 })
-    mocked.listCasePois.mockResolvedValue({ items: [{ id: 'hospital-1', name: 'Fictional hospital', category: 'hospital', address: 'Fictional address', longitude: null, latitude: null }], source: 'fixed_demo_fallback', degradation_status: 'degraded', fallback_message: null })
+  it("clears nearby resource results when the selected category changes", async () => {
+    vi.clearAllMocks();
+    mocked.listCases.mockResolvedValue([
+      {
+        id: "case-command",
+        case_code: "AG-COMMAND",
+        status: "active",
+        access_role: "commander",
+        display_name: "Commander case",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
+      },
+    ]);
+    mocked.getCase.mockResolvedValue(
+      detail("case-command", "Commander case", "commander"),
+    );
+    mocked.getCaseResourceConfiguration.mockResolvedValue({
+      attachment_max_image_bytes: 5 * 1024 * 1024,
+      attachment_max_per_case: 12,
+      case_place_types: ["frequent"],
+    });
+    mocked.listCaseClues.mockResolvedValue({
+      items: [],
+      page: 1,
+      page_size: 25,
+      total: 0,
+    });
+    mocked.listCasePois.mockResolvedValue({
+      items: [
+        {
+          id: "hospital-1",
+          name: "Fictional hospital",
+          category: "hospital",
+          address: "Fictional address",
+          longitude: null,
+          latitude: null,
+        },
+      ],
+      source: "fixed_demo_fallback",
+      degradation_status: "degraded",
+      fallback_message: null,
+    });
 
-    render(<CaseWorkspacePage mode="commander" />)
+    render(<CaseWorkspacePage mode="commander" />);
 
-    await screen.findByRole('heading', { name: 'Commander case' })
-    fireEvent.click(screen.getByRole('button', { name: '查询' }))
-    expect(await screen.findByText('Fictional hospital')).toBeInTheDocument()
+    await screen.findByRole("heading", { name: "Commander case" });
+    fireEvent.click(screen.getByRole("button", { name: "查询" }));
+    expect(await screen.findByText("Fictional hospital")).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText('周边资源类别'), { target: { value: 'police' } })
-    expect(screen.queryByText('Fictional hospital')).not.toBeInTheDocument()
-  })
+    fireEvent.change(screen.getByLabelText("周边资源类别"), {
+      target: { value: "police" },
+    });
+    expect(screen.queryByText("Fictional hospital")).not.toBeInTheDocument();
+  });
 
-  it('loads a filtered commander queue and requires confirmation before reviewing a clue', async () => {
-    vi.clearAllMocks()
+  it("loads a filtered commander queue and requires confirmation before reviewing a clue", async () => {
+    vi.clearAllMocks();
     const pendingClue = {
-      id: 'clue-pending', case_id: 'case-command', status: 'pending_review', source: 'field responder', source_type: 'field_report',
-      content: 'A fictional field observation.', raw_record_reference: null, occurred_at: null, reported_at: '2026-07-24T00:00:00Z', confirmed_at: null,
-      location_text: null, location_precision: null, next_action: null, linked_task_reference: null, related_clue_id: null, relationship_type: null,
-      review_reason: null, attachment_ids: [], created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z', reviewed_at: null, is_own_submission: false,
-    }
-    mocked.listCases.mockResolvedValue([{ id: 'case-command', case_code: 'AG-COMMAND', status: 'active', access_role: 'commander', display_name: '指挥案件', last_seen_at: null, last_seen_location: null, created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z' }])
-    mocked.getCase.mockResolvedValue(detail('case-command', '指挥案件', 'commander'))
-    mocked.getCaseResourceConfiguration.mockResolvedValue({ attachment_max_image_bytes: 5 * 1024 * 1024, attachment_max_per_case: 12, case_place_types: ['frequent'] })
-    mocked.listCaseClues.mockResolvedValue({ items: [pendingClue], page: 1, page_size: 25, total: 1 })
-    mocked.reviewClue.mockResolvedValue({ ...pendingClue, status: 'confirmed' })
-
-    render(<CaseWorkspacePage mode="commander" />)
-
-    await screen.findByRole('heading', { name: '指挥案件' })
-    await waitFor(() => expect(mocked.listCaseClues).toHaveBeenCalledWith('test-session', 'case-command', expect.objectContaining({ status: 'pending_review', sort: 'created_at', order: 'desc' })))
-    fireEvent.change(screen.getByLabelText('来源类型筛选'), { target: { value: 'field_report' } })
-    await waitFor(() => expect(mocked.listCaseClues).toHaveBeenLastCalledWith('test-session', 'case-command', expect.objectContaining({ source_type: 'field_report' })))
-
-    fireEvent.change(screen.getByLabelText('审核理由'), { target: { value: 'Reviewed against the fictional record.' } })
-    const reviewTrigger = screen.getByRole('button', { name: '确认' })
-    reviewTrigger.focus()
-    fireEvent.click(reviewTrigger)
-    expect(mocked.reviewClue).not.toHaveBeenCalled()
-    const confirmationDialog = screen.getByRole('dialog', { name: '确认审核操作' })
-    await waitFor(() => expect(confirmationDialog.contains(document.activeElement)).toBe(true))
-    const cancelReview = screen.getByRole('button', { name: '取消' })
-    const submitReview = screen.getByRole('button', { name: '确认提交' })
-    cancelReview.focus()
-    fireEvent.keyDown(cancelReview, { key: 'Tab' })
-    expect(submitReview).toHaveFocus()
-    fireEvent.keyDown(submitReview, { key: 'Tab' })
-    expect(cancelReview).toHaveFocus()
-    fireEvent.keyDown(confirmationDialog, { key: 'Escape' })
-    await waitFor(() => expect(screen.queryByRole('dialog', { name: '确认审核操作' })).not.toBeInTheDocument())
-    expect(reviewTrigger).toHaveFocus()
-
-    fireEvent.click(reviewTrigger)
-    fireEvent.click(screen.getByRole('button', { name: '确认提交' }))
-    await waitFor(() => expect(mocked.reviewClue).toHaveBeenCalledWith('test-session', 'clue-pending', expect.objectContaining({ status: 'confirmed', reason: 'Reviewed against the fictional record.' })))
-  })
-
-  it('describes task creation as open until a volunteer is selected', async () => {
-    vi.clearAllMocks()
-    const confirmedClue: Clue = {
-      id: 'clue-confirmed', case_id: 'case-command', status: 'confirmed', source: 'commander', source_type: 'manual_report',
-      content: 'Confirmed sighting for task creation.', raw_record_reference: null, occurred_at: null, reported_at: '2026-07-24T00:00:00Z', confirmed_at: '2026-07-24T01:00:00Z',
-      location_text: null, location_precision: null, next_action: null, linked_task_reference: null, related_clue_id: null, relationship_type: null,
-      review_reason: null, attachment_ids: [], created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z', reviewed_at: '2026-07-24T01:00:00Z', is_own_submission: false,
-    }
-    const commandDetail = detail('case-command', 'Commander case', 'commander')
-    commandDetail.clues = [confirmedClue]
-    mocked.listCases.mockResolvedValue([{ id: 'case-command', case_code: 'AG-COMMAND', status: 'active', access_role: 'commander', display_name: 'Commander case', last_seen_at: null, last_seen_location: null, created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z' }])
-    mocked.getCase.mockResolvedValue(commandDetail)
-    mocked.getCaseResourceConfiguration.mockResolvedValue({ attachment_max_image_bytes: 5 * 1024 * 1024, attachment_max_per_case: 12, case_place_types: ['frequent'] })
-    mocked.listCaseTasks.mockResolvedValue({ items: [], page: 1, page_size: 25, total: 0 })
-    mocked.listCaseMembers.mockResolvedValue([{ user_id: 'volunteer-1', email: 'volunteer@demo.invalid', display_name: 'Demo volunteer', account_type: 'member', global_capabilities: [], case_role: 'volunteer' }])
-
-    render(<CaseWorkspacePage mode="commander" />)
-
-    expect(await screen.findByRole('heading', { name: '创建开放任务' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: '创建并等待志愿者申请' })).toBeInTheDocument()
-    await screen.findByRole('option', { name: 'Demo volunteer' })
-
-    fireEvent.change(screen.getByLabelText('志愿者'), { target: { value: 'volunteer-1' } })
-
-    expect(await screen.findByRole('heading', { name: '人工创建并分配任务' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: '创建并分配' })).toBeInTheDocument()
-  })
-
-  it('selects a related clue by searchable case content instead of requiring a UUID', async () => {
-    vi.clearAllMocks()
-    const pendingClue: Clue = {
-      id: 'clue-pending', case_id: 'case-command', status: 'pending_review', source: 'field responder', source_type: 'field_report',
-      content: 'A fictional field observation.', raw_record_reference: null, occurred_at: null, reported_at: '2026-07-24T00:00:00Z', confirmed_at: null,
-      location_text: null, location_precision: null, next_action: null, linked_task_reference: null, related_clue_id: null, relationship_type: null,
-      review_reason: null, attachment_ids: [], created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z', reviewed_at: null, is_own_submission: false,
-    }
-    const relatedClue: Clue = {
-      ...pendingClue,
-      id: 'clue-related',
-      status: 'confirmed',
-      content: '公交站旁的目击记录。',
-      location_text: '北门公交站',
-    }
-    const commandDetail = detail('case-command', '指挥案件', 'commander')
-    commandDetail.clues = [pendingClue, relatedClue]
-    mocked.listCommandIntake.mockResolvedValue([])
-    mocked.listCases.mockResolvedValue([{ id: 'case-command', case_code: 'AG-COMMAND', status: 'active', access_role: 'commander', display_name: '指挥案件', last_seen_at: null, last_seen_location: null, created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z' }])
-    mocked.getCase.mockResolvedValue(commandDetail)
-    mocked.getCaseResourceConfiguration.mockResolvedValue({ attachment_max_image_bytes: 5 * 1024 * 1024, attachment_max_per_case: 12, case_place_types: ['frequent'] })
-    mocked.getCaseMapView.mockResolvedValue({ items: [] })
-    mocked.listCaseClues.mockResolvedValue({ items: [pendingClue], page: 1, page_size: 25, total: 1 })
-    mocked.reviewClue.mockResolvedValue({ ...pendingClue, status: 'duplicate', related_clue_id: relatedClue.id, relationship_type: 'duplicate_of' })
-
-    render(<CaseWorkspacePage mode="commander" />)
-
-    await screen.findByRole('heading', { name: '指挥案件' })
-    fireEvent.change(await screen.findByLabelText('审核理由'), { target: { value: '与已有目击记录重复。' } })
-    fireEvent.change(screen.getByLabelText('搜索关联线索'), { target: { value: '公交站' } })
-    expect(screen.getByLabelText('选择关联线索')).toHaveTextContent('公交站旁的目击记录')
-    expect(screen.queryByText('clue-related')).not.toBeInTheDocument()
-    fireEvent.change(screen.getByLabelText('选择关联线索'), { target: { value: relatedClue.id } })
-    const duplicate = screen.getByRole('button', { name: '重复' })
-    expect(duplicate).toBeEnabled()
-    fireEvent.click(duplicate)
-    fireEvent.click(screen.getByRole('button', { name: '确认提交' }))
-    await waitFor(() => expect(mocked.reviewClue).toHaveBeenCalledWith('test-session', 'clue-pending', expect.objectContaining({
-      status: 'duplicate',
-      related_clue_id: relatedClue.id,
-      relationship_type: 'duplicate_of',
-    })))
-  })
-
-  it('discards a stale commander queue response after filters change', async () => {
-    vi.clearAllMocks()
-    const firstQueue = deferred<{ items: Array<Record<string, unknown>>; page: number; page_size: number; total: number }>()
-    const secondQueue = deferred<{ items: Array<Record<string, unknown>>; page: number; page_size: number; total: number }>()
-    const clue = (id: string, content: string, sourceType: string) => ({
-      id,
-      case_id: 'case-command',
-      status: 'pending_review',
-      source: 'field responder',
-      source_type: sourceType,
-      content,
+      id: "clue-pending",
+      case_id: "case-command",
+      status: "pending_review",
+      source: "field responder",
+      source_type: "field_report",
+      content: "A fictional field observation.",
       raw_record_reference: null,
       occurred_at: null,
-      reported_at: '2026-07-24T00:00:00Z',
+      reported_at: "2026-07-24T00:00:00Z",
       confirmed_at: null,
       location_text: null,
       location_precision: null,
@@ -461,61 +580,463 @@ describe('CaseWorkspacePage', () => {
       relationship_type: null,
       review_reason: null,
       attachment_ids: [],
-      created_at: '2026-07-24T00:00:00Z',
-      updated_at: '2026-07-24T00:00:00Z',
+      created_at: "2026-07-24T00:00:00Z",
+      updated_at: "2026-07-24T00:00:00Z",
       reviewed_at: null,
       is_own_submission: false,
-    })
-    mocked.listCases.mockResolvedValue([{ id: 'case-command', case_code: 'AG-COMMAND', status: 'active', access_role: 'commander', display_name: '指挥案件', last_seen_at: null, last_seen_location: null, created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z' }])
-    mocked.getCase.mockResolvedValue(detail('case-command', '指挥案件', 'commander'))
-    mocked.getCaseResourceConfiguration.mockResolvedValue({ attachment_max_image_bytes: 5 * 1024 * 1024, attachment_max_per_case: 12, case_place_types: ['frequent'] })
+    };
+    mocked.listCases.mockResolvedValue([
+      {
+        id: "case-command",
+        case_code: "AG-COMMAND",
+        status: "active",
+        access_role: "commander",
+        display_name: "指挥案件",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
+      },
+    ]);
+    mocked.getCase.mockResolvedValue(
+      detail("case-command", "指挥案件", "commander"),
+    );
+    mocked.getCaseResourceConfiguration.mockResolvedValue({
+      attachment_max_image_bytes: 5 * 1024 * 1024,
+      attachment_max_per_case: 12,
+      case_place_types: ["frequent"],
+    });
+    mocked.listCaseClues.mockResolvedValue({
+      items: [pendingClue],
+      page: 1,
+      page_size: 25,
+      total: 1,
+    });
+    mocked.reviewClue.mockResolvedValue({
+      ...pendingClue,
+      status: "confirmed",
+    });
+
+    render(<CaseWorkspacePage mode="commander" />);
+
+    await screen.findByRole("heading", { name: "指挥案件" });
+    await waitFor(() =>
+      expect(mocked.listCaseClues).toHaveBeenCalledWith(
+        "test-session",
+        "case-command",
+        expect.objectContaining({
+          status: "pending_review",
+          sort: "created_at",
+          order: "desc",
+        }),
+      ),
+    );
+    fireEvent.change(screen.getByLabelText("来源类型筛选"), {
+      target: { value: "field_report" },
+    });
+    await waitFor(() =>
+      expect(mocked.listCaseClues).toHaveBeenLastCalledWith(
+        "test-session",
+        "case-command",
+        expect.objectContaining({ source_type: "field_report" }),
+      ),
+    );
+
+    fireEvent.change(screen.getByLabelText("审核理由"), {
+      target: { value: "Reviewed against the fictional record." },
+    });
+    const reviewTrigger = screen.getByRole("button", { name: "确认" });
+    reviewTrigger.focus();
+    fireEvent.click(reviewTrigger);
+    expect(mocked.reviewClue).not.toHaveBeenCalled();
+    const confirmationDialog = screen.getByRole("dialog", {
+      name: "确认审核操作",
+    });
+    await waitFor(() =>
+      expect(confirmationDialog.contains(document.activeElement)).toBe(true),
+    );
+    const cancelReview = screen.getByRole("button", { name: "取消" });
+    const submitReview = screen.getByRole("button", { name: "确认提交" });
+    cancelReview.focus();
+    fireEvent.keyDown(cancelReview, { key: "Tab" });
+    expect(submitReview).toHaveFocus();
+    fireEvent.keyDown(submitReview, { key: "Tab" });
+    expect(cancelReview).toHaveFocus();
+    fireEvent.keyDown(confirmationDialog, { key: "Escape" });
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("dialog", { name: "确认审核操作" }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(reviewTrigger).toHaveFocus();
+
+    fireEvent.click(reviewTrigger);
+    fireEvent.click(screen.getByRole("button", { name: "确认提交" }));
+    await waitFor(() =>
+      expect(mocked.reviewClue).toHaveBeenCalledWith(
+        "test-session",
+        "clue-pending",
+        expect.objectContaining({
+          status: "confirmed",
+          reason: "Reviewed against the fictional record.",
+        }),
+      ),
+    );
+  });
+
+  it("describes task creation as open until a volunteer is selected", async () => {
+    vi.clearAllMocks();
+    const confirmedClue: Clue = {
+      id: "clue-confirmed",
+      case_id: "case-command",
+      status: "confirmed",
+      source: "commander",
+      source_type: "manual_report",
+      content: "Confirmed sighting for task creation.",
+      raw_record_reference: null,
+      occurred_at: null,
+      reported_at: "2026-07-24T00:00:00Z",
+      confirmed_at: "2026-07-24T01:00:00Z",
+      location_text: null,
+      location_precision: null,
+      next_action: null,
+      linked_task_reference: null,
+      related_clue_id: null,
+      relationship_type: null,
+      review_reason: null,
+      attachment_ids: [],
+      created_at: "2026-07-24T00:00:00Z",
+      updated_at: "2026-07-24T00:00:00Z",
+      reviewed_at: "2026-07-24T01:00:00Z",
+      is_own_submission: false,
+    };
+    const commandDetail = detail("case-command", "Commander case", "commander");
+    commandDetail.clues = [confirmedClue];
+    mocked.listCases.mockResolvedValue([
+      {
+        id: "case-command",
+        case_code: "AG-COMMAND",
+        status: "active",
+        access_role: "commander",
+        display_name: "Commander case",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
+      },
+    ]);
+    mocked.getCase.mockResolvedValue(commandDetail);
+    mocked.getCaseResourceConfiguration.mockResolvedValue({
+      attachment_max_image_bytes: 5 * 1024 * 1024,
+      attachment_max_per_case: 12,
+      case_place_types: ["frequent"],
+    });
+    mocked.listCaseTasks.mockResolvedValue({
+      items: [],
+      page: 1,
+      page_size: 25,
+      total: 0,
+    });
+    mocked.listCaseMembers.mockResolvedValue([
+      {
+        user_id: "volunteer-1",
+        email: "volunteer@demo.invalid",
+        display_name: "Demo volunteer",
+        account_type: "member",
+        global_capabilities: [],
+        case_role: "volunteer",
+      },
+    ]);
+
+    render(<CaseWorkspacePage mode="commander" />);
+
+    expect(
+      await screen.findByRole("heading", { name: "创建开放任务" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "创建并等待志愿者申请" }),
+    ).toBeInTheDocument();
+    await screen.findByRole("option", { name: "Demo volunteer" });
+
+    fireEvent.change(screen.getByLabelText("志愿者"), {
+      target: { value: "volunteer-1" },
+    });
+
+    expect(
+      await screen.findByRole("heading", { name: "人工创建并分配任务" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "创建并分配" }),
+    ).toBeInTheDocument();
+  });
+
+  it("selects a related clue by searchable case content instead of requiring a UUID", async () => {
+    vi.clearAllMocks();
+    const pendingClue: Clue = {
+      id: "clue-pending",
+      case_id: "case-command",
+      status: "pending_review",
+      source: "field responder",
+      source_type: "field_report",
+      content: "A fictional field observation.",
+      raw_record_reference: null,
+      occurred_at: null,
+      reported_at: "2026-07-24T00:00:00Z",
+      confirmed_at: null,
+      location_text: null,
+      location_precision: null,
+      next_action: null,
+      linked_task_reference: null,
+      related_clue_id: null,
+      relationship_type: null,
+      review_reason: null,
+      attachment_ids: [],
+      created_at: "2026-07-24T00:00:00Z",
+      updated_at: "2026-07-24T00:00:00Z",
+      reviewed_at: null,
+      is_own_submission: false,
+    };
+    const relatedClue: Clue = {
+      ...pendingClue,
+      id: "clue-related",
+      status: "confirmed",
+      content: "公交站旁的目击记录。",
+      location_text: "北门公交站",
+    };
+    const commandDetail = detail("case-command", "指挥案件", "commander");
+    commandDetail.clues = [pendingClue, relatedClue];
+    mocked.listCommandIntake.mockResolvedValue([]);
+    mocked.listCases.mockResolvedValue([
+      {
+        id: "case-command",
+        case_code: "AG-COMMAND",
+        status: "active",
+        access_role: "commander",
+        display_name: "指挥案件",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
+      },
+    ]);
+    mocked.getCase.mockResolvedValue(commandDetail);
+    mocked.getCaseResourceConfiguration.mockResolvedValue({
+      attachment_max_image_bytes: 5 * 1024 * 1024,
+      attachment_max_per_case: 12,
+      case_place_types: ["frequent"],
+    });
+    mocked.getCaseMapView.mockResolvedValue({ items: [] });
+    mocked.listCaseClues.mockResolvedValue({
+      items: [pendingClue],
+      page: 1,
+      page_size: 25,
+      total: 1,
+    });
+    mocked.reviewClue.mockResolvedValue({
+      ...pendingClue,
+      status: "duplicate",
+      related_clue_id: relatedClue.id,
+      relationship_type: "duplicate_of",
+    });
+
+    render(<CaseWorkspacePage mode="commander" />);
+
+    await screen.findByRole("heading", { name: "指挥案件" });
+    fireEvent.change(await screen.findByLabelText("审核理由"), {
+      target: { value: "与已有目击记录重复。" },
+    });
+    fireEvent.change(screen.getByLabelText("搜索关联线索"), {
+      target: { value: "公交站" },
+    });
+    expect(screen.getByLabelText("选择关联线索")).toHaveTextContent(
+      "公交站旁的目击记录",
+    );
+    expect(screen.queryByText("clue-related")).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("选择关联线索"), {
+      target: { value: relatedClue.id },
+    });
+    const duplicate = screen.getByRole("button", { name: "重复" });
+    expect(duplicate).toBeEnabled();
+    fireEvent.click(duplicate);
+    fireEvent.click(screen.getByRole("button", { name: "确认提交" }));
+    await waitFor(() =>
+      expect(mocked.reviewClue).toHaveBeenCalledWith(
+        "test-session",
+        "clue-pending",
+        expect.objectContaining({
+          status: "duplicate",
+          related_clue_id: relatedClue.id,
+          relationship_type: "duplicate_of",
+        }),
+      ),
+    );
+  });
+
+  it("discards a stale commander queue response after filters change", async () => {
+    vi.clearAllMocks();
+    const firstQueue = deferred<{
+      items: Array<Record<string, unknown>>;
+      page: number;
+      page_size: number;
+      total: number;
+    }>();
+    const secondQueue = deferred<{
+      items: Array<Record<string, unknown>>;
+      page: number;
+      page_size: number;
+      total: number;
+    }>();
+    const clue = (id: string, content: string, sourceType: string) => ({
+      id,
+      case_id: "case-command",
+      status: "pending_review",
+      source: "field responder",
+      source_type: sourceType,
+      content,
+      raw_record_reference: null,
+      occurred_at: null,
+      reported_at: "2026-07-24T00:00:00Z",
+      confirmed_at: null,
+      location_text: null,
+      location_precision: null,
+      next_action: null,
+      linked_task_reference: null,
+      related_clue_id: null,
+      relationship_type: null,
+      review_reason: null,
+      attachment_ids: [],
+      created_at: "2026-07-24T00:00:00Z",
+      updated_at: "2026-07-24T00:00:00Z",
+      reviewed_at: null,
+      is_own_submission: false,
+    });
+    mocked.listCases.mockResolvedValue([
+      {
+        id: "case-command",
+        case_code: "AG-COMMAND",
+        status: "active",
+        access_role: "commander",
+        display_name: "指挥案件",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
+      },
+    ]);
+    mocked.getCase.mockResolvedValue(
+      detail("case-command", "指挥案件", "commander"),
+    );
+    mocked.getCaseResourceConfiguration.mockResolvedValue({
+      attachment_max_image_bytes: 5 * 1024 * 1024,
+      attachment_max_per_case: 12,
+      case_place_types: ["frequent"],
+    });
     mocked.listCaseClues
       .mockReturnValueOnce(firstQueue.promise)
-      .mockReturnValueOnce(secondQueue.promise)
+      .mockReturnValueOnce(secondQueue.promise);
 
-    render(<CaseWorkspacePage mode="commander" />)
+    render(<CaseWorkspacePage mode="commander" />);
 
-    await screen.findByRole('heading', { name: '指挥案件' })
-    await waitFor(() => expect(mocked.listCaseClues).toHaveBeenCalledTimes(1))
-    fireEvent.change(screen.getByLabelText('来源类型筛选'), { target: { value: 'field_report' } })
-    await waitFor(() => expect(mocked.listCaseClues).toHaveBeenCalledTimes(2))
-
-    await act(async () => {
-      secondQueue.resolve({ items: [clue('latest-clue', 'latest clue', 'field_report')], page: 1, page_size: 25, total: 1 })
-      await secondQueue.promise
-    })
-    expect(await screen.findByText('latest clue')).toBeInTheDocument()
+    await screen.findByRole("heading", { name: "指挥案件" });
+    await waitFor(() => expect(mocked.listCaseClues).toHaveBeenCalledTimes(1));
+    fireEvent.change(screen.getByLabelText("来源类型筛选"), {
+      target: { value: "field_report" },
+    });
+    await waitFor(() => expect(mocked.listCaseClues).toHaveBeenCalledTimes(2));
 
     await act(async () => {
-      firstQueue.resolve({ items: [clue('stale-clue', 'stale clue', 'manual_report')], page: 1, page_size: 25, total: 1 })
-      await firstQueue.promise
-    })
-    expect(screen.getByText('latest clue')).toBeInTheDocument()
-    expect(screen.queryByText('stale clue')).not.toBeInTheDocument()
-  })
+      secondQueue.resolve({
+        items: [clue("latest-clue", "latest clue", "field_report")],
+        page: 1,
+        page_size: 25,
+        total: 1,
+      });
+      await secondQueue.promise;
+    });
+    expect(await screen.findByText("latest clue")).toBeInTheDocument();
 
-  it('clears the commander queue when authentication is lost', async () => {
-    vi.clearAllMocks()
-    mocked.auth.token = 'test-session'
+    await act(async () => {
+      firstQueue.resolve({
+        items: [clue("stale-clue", "stale clue", "manual_report")],
+        page: 1,
+        page_size: 25,
+        total: 1,
+      });
+      await firstQueue.promise;
+    });
+    expect(screen.getByText("latest clue")).toBeInTheDocument();
+    expect(screen.queryByText("stale clue")).not.toBeInTheDocument();
+  });
+
+  it("clears the commander queue when authentication is lost", async () => {
+    vi.clearAllMocks();
+    mocked.auth.token = "test-session";
     const sensitiveClue = {
-      id: 'sensitive-clue', case_id: 'case-command', status: 'pending_review', source: 'field responder', source_type: 'field_report',
-      content: 'Sensitive commander queue clue', raw_record_reference: null, occurred_at: null, reported_at: '2026-07-24T00:00:00Z', confirmed_at: null,
-      location_text: null, location_precision: null, next_action: null, linked_task_reference: null, related_clue_id: null, relationship_type: null,
-      review_reason: null, attachment_ids: [], created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z', reviewed_at: null, is_own_submission: false,
-    }
-    mocked.listCases.mockResolvedValue([{ id: 'case-command', case_code: 'AG-COMMAND', status: 'active', access_role: 'commander', display_name: '指挥案件', last_seen_at: null, last_seen_location: null, created_at: '2026-07-24T00:00:00Z', updated_at: '2026-07-24T00:00:00Z' }])
-    mocked.getCase.mockResolvedValue(detail('case-command', '指挥案件', 'commander'))
-    mocked.getCaseResourceConfiguration.mockResolvedValue({ attachment_max_image_bytes: 5 * 1024 * 1024, attachment_max_per_case: 12, case_place_types: ['frequent'] })
-    mocked.listCaseClues.mockResolvedValue({ items: [sensitiveClue], page: 1, page_size: 25, total: 1 })
+      id: "sensitive-clue",
+      case_id: "case-command",
+      status: "pending_review",
+      source: "field responder",
+      source_type: "field_report",
+      content: "Sensitive commander queue clue",
+      raw_record_reference: null,
+      occurred_at: null,
+      reported_at: "2026-07-24T00:00:00Z",
+      confirmed_at: null,
+      location_text: null,
+      location_precision: null,
+      next_action: null,
+      linked_task_reference: null,
+      related_clue_id: null,
+      relationship_type: null,
+      review_reason: null,
+      attachment_ids: [],
+      created_at: "2026-07-24T00:00:00Z",
+      updated_at: "2026-07-24T00:00:00Z",
+      reviewed_at: null,
+      is_own_submission: false,
+    };
+    mocked.listCases.mockResolvedValue([
+      {
+        id: "case-command",
+        case_code: "AG-COMMAND",
+        status: "active",
+        access_role: "commander",
+        display_name: "指挥案件",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
+      },
+    ]);
+    mocked.getCase.mockResolvedValue(
+      detail("case-command", "指挥案件", "commander"),
+    );
+    mocked.getCaseResourceConfiguration.mockResolvedValue({
+      attachment_max_image_bytes: 5 * 1024 * 1024,
+      attachment_max_per_case: 12,
+      case_place_types: ["frequent"],
+    });
+    mocked.listCaseClues.mockResolvedValue({
+      items: [sensitiveClue],
+      page: 1,
+      page_size: 25,
+      total: 1,
+    });
 
-    const { rerender } = render(<CaseWorkspacePage mode="commander" />)
+    const { rerender } = render(<CaseWorkspacePage mode="commander" />);
 
-    expect(await screen.findByText('Sensitive commander queue clue')).toBeInTheDocument()
-    mocked.auth.token = null
-    rerender(<CaseWorkspacePage mode="commander" />)
+    expect(
+      await screen.findByText("Sensitive commander queue clue"),
+    ).toBeInTheDocument();
+    mocked.auth.token = null;
+    rerender(<CaseWorkspacePage mode="commander" />);
 
-    await waitFor(() => expect(screen.queryByText('Sensitive commander queue clue')).not.toBeInTheDocument())
-    expect(screen.queryByText('正在加载审核队列')).not.toBeInTheDocument()
-    mocked.auth.token = 'test-session'
-  })
-})
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Sensitive commander queue clue"),
+      ).not.toBeInTheDocument(),
+    );
+    expect(screen.queryByText("正在加载审核队列")).not.toBeInTheDocument();
+    mocked.auth.token = "test-session";
+  });
+});

--- a/frontend/src/pages/CaseWorkspacePage.tsx
+++ b/frontend/src/pages/CaseWorkspacePage.tsx
@@ -1,4 +1,4 @@
-import { AlertDialog, Button, Chip, Input, TextArea } from '@heroui/react'
+import { AlertDialog, Button, Chip, Input, TextArea } from "@heroui/react";
 import {
   CheckCircle2,
   ChevronRight,
@@ -8,8 +8,8 @@ import {
   RefreshCw,
   Send,
   UserPlus,
-} from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   addCaseMember,
   acceptCommandCase,
@@ -37,7 +37,7 @@ import {
   updateTaskStatus,
   submitTaskFeedback,
   uploadCaseAttachment,
-} from '../api/cases'
+} from "../api/cases";
 import type {
   CaseDetail,
   CaseListItem,
@@ -63,152 +63,179 @@ import type {
   SummaryDraft,
   PlaceType,
   PlaceVisibility,
-} from '../api/cases'
-import { ApiClientError } from '../api/client'
-import { useAuth } from '../auth/useAuth'
-import { EmptyState, ErrorState, LoadingState } from '../components/ContentState'
-import { FamilyIntakeForm } from './FamilyIntakeForm'
+} from "../api/cases";
+import { ApiClientError } from "../api/client";
+import { useAuth } from "../auth/useAuth";
+import {
+  EmptyState,
+  ErrorState,
+  LoadingState,
+} from "../components/ContentState";
+import { FamilyIntakeForm } from "./FamilyIntakeForm";
 
-type WorkspaceMode = 'family' | 'commander' | 'volunteer'
-type ReviewDraft = { reason: string; relatedClueId: string; relatedClueQuery: string }
+type WorkspaceMode = "family" | "commander" | "volunteer";
+type ReviewDraft = {
+  reason: string;
+  relatedClueId: string;
+  relatedClueQuery: string;
+};
 type ClueQueueFilters = {
-  status: ClueStatus | ''
-  sourceType: ClueSourceType | ''
-  sort: 'created_at' | 'occurred_at'
-  order: 'asc' | 'desc'
-  page: number
-}
+  status: ClueStatus | "";
+  sourceType: ClueSourceType | "";
+  sort: "created_at" | "occurred_at";
+  order: "asc" | "desc";
+  page: number;
+};
 const defaultClueQueueFilters: ClueQueueFilters = {
-  status: 'pending_review',
-  sourceType: '',
-  sort: 'created_at',
-  order: 'desc',
+  status: "pending_review",
+  sourceType: "",
+  sort: "created_at",
+  order: "desc",
   page: 1,
-}
+};
 
-const workspaceCopy: Record<WorkspaceMode, { context: string; title: string }> = {
-  family: { context: '家属端', title: '走失求助' },
-  commander: { context: '指挥端', title: '案件指挥' },
-  volunteer: { context: '志愿者端', title: '协作案件' },
-}
+const workspaceCopy: Record<WorkspaceMode, { context: string; title: string }> =
+  {
+    family: { context: "家属端", title: "走失求助" },
+    commander: { context: "指挥端", title: "案件指挥" },
+    volunteer: { context: "志愿者端", title: "协作案件" },
+  };
 
 const statusLabels: Record<string, string> = {
-  active: '进行中',
-  resolved: '已找到',
-  closed: '已关闭',
-  pending_review: '待审核',
-  needs_verification: '待核实',
-  confirmed: '已确认',
-  rejected: '已排除',
-  expired: '已失效',
-  duplicate: '重复',
-  conflicting: '冲突',
-  insufficient_information: '信息不足',
-}
+  active: "进行中",
+  resolved: "已找到",
+  closed: "已关闭",
+  pending_review: "待审核",
+  needs_verification: "待核实",
+  confirmed: "已确认",
+  rejected: "已排除",
+  expired: "已失效",
+  duplicate: "重复",
+  conflicting: "冲突",
+  insufficient_information: "信息不足",
+};
 
 const placeTypeLabels: Record<string, string> = {
-  frequent: '常去地点',
-  key_location: '关键地点',
-  last_seen_context: '最后出现相关',
-  medical: '医疗',
-  shelter: '临时安置',
-  other: '其他',
-}
+  frequent: "常去地点",
+  key_location: "关键地点",
+  last_seen_context: "最后出现相关",
+  medical: "医疗",
+  shelter: "临时安置",
+  other: "其他",
+};
 
 export function CaseWorkspacePage({ mode }: { mode: WorkspaceMode }) {
-  const { token, user } = useAuth()
-  const [cases, setCases] = useState<CaseListItem[]>([])
-  const [selectedId, setSelectedId] = useState<string | null>(null)
-  const [detail, setDetail] = useState<CaseDetail | null>(null)
-  const [resourceConfiguration, setResourceConfiguration] = useState<CaseResourceConfiguration | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const [isDetailLoading, setIsDetailLoading] = useState(false)
-  const [listError, setListError] = useState('')
-  const [detailError, setDetailError] = useState('')
-  const [notice, setNotice] = useState('')
-  const [showCreate, setShowCreate] = useState(false)
-  const detailRequestVersion = useRef(0)
+  const { token, user } = useAuth();
+  const [cases, setCases] = useState<CaseListItem[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [detail, setDetail] = useState<CaseDetail | null>(null);
+  const [resourceConfiguration, setResourceConfiguration] =
+    useState<CaseResourceConfiguration | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isDetailLoading, setIsDetailLoading] = useState(false);
+  const [listError, setListError] = useState("");
+  const [detailError, setDetailError] = useState("");
+  const [notice, setNotice] = useState("");
+  const [showCreate, setShowCreate] = useState(false);
+  const detailRequestVersion = useRef(0);
 
-  const loadCases = useCallback(async (preferredId?: string) => {
-    if (!token) return
-    setIsLoading(true)
-    setListError('')
-    try {
-      const items = await listCases(token)
-      setCases(items)
-      setSelectedId((currentId) => {
-        const nextId = preferredId ?? currentId ?? items[0]?.id ?? null
-        if (!nextId) setDetail(null)
-        return nextId
-      })
-    } catch (cause) {
-      setListError(messageFrom(cause))
-    } finally {
-      setIsLoading(false)
-    }
-  }, [token])
+  const loadCases = useCallback(
+    async (preferredId?: string) => {
+      if (!token) return;
+      setIsLoading(true);
+      setListError("");
+      try {
+        const items = await listCases(token);
+        setCases(items);
+        setSelectedId((currentId) => {
+          const nextId = preferredId ?? currentId ?? items[0]?.id ?? null;
+          if (!nextId) setDetail(null);
+          return nextId;
+        });
+      } catch (cause) {
+        setListError(messageFrom(cause));
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [token],
+  );
 
-  const loadDetail = useCallback(async (caseId: string) => {
-    const requestVersion = detailRequestVersion.current + 1
-    detailRequestVersion.current = requestVersion
-    if (!token) return
-    setIsDetailLoading(true)
-    setDetailError('')
-    try {
-      const [nextDetail, nextResourceConfiguration] = await Promise.all([
-        getCase(token, caseId),
-        getCaseResourceConfiguration(token, caseId),
-      ])
-      if (requestVersion !== detailRequestVersion.current) return
-      setDetail(nextDetail)
-      setResourceConfiguration(nextResourceConfiguration)
-    } catch (cause) {
-      if (requestVersion !== detailRequestVersion.current) return
-      setDetailError(messageFrom(cause))
-      setDetail(null)
-      setResourceConfiguration(null)
-    } finally {
-      if (requestVersion === detailRequestVersion.current) setIsDetailLoading(false)
-    }
-  }, [token])
+  const loadDetail = useCallback(
+    async (caseId: string) => {
+      const requestVersion = detailRequestVersion.current + 1;
+      detailRequestVersion.current = requestVersion;
+      if (!token) return;
+      setIsDetailLoading(true);
+      setDetailError("");
+      try {
+        const [nextDetail, nextResourceConfiguration] = await Promise.all([
+          getCase(token, caseId),
+          getCaseResourceConfiguration(token, caseId),
+        ]);
+        if (requestVersion !== detailRequestVersion.current) return;
+        setDetail(nextDetail);
+        setResourceConfiguration(nextResourceConfiguration);
+      } catch (cause) {
+        if (requestVersion !== detailRequestVersion.current) return;
+        setDetailError(messageFrom(cause));
+        setDetail(null);
+        setResourceConfiguration(null);
+      } finally {
+        if (requestVersion === detailRequestVersion.current)
+          setIsDetailLoading(false);
+      }
+    },
+    [token],
+  );
 
   useEffect(() => {
-    void loadCases()
-  }, [loadCases])
+    void loadCases();
+  }, [loadCases]);
 
   useEffect(() => {
     if (selectedId) {
-      void loadDetail(selectedId)
-      return
+      void loadDetail(selectedId);
+      return;
     }
-    detailRequestVersion.current += 1
-    setDetail(null)
-    setResourceConfiguration(null)
-    setDetailError('')
-    setIsDetailLoading(false)
-  }, [loadDetail, selectedId])
+    detailRequestVersion.current += 1;
+    setDetail(null);
+    setResourceConfiguration(null);
+    setDetailError("");
+    setIsDetailLoading(false);
+  }, [loadDetail, selectedId]);
 
   const pendingCount = useMemo(
-    () => detail?.clues.filter((clue) => clue.status === 'pending_review').length ?? 0,
+    () =>
+      detail?.clues.filter((clue) => clue.status === "pending_review").length ??
+      0,
     [detail],
-  )
-  const copy = workspaceCopy[mode]
-  const canCreateCase = user?.account_type === 'member'
+  );
+  const copy = workspaceCopy[mode];
+  const canCreateCase = user?.account_type === "member";
 
   return (
     <div className="mx-auto w-full max-w-7xl px-4 py-7 sm:px-6 lg:px-10 lg:py-10">
       <header className="mb-6 flex min-h-14 flex-col items-start justify-between gap-3 sm:flex-row sm:items-end">
         <div>
-          <span className="mb-1 block text-xs font-semibold text-slate-500">{copy.context}</span>
-          <h1 className="m-0 text-2xl font-bold text-slate-950 lg:text-3xl">{copy.title}</h1>
+          <span className="mb-1 block text-xs font-semibold text-slate-500">
+            {copy.context}
+          </span>
+          <h1 className="m-0 text-2xl font-bold text-slate-950 lg:text-3xl">
+            {copy.title}
+          </h1>
         </div>
         <div className="flex gap-2">
           <Button size="sm" variant="ghost" onPress={() => void loadCases()}>
             <RefreshCw size={16} />
             刷新
           </Button>
-          {canCreateCase && mode !== 'volunteer' && (
-            <Button size="sm" variant="primary" onPress={() => setShowCreate((value) => !value)}>
+          {canCreateCase && mode !== "volunteer" && (
+            <Button
+              size="sm"
+              variant="primary"
+              onPress={() => setShowCreate((value) => !value)}
+            >
               <CirclePlus size={16} />
               新建案件
             </Button>
@@ -216,34 +243,51 @@ export function CaseWorkspacePage({ mode }: { mode: WorkspaceMode }) {
         </div>
       </header>
 
-      {listError && cases.length > 0 && <Message tone="error">{listError}</Message>}
+      {listError && cases.length > 0 && (
+        <Message tone="error">{listError}</Message>
+      )}
       {notice && <Message tone="success">{notice}</Message>}
 
-      {mode === 'commander' && <CommandIntakePanel token={token} onAccepted={async () => { await loadCases() }} />}
+      {mode === "commander" && (
+        <CommandIntakePanel
+          token={token}
+          onAccepted={async () => {
+            await loadCases();
+          }}
+        />
+      )}
 
-      {showCreate && canCreateCase && mode !== 'volunteer' && (
+      {showCreate && canCreateCase && mode !== "volunteer" && (
         <FamilyIntakeForm
           onCancel={() => setShowCreate(false)}
           onConfirmed={async (caseId, caseCode) => {
-            setShowCreate(false)
-            setNotice(`案件 ${caseCode} 已由家属人工确认创建`)
-            await loadCases(caseId)
+            setShowCreate(false);
+            setNotice(`案件 ${caseCode} 已由家属人工确认创建`);
+            await loadCases(caseId);
           }}
         />
       )}
 
       <div className="mt-5 grid min-h-[560px] overflow-hidden border-y border-slate-200 bg-white lg:grid-cols-[310px_minmax(0,1fr)]">
-        <section className="border-b border-slate-200 lg:border-r lg:border-b-0" aria-label="案件列表">
+        <section
+          className="border-b border-slate-200 lg:border-r lg:border-b-0"
+          aria-label="案件列表"
+        >
           <div className="flex min-h-16 items-center justify-between border-b border-slate-200 px-4 py-3">
             <strong className="text-sm text-slate-950">可访问案件</strong>
-            <Chip size="sm" variant="soft"><Chip.Label>{cases.length}</Chip.Label></Chip>
+            <Chip size="sm" variant="soft">
+              <Chip.Label>{cases.length}</Chip.Label>
+            </Chip>
           </div>
           {isLoading ? (
             <LoadingState label="正在加载可访问案件" />
           ) : listError && cases.length === 0 ? (
             <ErrorState message={listError} onRetry={() => void loadCases()} />
           ) : cases.length === 0 ? (
-            <EmptyState title="暂无案件" description="新建案件后，会显示在这里。" />
+            <EmptyState
+              title="暂无案件"
+              description="新建案件后，会显示在这里。"
+            />
           ) : (
             <div className="divide-y divide-slate-100">
               {cases.map((item) => (
@@ -253,16 +297,24 @@ export function CaseWorkspacePage({ mode }: { mode: WorkspaceMode }) {
                   onClick={() => setSelectedId(item.id)}
                   aria-pressed={selectedId === item.id}
                   className={`flex min-h-20 w-full items-center gap-3 px-4 py-3 text-left transition-colors ${
-                    selectedId === item.id ? 'bg-brand-50' : 'hover:bg-slate-50'
+                    selectedId === item.id ? "bg-brand-50" : "hover:bg-slate-50"
                   }`}
                 >
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-2">
-                      <strong className="truncate text-sm text-slate-950">{item.display_name}</strong>
-                      <Chip size="sm" variant="soft"><Chip.Label>{statusLabels[item.status]}</Chip.Label></Chip>
+                      <strong className="truncate text-sm text-slate-950">
+                        {item.display_name}
+                      </strong>
+                      <Chip size="sm" variant="soft">
+                        <Chip.Label>{statusLabels[item.status]}</Chip.Label>
+                      </Chip>
                     </div>
-                    <span className="mt-1 block truncate text-xs text-slate-500">{item.case_code}</span>
-                    <span className="mt-0.5 block truncate text-xs text-slate-500">{item.last_seen_location ?? '地点待补充'}</span>
+                    <span className="mt-1 block truncate text-xs text-slate-500">
+                      {item.case_code}
+                    </span>
+                    <span className="mt-0.5 block truncate text-xs text-slate-500">
+                      {item.last_seen_location ?? "地点待补充"}
+                    </span>
                   </div>
                   <ChevronRight size={17} className="shrink-0 text-slate-400" />
                 </button>
@@ -285,9 +337,9 @@ export function CaseWorkspacePage({ mode }: { mode: WorkspaceMode }) {
               resourceConfiguration={resourceConfiguration}
               pendingCount={pendingCount}
               onChanged={async (message) => {
-                setNotice(message)
-                await loadDetail(detail.id)
-                await loadCases(detail.id)
+                setNotice(message);
+                await loadDetail(detail.id);
+                await loadCases(detail.id);
               }}
             />
           ) : (
@@ -298,7 +350,7 @@ export function CaseWorkspacePage({ mode }: { mode: WorkspaceMode }) {
         </section>
       </div>
     </div>
-  )
+  );
 }
 
 function CaseDetailView({
@@ -307,67 +359,92 @@ function CaseDetailView({
   pendingCount,
   onChanged,
 }: {
-  detail: CaseDetail
-  resourceConfiguration: CaseResourceConfiguration
-  pendingCount: number
-  onChanged: (message: string) => Promise<void>
+  detail: CaseDetail;
+  resourceConfiguration: CaseResourceConfiguration;
+  pendingCount: number;
+  onChanged: (message: string) => Promise<void>;
 }) {
-  const { token } = useAuth()
-  const [clueContent, setClueContent] = useState('')
-  const [clueLocation, setClueLocation] = useState('')
-  const [clueOccurredAt, setClueOccurredAt] = useState('')
-  const [clueSourceType, setClueSourceType] = useState<PublicClueSourceType>('manual_report')
-  const [clueRawReference, setClueRawReference] = useState('')
-  const [clueLocationPrecision, setClueLocationPrecision] = useState<LocationPrecision | ''>('')
-  const [clueNextAction, setClueNextAction] = useState('')
-  const [linkedAttachmentIds, setLinkedAttachmentIds] = useState<string[]>([])
-  const [reviewDrafts, setReviewDrafts] = useState<Record<string, ReviewDraft>>({})
-  const [clueQueue, setClueQueue] = useState<{ items: Clue[]; total: number; page: number; pageSize: number }>({
+  const { token } = useAuth();
+  const [clueContent, setClueContent] = useState("");
+  const [clueLocation, setClueLocation] = useState("");
+  const [clueOccurredAt, setClueOccurredAt] = useState("");
+  const [clueSourceType, setClueSourceType] =
+    useState<PublicClueSourceType>("manual_report");
+  const [clueRawReference, setClueRawReference] = useState("");
+  const [clueLocationPrecision, setClueLocationPrecision] = useState<
+    LocationPrecision | ""
+  >("");
+  const [clueNextAction, setClueNextAction] = useState("");
+  const [linkedAttachmentIds, setLinkedAttachmentIds] = useState<string[]>([]);
+  const [reviewDrafts, setReviewDrafts] = useState<Record<string, ReviewDraft>>(
+    {},
+  );
+  const [clueQueue, setClueQueue] = useState<{
+    items: Clue[];
+    total: number;
+    page: number;
+    pageSize: number;
+  }>({
     items: [],
     total: 0,
     page: 1,
     pageSize: 25,
-  })
-  const [queueFilters, setQueueFilters] = useState<ClueQueueFilters>(defaultClueQueueFilters)
-  const [isQueueLoading, setIsQueueLoading] = useState(false)
-  const [queueError, setQueueError] = useState('')
-  const queueRequestVersion = useRef(0)
-  const [place, setPlace] = useState<CreateCasePlacePayload>({ name: '', place_type: '', address: '', longitude: null, latitude: null, visibility: 'confirmed' })
-  const [attachment, setAttachment] = useState<File | null>(null)
-  const [nextStatus, setNextStatus] = useState<CaseStatus>(detail.status)
-  const [memberEmail, setMemberEmail] = useState('')
-  const [memberRole, setMemberRole] = useState<CaseRole>('volunteer')
-  const [busy, setBusy] = useState('')
-  const [error, setError] = useState('')
-  const isCommander = detail.access_role === 'commander'
+  });
+  const [queueFilters, setQueueFilters] = useState<ClueQueueFilters>(
+    defaultClueQueueFilters,
+  );
+  const [isQueueLoading, setIsQueueLoading] = useState(false);
+  const [queueError, setQueueError] = useState("");
+  const queueRequestVersion = useRef(0);
+  const [place, setPlace] = useState<CreateCasePlacePayload>({
+    name: "",
+    place_type: "",
+    address: "",
+    longitude: null,
+    latitude: null,
+    visibility: "confirmed",
+  });
+  const [attachment, setAttachment] = useState<File | null>(null);
+  const [nextStatus, setNextStatus] = useState<CaseStatus>(detail.status);
+  const [memberEmail, setMemberEmail] = useState("");
+  const [memberRole, setMemberRole] = useState<CaseRole>("volunteer");
+  const [busy, setBusy] = useState("");
+  const [error, setError] = useState("");
+  const isCommander = detail.access_role === "commander";
   const allowedMemberRoles: CaseRole[] = isCommander
-    ? ['family', 'commander', 'volunteer']
-    : ['family', 'commander']
+    ? ["family", "commander", "volunteer"]
+    : ["family", "commander"];
   const selectedMemberRole = allowedMemberRoles.includes(memberRole)
     ? memberRole
-    : allowedMemberRoles[0]
-  const canEditElderProfile = detail.access_role === 'family' || isCommander
-  const canSubmitPlace = detail.access_role === 'family' || isCommander
-  const placeTypes = resourceConfiguration.case_place_types
-  const statusOptions: CaseStatus[] = detail.status === 'active'
-    ? ['active', 'resolved', 'closed']
-    : detail.status === 'resolved'
-      ? ['resolved', 'active', 'closed']
-      : ['closed']
+    : allowedMemberRoles[0];
+  const canEditElderProfile = detail.access_role === "family" || isCommander;
+  const canSubmitPlace = detail.access_role === "family" || isCommander;
+  const placeTypes = resourceConfiguration.case_place_types;
+  const statusOptions: CaseStatus[] =
+    detail.status === "active"
+      ? ["active", "resolved", "closed"]
+      : detail.status === "resolved"
+        ? ["resolved", "active", "closed"]
+        : ["closed"];
 
   const loadClueQueue = useCallback(async () => {
-    const requestVersion = queueRequestVersion.current + 1
-    queueRequestVersion.current = requestVersion
+    const requestVersion = queueRequestVersion.current + 1;
+    queueRequestVersion.current = requestVersion;
     if (!token) {
-      setClueQueue({ items: [], total: 0, page: 1, pageSize: 25 })
-      setQueueError('')
-      setIsQueueLoading(false)
-      return
+      setClueQueue({ items: [], total: 0, page: 1, pageSize: 25 });
+      setQueueError("");
+      setIsQueueLoading(false);
+      return;
     }
-    if (!isCommander) return
-    setClueQueue({ items: [], total: 0, page: queueFilters.page, pageSize: 25 })
-    setIsQueueLoading(true)
-    setQueueError('')
+    if (!isCommander) return;
+    setClueQueue({
+      items: [],
+      total: 0,
+      page: queueFilters.page,
+      pageSize: 25,
+    });
+    setIsQueueLoading(true);
+    setQueueError("");
     try {
       const page = await listCaseClues(token, detail.id, {
         page: queueFilters.page,
@@ -376,56 +453,61 @@ function CaseDetailView({
         source_type: queueFilters.sourceType || undefined,
         sort: queueFilters.sort,
         order: queueFilters.order,
-      })
-      if (requestVersion !== queueRequestVersion.current) return
+      });
+      if (requestVersion !== queueRequestVersion.current) return;
       setClueQueue({
         items: page.items,
         total: page.total,
         page: page.page,
         pageSize: page.page_size,
-      })
+      });
     } catch (cause) {
-      if (requestVersion !== queueRequestVersion.current) return
-      setQueueError(messageFrom(cause))
+      if (requestVersion !== queueRequestVersion.current) return;
+      setQueueError(messageFrom(cause));
     } finally {
-      if (requestVersion === queueRequestVersion.current) setIsQueueLoading(false)
+      if (requestVersion === queueRequestVersion.current)
+        setIsQueueLoading(false);
     }
-  }, [detail.id, isCommander, queueFilters, token])
+  }, [detail.id, isCommander, queueFilters, token]);
 
-  const visibleClues = isCommander ? clueQueue.items : detail.clues
+  const visibleClues = isCommander ? clueQueue.items : detail.clues;
 
-  useEffect(() => setNextStatus(detail.status), [detail.status])
+  useEffect(() => setNextStatus(detail.status), [detail.status]);
   useEffect(() => {
-    setPlace((current) => (
+    setPlace((current) =>
       placeTypes.includes(current.place_type)
         ? current
-        : { ...current, place_type: placeTypes[0] ?? '' }
-    ))
-  }, [placeTypes])
+        : { ...current, place_type: placeTypes[0] ?? "" },
+    );
+  }, [placeTypes]);
   useEffect(() => {
     if (isCommander) {
-      void loadClueQueue()
-      return
+      void loadClueQueue();
+      return;
     }
-    queueRequestVersion.current += 1
-    setClueQueue({ items: [], total: 0, page: 1, pageSize: 25 })
-    setQueueError('')
-    setIsQueueLoading(false)
-  }, [isCommander, loadClueQueue])
+    queueRequestVersion.current += 1;
+    setClueQueue({ items: [], total: 0, page: 1, pageSize: 25 });
+    setQueueError("");
+    setIsQueueLoading(false);
+  }, [isCommander, loadClueQueue]);
 
-  async function run(key: string, action: () => Promise<unknown>, message: string) {
-    setBusy(key)
-    setError('')
+  async function run(
+    key: string,
+    action: () => Promise<unknown>,
+    message: string,
+  ) {
+    setBusy(key);
+    setError("");
     try {
-      await action()
-      await onChanged(message)
-      await loadClueQueue()
-      return true
+      await action();
+      await onChanged(message);
+      await loadClueQueue();
+      return true;
     } catch (cause) {
-      setError(messageFrom(cause))
-      return false
+      setError(messageFrom(cause));
+      return false;
     } finally {
-      setBusy('')
+      setBusy("");
     }
   }
 
@@ -435,13 +517,25 @@ function CaseDetailView({
         <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-start">
           <div>
             <div className="flex flex-wrap items-center gap-2">
-              <h2 className="m-0 text-xl font-bold text-slate-950">{detail.elder_profile.display_name}</h2>
-              <Chip size="sm" variant="soft"><Chip.Label>{statusLabels[detail.status]}</Chip.Label></Chip>
-              {pendingCount > 0 && <Chip size="sm" variant="soft"><Chip.Label>{pendingCount} 条待审核</Chip.Label></Chip>}
+              <h2 className="m-0 text-xl font-bold text-slate-950">
+                {detail.elder_profile.display_name}
+              </h2>
+              <Chip size="sm" variant="soft">
+                <Chip.Label>{statusLabels[detail.status]}</Chip.Label>
+              </Chip>
+              {pendingCount > 0 && (
+                <Chip size="sm" variant="soft">
+                  <Chip.Label>{pendingCount} 条待审核</Chip.Label>
+                </Chip>
+              )}
             </div>
-            <span className="mt-1 block text-xs text-slate-500">{detail.case_code}</span>
+            <span className="mt-1 block text-xs text-slate-500">
+              {detail.case_code}
+            </span>
           </div>
-          <span className="text-xs text-slate-500">权限：{detail.access_role}</span>
+          <span className="text-xs text-slate-500">
+            权限：{detail.access_role}
+          </span>
         </div>
       </header>
 
@@ -449,80 +543,202 @@ function CaseDetailView({
       <CaseSituationPanel detail={detail} token={token} />
       <CaseCollaborationPanel detail={detail} token={token} />
 
-      <section className="grid gap-x-8 gap-y-4 border-b border-slate-200 px-5 py-5 sm:grid-cols-2 sm:px-6 lg:grid-cols-3" aria-label="老人资料">
-        <Info label="最后出现地点" value={detail.elder_profile.last_seen_location} icon={<MapPin size={16} />} />
-        <Info label="最后出现时间" value={formatDate(detail.elder_profile.last_seen_at)} />
-        <Info label="年龄" value={detail.elder_profile.age == null ? null : `${detail.elder_profile.age} 岁`} />
+      <section
+        className="grid gap-x-8 gap-y-4 border-b border-slate-200 px-5 py-5 sm:grid-cols-2 sm:px-6 lg:grid-cols-3"
+        aria-label="老人资料"
+      >
+        <Info
+          label="最后出现地点"
+          value={detail.elder_profile.last_seen_location}
+          icon={<MapPin size={16} />}
+        />
+        <Info
+          label="最后出现时间"
+          value={formatDate(detail.elder_profile.last_seen_at)}
+        />
+        <Info
+          label="年龄"
+          value={
+            detail.elder_profile.age == null
+              ? null
+              : `${detail.elder_profile.age} 岁`
+          }
+        />
         <Info label="体貌" value={detail.elder_profile.physical_description} />
         <Info label="衣着" value={detail.elder_profile.clothing_description} />
-        {detail.elder_profile.health_notes && <Info label="健康注意" value={detail.elder_profile.health_notes} />}
+        {detail.elder_profile.health_notes && (
+          <Info label="健康注意" value={detail.elder_profile.health_notes} />
+        )}
       </section>
 
-      {canEditElderProfile && <ElderProfileEditor detail={detail} token={token} busy={busy} onSave={(payload) => run('elder-profile', () => updateElderProfile(token!, detail.id, payload), '人物摘要已更新')} />}
+      {canEditElderProfile && (
+        <ElderProfileEditor
+          detail={detail}
+          token={token}
+          busy={busy}
+          onSave={(payload) =>
+            run(
+              "elder-profile",
+              () => updateElderProfile(token!, detail.id, payload),
+              "人物摘要已更新",
+            )
+          }
+        />
+      )}
 
-      {(isCommander || detail.access_role === 'family') && (
+      {(isCommander || detail.access_role === "family") && (
         <section className="grid gap-5 border-b border-slate-200 bg-slate-50 px-5 py-5 sm:px-6 lg:grid-cols-2">
-          {isCommander && <form
-            onSubmit={(event) => {
-              event.preventDefault()
-              if (!token) return
-              void run('status', () => updateCaseStatus(token, detail.id, nextStatus), '案件状态已更新')
-            }}
-          >
-            <h3 id="case-status-title" className="m-0 text-sm font-bold text-slate-950">案件状态</h3>
-            <div className="mt-3 flex gap-2">
-              <select aria-labelledby="case-status-title" className="min-h-10 flex-1 rounded-md border border-slate-300 bg-white px-3 text-sm" value={nextStatus} onChange={(event) => setNextStatus(event.target.value as CaseStatus)} disabled={detail.status === 'closed'}>
-                {statusOptions.map((status) => <option key={status} value={status}>{statusLabels[status]}</option>)}
-              </select>
-              <Button type="submit" size="sm" variant="secondary" isDisabled={busy === 'status' || nextStatus === detail.status}>保存</Button>
-            </div>
-          </form>}
+          {isCommander && (
+            <form
+              onSubmit={(event) => {
+                event.preventDefault();
+                if (!token) return;
+                void run(
+                  "status",
+                  () => updateCaseStatus(token, detail.id, nextStatus),
+                  "案件状态已更新",
+                );
+              }}
+            >
+              <h3
+                id="case-status-title"
+                className="m-0 text-sm font-bold text-slate-950"
+              >
+                案件状态
+              </h3>
+              <div className="mt-3 flex gap-2">
+                <select
+                  aria-labelledby="case-status-title"
+                  className="min-h-10 flex-1 rounded-md border border-slate-300 bg-white px-3 text-sm"
+                  value={nextStatus}
+                  onChange={(event) =>
+                    setNextStatus(event.target.value as CaseStatus)
+                  }
+                  disabled={detail.status === "closed"}
+                >
+                  {statusOptions.map((status) => (
+                    <option key={status} value={status}>
+                      {statusLabels[status]}
+                    </option>
+                  ))}
+                </select>
+                <Button
+                  type="submit"
+                  size="sm"
+                  variant="secondary"
+                  isDisabled={busy === "status" || nextStatus === detail.status}
+                >
+                  保存
+                </Button>
+              </div>
+            </form>
+          )}
 
           <form
             onSubmit={(event) => {
-              event.preventDefault()
-              if (!token) return
-              void run('member', () => addCaseMember(token, detail.id, memberEmail.trim(), selectedMemberRole), '案件成员已添加').then((succeeded) => {
-                if (succeeded) setMemberEmail('')
-              })
+              event.preventDefault();
+              if (!token) return;
+              void run(
+                "member",
+                () =>
+                  addCaseMember(
+                    token,
+                    detail.id,
+                    memberEmail.trim(),
+                    selectedMemberRole,
+                  ),
+                "案件成员已添加",
+              ).then((succeeded) => {
+                if (succeeded) setMemberEmail("");
+              });
             }}
           >
             <h3 className="m-0 text-sm font-bold text-slate-950">添加成员</h3>
             <div className="mt-3 grid gap-2 sm:grid-cols-[minmax(0,1fr)_120px_auto]">
-              <Input type="email" value={memberEmail} maxLength={320} onChange={(event) => setMemberEmail(event.target.value)} placeholder="成员邮箱" fullWidth required />
-              <select aria-label="成员角色" className="min-h-10 rounded-md border border-slate-300 bg-white px-3 text-sm" value={selectedMemberRole} onChange={(event) => setMemberRole(event.target.value as CaseRole)}>
+              <Input
+                type="email"
+                value={memberEmail}
+                maxLength={320}
+                onChange={(event) => setMemberEmail(event.target.value)}
+                placeholder="成员邮箱"
+                fullWidth
+                required
+              />
+              <select
+                aria-label="成员角色"
+                className="min-h-10 rounded-md border border-slate-300 bg-white px-3 text-sm"
+                value={selectedMemberRole}
+                onChange={(event) =>
+                  setMemberRole(event.target.value as CaseRole)
+                }
+              >
                 <option value="family">家属</option>
                 <option value="commander">指挥</option>
                 {isCommander && <option value="volunteer">志愿者</option>}
               </select>
-              <Button type="submit" size="sm" variant="secondary" isDisabled={busy === 'member'} isIconOnly aria-label="添加案件成员"><UserPlus size={17} /></Button>
+              <Button
+                type="submit"
+                size="sm"
+                variant="secondary"
+                isDisabled={busy === "member"}
+                isIconOnly
+                aria-label="添加案件成员"
+              >
+                <UserPlus size={17} />
+              </Button>
             </div>
           </form>
         </section>
       )}
 
-      {error && <div className="px-5 pt-4 sm:px-6"><Message tone="error">{error}</Message></div>}
+      {error && (
+        <div className="px-5 pt-4 sm:px-6">
+          <Message tone="error">{error}</Message>
+        </div>
+      )}
 
       <section className="px-5 py-5 sm:px-6" aria-labelledby="clues-title">
         <div className="flex items-center justify-between gap-3">
-          <h3 id="clues-title" className="m-0 text-base font-bold text-slate-950">线索</h3>
-          <Chip size="sm" variant="soft"><Chip.Label>{detail.clues.length} 条可见</Chip.Label></Chip>
+          <h3
+            id="clues-title"
+            className="m-0 text-base font-bold text-slate-950"
+          >
+            线索
+          </h3>
+          <Chip size="sm" variant="soft">
+            <Chip.Label>{detail.clues.length} 条可见</Chip.Label>
+          </Chip>
         </div>
 
         {isCommander && (
           <fieldset className="mt-4 grid gap-3 rounded-md border border-slate-200 bg-slate-50 p-3 sm:grid-cols-2 lg:grid-cols-4">
-            <legend className="px-1 text-sm font-semibold text-slate-800">筛选与排序</legend>
+            <legend className="px-1 text-sm font-semibold text-slate-800">
+              筛选与排序
+            </legend>
             <Field label="审核状态">
               <select
                 aria-label="审核状态筛选"
                 className="min-h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm"
                 value={queueFilters.status}
-                onChange={(event) => setQueueFilters((current) => ({ ...current, status: event.target.value as ClueStatus | '', page: 1 }))}
+                onChange={(event) =>
+                  setQueueFilters((current) => ({
+                    ...current,
+                    status: event.target.value as ClueStatus | "",
+                    page: 1,
+                  }))
+                }
               >
                 <option value="">全部状态</option>
-                {Object.entries(statusLabels).filter(([status]) => !['active', 'resolved', 'closed'].includes(status)).map(([status, label]) => (
-                  <option key={status} value={status}>{label}</option>
-                ))}
+                {Object.entries(statusLabels)
+                  .filter(
+                    ([status]) =>
+                      !["active", "resolved", "closed"].includes(status),
+                  )
+                  .map(([status, label]) => (
+                    <option key={status} value={status}>
+                      {label}
+                    </option>
+                  ))}
               </select>
             </Field>
             <Field label="来源类型">
@@ -530,7 +746,13 @@ function CaseDetailView({
                 aria-label="来源类型筛选"
                 className="min-h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm"
                 value={queueFilters.sourceType}
-                onChange={(event) => setQueueFilters((current) => ({ ...current, sourceType: event.target.value as ClueSourceType | '', page: 1 }))}
+                onChange={(event) =>
+                  setQueueFilters((current) => ({
+                    ...current,
+                    sourceType: event.target.value as ClueSourceType | "",
+                    page: 1,
+                  }))
+                }
               >
                 <option value="">全部来源</option>
                 <option value="manual_report">人工上报</option>
@@ -544,7 +766,13 @@ function CaseDetailView({
                 aria-label="时间字段排序"
                 className="min-h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm"
                 value={queueFilters.sort}
-                onChange={(event) => setQueueFilters((current) => ({ ...current, sort: event.target.value as ClueQueueFilters['sort'], page: 1 }))}
+                onChange={(event) =>
+                  setQueueFilters((current) => ({
+                    ...current,
+                    sort: event.target.value as ClueQueueFilters["sort"],
+                    page: 1,
+                  }))
+                }
               >
                 <option value="created_at">上报时间</option>
                 <option value="occurred_at">发生时间</option>
@@ -555,7 +783,13 @@ function CaseDetailView({
                 aria-label="排序方向"
                 className="min-h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm"
                 value={queueFilters.order}
-                onChange={(event) => setQueueFilters((current) => ({ ...current, order: event.target.value as ClueQueueFilters['order'], page: 1 }))}
+                onChange={(event) =>
+                  setQueueFilters((current) => ({
+                    ...current,
+                    order: event.target.value as ClueQueueFilters["order"],
+                    page: 1,
+                  }))
+                }
               >
                 <option value="desc">最新优先</option>
                 <option value="asc">最早优先</option>
@@ -564,77 +798,285 @@ function CaseDetailView({
           </fieldset>
         )}
 
-        {isCommander && queueError && <div className="mt-4"><ErrorState message={queueError} onRetry={() => void loadClueQueue()} /></div>}
+        {isCommander && queueError && (
+          <div className="mt-4">
+            <ErrorState
+              message={queueError}
+              onRetry={() => void loadClueQueue()}
+            />
+          </div>
+        )}
 
         <div className="mt-4 divide-y divide-slate-100 border-y border-slate-200">
           {isQueueLoading ? (
             <LoadingState label="正在加载审核队列" />
           ) : visibleClues.length === 0 ? (
-            <div className="flex min-h-28 items-center justify-center text-sm text-slate-500">暂无可见线索</div>
-          ) : visibleClues.map((clue) => (
-            <article key={clue.id} className="py-4">
-              <div className="flex flex-wrap items-center gap-2">
-                <Chip size="sm" variant="soft"><Chip.Label>{statusLabels[clue.status] ?? clue.status}</Chip.Label></Chip>
-                <span className="text-xs text-slate-500">{clue.source}</span>
-                {clue.source_type !== 'manual_report' && <span className="text-xs font-medium text-amber-700">{clue.source_type === 'ai_draft' ? 'AI 字段草稿' : clue.source_type === 'chat_draft' ? '聊天整理草稿' : '现场反馈'}</span>}
-                {clue.is_own_submission && <span className="text-xs font-medium text-brand-700">本人提交</span>}
-                <span className="ml-auto text-xs text-slate-500">事件：{formatDate(clue.occurred_at) ?? '未提供'} · 上报：{formatDate(clue.reported_at)}</span>
-              </div>
-              <p className="m-0 mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-700">{clue.content}</p>
-              {clue.raw_record_reference && <p className="m-0 mt-1 text-xs text-slate-500">受控原始记录：{clue.raw_record_reference}</p>}
-              {clue.location_text && <p className="m-0 mt-1 text-xs text-slate-500">地点：{clue.location_text}{clue.location_precision ? `（${clue.location_precision === 'exact' ? '精确' : clue.location_precision === 'approximate' ? '约略' : '精度未知'}）` : ''}</p>}
-              {(clue.next_action || clue.linked_task_reference || clue.review_reason || clue.confirmed_at) && <div className="mt-2 rounded bg-slate-50 px-2 py-1.5 text-xs leading-5 text-slate-600">
-                {clue.review_reason && <div>审核理由：{clue.review_reason}</div>}
-                {clue.confirmed_at && <div>确认时间：{formatDate(clue.confirmed_at)}</div>}
-                {clue.next_action && <div>下一步：{clue.next_action}</div>}
-                {clue.linked_task_reference && <div>关联任务：{clue.linked_task_reference}</div>}
-              </div>}
-              {isCommander && clue.status === 'pending_review' && (
-                <div className="mt-3 grid gap-3 rounded-md border border-amber-200 bg-amber-50 p-3">
-                  <Field label="审核理由（每次确认、排除、降级或合并必填）" required>
-                    <TextArea aria-label="审核理由" value={reviewDrafts[clue.id]?.reason ?? ''} maxLength={1000} rows={2} onChange={(event) => setReviewDrafts((current) => ({ ...current, [clue.id]: { reason: event.target.value, relatedClueId: current[clue.id]?.relatedClueId ?? '', relatedClueQuery: current[clue.id]?.relatedClueQuery ?? '' } }))} fullWidth required />
-                  </Field>
-                  <Field label="关联线索（重复或冲突时必选）">
-                    <RelatedCluePicker
-                      clueId={clue.id}
-                      candidates={detail.clues}
-                      selectedId={reviewDrafts[clue.id]?.relatedClueId ?? ''}
-                      query={reviewDrafts[clue.id]?.relatedClueQuery ?? ''}
-                      onChange={(relatedClueId, relatedClueQuery) => setReviewDrafts((current) => ({ ...current, [clue.id]: { reason: current[clue.id]?.reason ?? '', relatedClueId, relatedClueQuery } }))}
-                    />
-                  </Field>
-                  <p className="m-0 text-xs leading-5 text-amber-900">审核只会由指挥端提交。每条线索各自保存审核草稿，成功审核后会清空该条草稿。</p>
-                  <div className="flex flex-wrap gap-2">
-                    <ReviewButton label="确认" status="confirmed" clueId={clue.id} reason={reviewDrafts[clue.id]?.reason ?? ''} relatedClueId={reviewDrafts[clue.id]?.relatedClueId ?? ''} busy={busy} run={run} onReviewed={() => setReviewDrafts((current) => { const next = { ...current }; delete next[clue.id]; return next })} />
-                    <ReviewButton label="待核实" status="needs_verification" clueId={clue.id} reason={reviewDrafts[clue.id]?.reason ?? ''} relatedClueId={reviewDrafts[clue.id]?.relatedClueId ?? ''} busy={busy} run={run} onReviewed={() => setReviewDrafts((current) => { const next = { ...current }; delete next[clue.id]; return next })} />
-                    <ReviewButton label="信息不足" status="insufficient_information" clueId={clue.id} reason={reviewDrafts[clue.id]?.reason ?? ''} relatedClueId={reviewDrafts[clue.id]?.relatedClueId ?? ''} busy={busy} run={run} onReviewed={() => setReviewDrafts((current) => { const next = { ...current }; delete next[clue.id]; return next })} />
-                    <ReviewButton label="排除" status="rejected" clueId={clue.id} reason={reviewDrafts[clue.id]?.reason ?? ''} relatedClueId={reviewDrafts[clue.id]?.relatedClueId ?? ''} busy={busy} run={run} onReviewed={() => setReviewDrafts((current) => { const next = { ...current }; delete next[clue.id]; return next })} />
-                    <ReviewButton label="重复" status="duplicate" clueId={clue.id} reason={reviewDrafts[clue.id]?.reason ?? ''} relatedClueId={reviewDrafts[clue.id]?.relatedClueId ?? ''} busy={busy} run={run} onReviewed={() => setReviewDrafts((current) => { const next = { ...current }; delete next[clue.id]; return next })} />
-                    <ReviewButton label="冲突" status="conflicting" clueId={clue.id} reason={reviewDrafts[clue.id]?.reason ?? ''} relatedClueId={reviewDrafts[clue.id]?.relatedClueId ?? ''} busy={busy} run={run} onReviewed={() => setReviewDrafts((current) => { const next = { ...current }; delete next[clue.id]; return next })} />
-                  </div>
+            <div className="flex min-h-28 items-center justify-center text-sm text-slate-500">
+              暂无可见线索
+            </div>
+          ) : (
+            visibleClues.map((clue) => (
+              <article key={clue.id} className="py-4">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Chip size="sm" variant="soft">
+                    <Chip.Label>
+                      {statusLabels[clue.status] ?? clue.status}
+                    </Chip.Label>
+                  </Chip>
+                  <span className="text-xs text-slate-500">{clue.source}</span>
+                  {clue.source_type !== "manual_report" && (
+                    <span className="text-xs font-medium text-amber-700">
+                      {clue.source_type === "ai_draft"
+                        ? "AI 字段草稿"
+                        : clue.source_type === "chat_draft"
+                          ? "聊天整理草稿"
+                          : "现场反馈"}
+                    </span>
+                  )}
+                  {clue.is_own_submission && (
+                    <span className="text-xs font-medium text-brand-700">
+                      本人提交
+                    </span>
+                  )}
+                  <span className="ml-auto text-xs text-slate-500">
+                    事件：{formatDate(clue.occurred_at) ?? "未提供"} · 上报：
+                    {formatDate(clue.reported_at)}
+                  </span>
                 </div>
-              )}
-            </article>
-          ))}
+                <p className="m-0 mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-700">
+                  {clue.content}
+                </p>
+                {clue.raw_record_reference && (
+                  <p className="m-0 mt-1 text-xs text-slate-500">
+                    受控原始记录：{clue.raw_record_reference}
+                  </p>
+                )}
+                {clue.location_text && (
+                  <p className="m-0 mt-1 text-xs text-slate-500">
+                    地点：{clue.location_text}
+                    {clue.location_precision
+                      ? `（${clue.location_precision === "exact" ? "精确" : clue.location_precision === "approximate" ? "约略" : "精度未知"}）`
+                      : ""}
+                  </p>
+                )}
+                {(clue.next_action ||
+                  clue.linked_task_reference ||
+                  clue.review_reason ||
+                  clue.confirmed_at) && (
+                  <div className="mt-2 rounded bg-slate-50 px-2 py-1.5 text-xs leading-5 text-slate-600">
+                    {clue.review_reason && (
+                      <div>审核理由：{clue.review_reason}</div>
+                    )}
+                    {clue.confirmed_at && (
+                      <div>确认时间：{formatDate(clue.confirmed_at)}</div>
+                    )}
+                    {clue.next_action && <div>下一步：{clue.next_action}</div>}
+                    {clue.linked_task_reference && (
+                      <div>关联任务：{clue.linked_task_reference}</div>
+                    )}
+                  </div>
+                )}
+                {isCommander && clue.status === "pending_review" && (
+                  <div className="mt-3 grid gap-3 rounded-md border border-amber-200 bg-amber-50 p-3">
+                    <Field
+                      label="审核理由（每次确认、排除、降级或合并必填）"
+                      required
+                    >
+                      <TextArea
+                        aria-label="审核理由"
+                        value={reviewDrafts[clue.id]?.reason ?? ""}
+                        maxLength={1000}
+                        rows={2}
+                        onChange={(event) =>
+                          setReviewDrafts((current) => ({
+                            ...current,
+                            [clue.id]: {
+                              reason: event.target.value,
+                              relatedClueId:
+                                current[clue.id]?.relatedClueId ?? "",
+                              relatedClueQuery:
+                                current[clue.id]?.relatedClueQuery ?? "",
+                            },
+                          }))
+                        }
+                        fullWidth
+                        required
+                      />
+                    </Field>
+                    <Field label="关联线索（重复或冲突时必选）">
+                      <RelatedCluePicker
+                        clueId={clue.id}
+                        candidates={detail.clues}
+                        selectedId={reviewDrafts[clue.id]?.relatedClueId ?? ""}
+                        query={reviewDrafts[clue.id]?.relatedClueQuery ?? ""}
+                        onChange={(relatedClueId, relatedClueQuery) =>
+                          setReviewDrafts((current) => ({
+                            ...current,
+                            [clue.id]: {
+                              reason: current[clue.id]?.reason ?? "",
+                              relatedClueId,
+                              relatedClueQuery,
+                            },
+                          }))
+                        }
+                      />
+                    </Field>
+                    <p className="m-0 text-xs leading-5 text-amber-900">
+                      审核只会由指挥端提交。每条线索各自保存审核草稿，成功审核后会清空该条草稿。
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      <ReviewButton
+                        label="确认"
+                        status="confirmed"
+                        clueId={clue.id}
+                        reason={reviewDrafts[clue.id]?.reason ?? ""}
+                        relatedClueId={
+                          reviewDrafts[clue.id]?.relatedClueId ?? ""
+                        }
+                        busy={busy}
+                        run={run}
+                        onReviewed={() =>
+                          setReviewDrafts((current) => {
+                            const next = { ...current };
+                            delete next[clue.id];
+                            return next;
+                          })
+                        }
+                      />
+                      <ReviewButton
+                        label="待核实"
+                        status="needs_verification"
+                        clueId={clue.id}
+                        reason={reviewDrafts[clue.id]?.reason ?? ""}
+                        relatedClueId={
+                          reviewDrafts[clue.id]?.relatedClueId ?? ""
+                        }
+                        busy={busy}
+                        run={run}
+                        onReviewed={() =>
+                          setReviewDrafts((current) => {
+                            const next = { ...current };
+                            delete next[clue.id];
+                            return next;
+                          })
+                        }
+                      />
+                      <ReviewButton
+                        label="信息不足"
+                        status="insufficient_information"
+                        clueId={clue.id}
+                        reason={reviewDrafts[clue.id]?.reason ?? ""}
+                        relatedClueId={
+                          reviewDrafts[clue.id]?.relatedClueId ?? ""
+                        }
+                        busy={busy}
+                        run={run}
+                        onReviewed={() =>
+                          setReviewDrafts((current) => {
+                            const next = { ...current };
+                            delete next[clue.id];
+                            return next;
+                          })
+                        }
+                      />
+                      <ReviewButton
+                        label="排除"
+                        status="rejected"
+                        clueId={clue.id}
+                        reason={reviewDrafts[clue.id]?.reason ?? ""}
+                        relatedClueId={
+                          reviewDrafts[clue.id]?.relatedClueId ?? ""
+                        }
+                        busy={busy}
+                        run={run}
+                        onReviewed={() =>
+                          setReviewDrafts((current) => {
+                            const next = { ...current };
+                            delete next[clue.id];
+                            return next;
+                          })
+                        }
+                      />
+                      <ReviewButton
+                        label="重复"
+                        status="duplicate"
+                        clueId={clue.id}
+                        reason={reviewDrafts[clue.id]?.reason ?? ""}
+                        relatedClueId={
+                          reviewDrafts[clue.id]?.relatedClueId ?? ""
+                        }
+                        busy={busy}
+                        run={run}
+                        onReviewed={() =>
+                          setReviewDrafts((current) => {
+                            const next = { ...current };
+                            delete next[clue.id];
+                            return next;
+                          })
+                        }
+                      />
+                      <ReviewButton
+                        label="冲突"
+                        status="conflicting"
+                        clueId={clue.id}
+                        reason={reviewDrafts[clue.id]?.reason ?? ""}
+                        relatedClueId={
+                          reviewDrafts[clue.id]?.relatedClueId ?? ""
+                        }
+                        busy={busy}
+                        run={run}
+                        onReviewed={() =>
+                          setReviewDrafts((current) => {
+                            const next = { ...current };
+                            delete next[clue.id];
+                            return next;
+                          })
+                        }
+                      />
+                    </div>
+                  </div>
+                )}
+              </article>
+            ))
+          )}
         </div>
 
         {isCommander && clueQueue.total > clueQueue.pageSize && (
-          <nav className="mt-4 flex items-center justify-between gap-3" aria-label="线索队列分页">
-            <span className="text-sm text-slate-600">第 {clueQueue.page} 页，共 {Math.ceil(clueQueue.total / clueQueue.pageSize)} 页</span>
+          <nav
+            className="mt-4 flex items-center justify-between gap-3"
+            aria-label="线索队列分页"
+          >
+            <span className="text-sm text-slate-600">
+              第 {clueQueue.page} 页，共{" "}
+              {Math.ceil(clueQueue.total / clueQueue.pageSize)} 页
+            </span>
             <div className="flex gap-2">
               <Button
                 size="sm"
                 variant="ghost"
                 isDisabled={isQueueLoading || clueQueue.page <= 1}
-                onPress={() => setQueueFilters((current) => ({ ...current, page: current.page - 1 }))}
+                onPress={() =>
+                  setQueueFilters((current) => ({
+                    ...current,
+                    page: current.page - 1,
+                  }))
+                }
               >
                 上一页
               </Button>
               <Button
                 size="sm"
                 variant="ghost"
-                isDisabled={isQueueLoading || clueQueue.page * clueQueue.pageSize >= clueQueue.total}
-                onPress={() => setQueueFilters((current) => ({ ...current, page: current.page + 1 }))}
+                isDisabled={
+                  isQueueLoading ||
+                  clueQueue.page * clueQueue.pageSize >= clueQueue.total
+                }
+                onPress={() =>
+                  setQueueFilters((current) => ({
+                    ...current,
+                    page: current.page + 1,
+                  }))
+                }
               >
                 下一页
               </Button>
@@ -642,430 +1084,1644 @@ function CaseDetailView({
           </nav>
         )}
 
-        {detail.status === 'active' && (
+        {detail.status === "active" && (
           <form
             className="mt-5 grid gap-3 sm:grid-cols-[minmax(0,1fr)_220px]"
             onSubmit={(event) => {
-              event.preventDefault()
-              if (!token) return
-              const content = nullable(clueContent)
+              event.preventDefault();
+              if (!token) return;
+              const content = nullable(clueContent);
               if (!content) {
-                setError('请填写线索内容后再提交。')
-                return
+                setError("请填写线索内容后再提交。");
+                return;
               }
-              const location = nullable(clueLocation)
+              const location = nullable(clueLocation);
               if (clueLocationPrecision && !location) {
-                setError('选择地点精度时，请同时填写地点。')
-                return
+                setError("选择地点精度时，请同时填写地点。");
+                return;
               }
               void run(
-                'clue',
-                () => createClue(token, detail.id, {
-                  source: detail.access_role,
-                  content,
-                  source_type: clueSourceType,
-                  raw_record_reference: nullable(clueRawReference),
-                  occurred_at: toIsoOrNull(clueOccurredAt),
-                  location_text: location,
-                  location_precision: clueLocationPrecision || null,
-                  next_action: nullable(clueNextAction),
-                  attachment_ids: linkedAttachmentIds,
-                }),
-                '线索已提交并进入人工审核',
+                "clue",
+                () =>
+                  createClue(token, detail.id, {
+                    source: detail.access_role,
+                    content,
+                    source_type: clueSourceType,
+                    raw_record_reference: nullable(clueRawReference),
+                    occurred_at: toIsoOrNull(clueOccurredAt),
+                    location_text: location,
+                    location_precision: clueLocationPrecision || null,
+                    next_action: nullable(clueNextAction),
+                    attachment_ids: linkedAttachmentIds,
+                  }),
+                "线索已提交并进入人工审核",
               ).then((succeeded) => {
                 if (succeeded) {
-                  setClueContent('')
-                  setClueLocation('')
-                  setClueOccurredAt('')
-                  setClueSourceType('manual_report')
-                  setClueRawReference('')
-                  setClueLocationPrecision('')
-                  setClueNextAction('')
-                  setLinkedAttachmentIds([])
+                  setClueContent("");
+                  setClueLocation("");
+                  setClueOccurredAt("");
+                  setClueSourceType("manual_report");
+                  setClueRawReference("");
+                  setClueLocationPrecision("");
+                  setClueNextAction("");
+                  setLinkedAttachmentIds([]);
                 }
-              })
+              });
             }}
           >
-            <Field label="线索内容" required><TextArea value={clueContent} maxLength={4000} onChange={(event) => setClueContent(event.target.value)} rows={3} fullWidth required /></Field>
+            <Field label="线索内容" required>
+              <TextArea
+                value={clueContent}
+                maxLength={4000}
+                onChange={(event) => setClueContent(event.target.value)}
+                rows={3}
+                fullWidth
+                required
+              />
+            </Field>
             <div className="space-y-3">
-              <Field label="来源类型"><select className="min-h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm" value={clueSourceType} onChange={(event) => setClueSourceType(event.target.value as PublicClueSourceType)}><option value="manual_report">人工上报</option><option value="field_report">现场反馈</option></select></Field>
-              <Field label="发生时间"><Input type="datetime-local" value={clueOccurredAt} onChange={(event) => setClueOccurredAt(event.target.value)} fullWidth /></Field>
-              <Field label="地点"><Input value={clueLocation} onChange={(event) => setClueLocation(event.target.value)} fullWidth /></Field>
-              <Field label="地点精度"><select className="min-h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm" value={clueLocationPrecision} onChange={(event) => setClueLocationPrecision(event.target.value as LocationPrecision | '')}><option value="">未提供</option><option value="exact">精确</option><option value="approximate">约略</option><option value="unknown">未知</option></select></Field>
-              <Field label="受控原始记录引用"><Input value={clueRawReference} maxLength={500} onChange={(event) => setClueRawReference(event.target.value)} fullWidth /></Field>
-              <Field label="下一步动作"><Input value={clueNextAction} maxLength={500} onChange={(event) => setClueNextAction(event.target.value)} fullWidth /></Field>
-              {detail.attachments.some((attachment) => attachment.is_own_submission) && <Field label="关联本人附件"><select multiple className="min-h-20 w-full rounded-md border border-slate-300 bg-white px-3 text-sm" value={linkedAttachmentIds} onChange={(event) => setLinkedAttachmentIds(Array.from(event.target.selectedOptions, (option) => option.value))}>{detail.attachments.filter((attachment) => attachment.is_own_submission).map((attachment) => <option key={attachment.id} value={attachment.id}>{attachment.original_filename}</option>)}</select></Field>}
-              <Button type="submit" variant="primary" fullWidth isDisabled={busy === 'clue'}><Send size={16} />提交线索</Button>
+              <Field label="来源类型">
+                <select
+                  className="min-h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm"
+                  value={clueSourceType}
+                  onChange={(event) =>
+                    setClueSourceType(
+                      event.target.value as PublicClueSourceType,
+                    )
+                  }
+                >
+                  <option value="manual_report">人工上报</option>
+                  <option value="field_report">现场反馈</option>
+                </select>
+              </Field>
+              <Field label="发生时间">
+                <Input
+                  type="datetime-local"
+                  value={clueOccurredAt}
+                  onChange={(event) => setClueOccurredAt(event.target.value)}
+                  fullWidth
+                />
+              </Field>
+              <Field label="地点">
+                <Input
+                  value={clueLocation}
+                  onChange={(event) => setClueLocation(event.target.value)}
+                  fullWidth
+                />
+              </Field>
+              <Field label="地点精度">
+                <select
+                  className="min-h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm"
+                  value={clueLocationPrecision}
+                  onChange={(event) =>
+                    setClueLocationPrecision(
+                      event.target.value as LocationPrecision | "",
+                    )
+                  }
+                >
+                  <option value="">未提供</option>
+                  <option value="exact">精确</option>
+                  <option value="approximate">约略</option>
+                  <option value="unknown">未知</option>
+                </select>
+              </Field>
+              <Field label="受控原始记录引用">
+                <Input
+                  value={clueRawReference}
+                  maxLength={500}
+                  onChange={(event) => setClueRawReference(event.target.value)}
+                  fullWidth
+                />
+              </Field>
+              <Field label="下一步动作">
+                <Input
+                  value={clueNextAction}
+                  maxLength={500}
+                  onChange={(event) => setClueNextAction(event.target.value)}
+                  fullWidth
+                />
+              </Field>
+              {detail.attachments.some(
+                (attachment) => attachment.is_own_submission,
+              ) && (
+                <Field label="关联本人附件">
+                  <select
+                    multiple
+                    className="min-h-20 w-full rounded-md border border-slate-300 bg-white px-3 text-sm"
+                    value={linkedAttachmentIds}
+                    onChange={(event) =>
+                      setLinkedAttachmentIds(
+                        Array.from(
+                          event.target.selectedOptions,
+                          (option) => option.value,
+                        ),
+                      )
+                    }
+                  >
+                    {detail.attachments
+                      .filter((attachment) => attachment.is_own_submission)
+                      .map((attachment) => (
+                        <option key={attachment.id} value={attachment.id}>
+                          {attachment.original_filename}
+                        </option>
+                      ))}
+                  </select>
+                </Field>
+              )}
+              <Button
+                type="submit"
+                variant="primary"
+                fullWidth
+                isDisabled={busy === "clue"}
+              >
+                <Send size={16} />
+                提交线索
+              </Button>
             </div>
           </form>
         )}
       </section>
 
-      <section className={`grid gap-6 border-t border-slate-200 bg-slate-50 px-5 py-5 sm:px-6 ${canSubmitPlace ? 'lg:grid-cols-2' : ''}`} aria-label="补充地点和图片">
-          {canSubmitPlace && <div>
+      <section
+        className={`grid gap-6 border-t border-slate-200 bg-slate-50 px-5 py-5 sm:px-6 ${canSubmitPlace ? "lg:grid-cols-2" : ""}`}
+        aria-label="补充地点和图片"
+      >
+        {canSubmitPlace && (
+          <div>
             <div className="flex items-center justify-between gap-3">
-              <h3 className="m-0 text-base font-bold text-slate-950">补充地点</h3>
+              <h3 className="m-0 text-base font-bold text-slate-950">
+                补充地点
+              </h3>
               <span className="text-xs text-slate-500">提交后待人工审核</span>
             </div>
             <div className="mt-3 divide-y divide-slate-200 rounded-md border border-slate-200 bg-white">
-              {detail.places.length === 0 ? <p className="m-0 px-3 py-3 text-xs text-slate-500">暂无可查看的补充地点</p> : detail.places.map((item) => (
-                <div key={item.id} className="px-3 py-3 text-sm">
-                  <strong className="text-slate-900">{item.name}</strong><span className="ml-2 text-xs text-slate-500">{item.review_status === 'pending_review' ? '待人工审核' : item.review_status}</span>
-                  <p className="m-0 mt-1 text-xs text-slate-600">{item.address}</p>
+              {detail.places.length === 0 ? (
+                <p className="m-0 px-3 py-3 text-xs text-slate-500">
+                  暂无可查看的补充地点
+                </p>
+              ) : (
+                detail.places.map((item) => (
+                  <div key={item.id} className="px-3 py-3 text-sm">
+                    <strong className="text-slate-900">{item.name}</strong>
+                    <span className="ml-2 text-xs text-slate-500">
+                      {item.review_status === "pending_review"
+                        ? "待人工审核"
+                        : item.review_status}
+                    </span>
+                    <p className="m-0 mt-1 text-xs text-slate-600">
+                      {item.address}
+                    </p>
+                  </div>
+                ))
+              )}
+            </div>
+            {detail.status !== "closed" && (
+              <form
+                className="mt-3 grid gap-3"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  if (
+                    !token ||
+                    !place.name.trim() ||
+                    !place.address.trim() ||
+                    !place.place_type
+                  ) {
+                    setError("请填写地点名称、类型和文字地址后再提交。");
+                    return;
+                  }
+                  if (
+                    (place.longitude === null) !==
+                    (place.latitude === null)
+                  ) {
+                    setError("经度和纬度必须同时填写或同时留空。");
+                    return;
+                  }
+                  void run(
+                    "place",
+                    () =>
+                      createCasePlace(token, detail.id, {
+                        ...place,
+                        name: place.name.trim(),
+                        address: place.address.trim(),
+                      }),
+                    "地点已提交，正在等待人工审核",
+                  ).then((ok) => {
+                    if (ok)
+                      setPlace({
+                        name: "",
+                        place_type: placeTypes[0] ?? "",
+                        address: "",
+                        longitude: null,
+                        latitude: null,
+                        visibility: "confirmed",
+                      });
+                  });
+                }}
+              >
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <Field label="地点名称" required>
+                    <Input
+                      value={place.name}
+                      maxLength={120}
+                      onChange={(event) =>
+                        setPlace({ ...place, name: event.target.value })
+                      }
+                      fullWidth
+                      required
+                    />
+                  </Field>
+                  <Field label="类型">
+                    <select
+                      className="min-h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm"
+                      value={place.place_type}
+                      onChange={(event) =>
+                        setPlace({
+                          ...place,
+                          place_type: event.target.value as PlaceType,
+                        })
+                      }
+                    >
+                      {placeTypes.map((type) => (
+                        <option key={type} value={type}>
+                          {placeTypeLabels[type] ?? type}
+                        </option>
+                      ))}
+                    </select>
+                  </Field>
                 </div>
-              ))}
-            </div>
-            {detail.status !== 'closed' && <form className="mt-3 grid gap-3" onSubmit={(event) => {
-              event.preventDefault()
-              if (!token || !place.name.trim() || !place.address.trim() || !place.place_type) { setError('请填写地点名称、类型和文字地址后再提交。'); return }
-              if ((place.longitude === null) !== (place.latitude === null)) { setError('经度和纬度必须同时填写或同时留空。'); return }
-              void run('place', () => createCasePlace(token, detail.id, { ...place, name: place.name.trim(), address: place.address.trim() }), '地点已提交，正在等待人工审核').then((ok) => {
-                if (ok) setPlace({ name: '', place_type: placeTypes[0] ?? '', address: '', longitude: null, latitude: null, visibility: 'confirmed' })
-              })
-            }}>
-              <div className="grid gap-3 sm:grid-cols-2">
-                <Field label="地点名称" required><Input value={place.name} maxLength={120} onChange={(event) => setPlace({ ...place, name: event.target.value })} fullWidth required /></Field>
-                <Field label="类型"><select className="min-h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm" value={place.place_type} onChange={(event) => setPlace({ ...place, place_type: event.target.value as PlaceType })}>{placeTypes.map((type) => <option key={type} value={type}>{placeTypeLabels[type] ?? type}</option>)}</select></Field>
-              </div>
-              <Field label="文字地址" required><Input value={place.address} maxLength={500} onChange={(event) => setPlace({ ...place, address: event.target.value })} fullWidth required /></Field>
-              <div className="grid gap-3 sm:grid-cols-3">
-                <Field label="经度（可选）"><Input type="number" min={-180} max={180} value={place.longitude ?? ''} onChange={(event) => setPlace({ ...place, longitude: event.target.value === '' ? null : Number(event.target.value) })} fullWidth /></Field>
-                <Field label="纬度（可选）"><Input type="number" min={-90} max={90} value={place.latitude ?? ''} onChange={(event) => setPlace({ ...place, latitude: event.target.value === '' ? null : Number(event.target.value) })} fullWidth /></Field>
-                <Field label="可见级别"><select className="min-h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm" value={place.visibility} onChange={(event) => setPlace({ ...place, visibility: event.target.value as PlaceVisibility })}><option value="confirmed">已确认范围</option><option value="internal">仅内部</option><option value="public">公开范围</option></select></Field>
-              </div>
-              <Button type="submit" variant="secondary" isDisabled={busy === 'place'}>提交地点</Button>
-            </form>}
-          </div>}
-          <div>
-            <div className="flex items-center justify-between gap-3"><h3 className="m-0 text-base font-bold text-slate-950">补充图片</h3><span className="text-xs text-slate-500">仅 JPEG/PNG，最大 {formatBytes(resourceConfiguration.attachment_max_image_bytes)}</span></div>
-            <div className="mt-3 divide-y divide-slate-200 rounded-md border border-slate-200 bg-white">
-              {detail.attachments.length === 0 ? <p className="m-0 px-3 py-3 text-xs text-slate-500">暂无可查看的图片</p> : detail.attachments.map((item) => <div key={item.id} className="flex items-center justify-between gap-2 px-3 py-3 text-sm"><span className="truncate text-slate-800">{item.original_filename}</span><span className="shrink-0 text-xs text-slate-500">{item.review_status === 'pending_review' ? '待人工审核' : item.review_status}</span></div>)}
-            </div>
-            {detail.status !== 'closed' && <form className="mt-3 grid gap-3" onSubmit={(event) => {
-              event.preventDefault()
-              if (!token || !attachment) { setError('请选择一张图片后再提交。'); return }
-              void run('attachment', () => uploadCaseAttachment(token, detail.id, attachment, resourceConfiguration.attachment_max_image_bytes), '图片已提交，正在等待人工审核').then((ok) => { if (ok) setAttachment(null) })
-            }}>
-              <input key={attachment ? `${attachment.name}-${attachment.lastModified}` : 'no-file'} type="file" accept="image/jpeg,image/png" onChange={(event) => setAttachment(event.target.files?.[0] ?? null)} className="block w-full text-sm text-slate-700" />
-              <Button type="submit" variant="secondary" isDisabled={busy === 'attachment'}>上传图片</Button>
-              <p className="m-0 text-xs leading-5 text-slate-500">上传会由服务端重新编码并移除非必要的 EXIF/GPS 元数据；失败时不会显示为上传成功。</p>
-            </form>}
+                <Field label="文字地址" required>
+                  <Input
+                    value={place.address}
+                    maxLength={500}
+                    onChange={(event) =>
+                      setPlace({ ...place, address: event.target.value })
+                    }
+                    fullWidth
+                    required
+                  />
+                </Field>
+                <div className="grid gap-3 sm:grid-cols-3">
+                  <Field label="经度（可选）">
+                    <Input
+                      type="number"
+                      min={-180}
+                      max={180}
+                      value={place.longitude ?? ""}
+                      onChange={(event) =>
+                        setPlace({
+                          ...place,
+                          longitude:
+                            event.target.value === ""
+                              ? null
+                              : Number(event.target.value),
+                        })
+                      }
+                      fullWidth
+                    />
+                  </Field>
+                  <Field label="纬度（可选）">
+                    <Input
+                      type="number"
+                      min={-90}
+                      max={90}
+                      value={place.latitude ?? ""}
+                      onChange={(event) =>
+                        setPlace({
+                          ...place,
+                          latitude:
+                            event.target.value === ""
+                              ? null
+                              : Number(event.target.value),
+                        })
+                      }
+                      fullWidth
+                    />
+                  </Field>
+                  <Field label="可见级别">
+                    <select
+                      className="min-h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm"
+                      value={place.visibility}
+                      onChange={(event) =>
+                        setPlace({
+                          ...place,
+                          visibility: event.target.value as PlaceVisibility,
+                        })
+                      }
+                    >
+                      <option value="confirmed">已确认范围</option>
+                      <option value="internal">仅内部</option>
+                      <option value="public">公开范围</option>
+                    </select>
+                  </Field>
+                </div>
+                <Button
+                  type="submit"
+                  variant="secondary"
+                  isDisabled={busy === "place"}
+                >
+                  提交地点
+                </Button>
+              </form>
+            )}
           </div>
+        )}
+        <div>
+          <div className="flex items-center justify-between gap-3">
+            <h3 className="m-0 text-base font-bold text-slate-950">补充图片</h3>
+            <span className="text-xs text-slate-500">
+              仅 JPEG/PNG，最大{" "}
+              {formatBytes(resourceConfiguration.attachment_max_image_bytes)}
+            </span>
+          </div>
+          <div className="mt-3 divide-y divide-slate-200 rounded-md border border-slate-200 bg-white">
+            {detail.attachments.length === 0 ? (
+              <p className="m-0 px-3 py-3 text-xs text-slate-500">
+                暂无可查看的图片
+              </p>
+            ) : (
+              detail.attachments.map((item) => (
+                <div
+                  key={item.id}
+                  className="flex items-center justify-between gap-2 px-3 py-3 text-sm"
+                >
+                  <span className="truncate text-slate-800">
+                    {item.original_filename}
+                  </span>
+                  <span className="shrink-0 text-xs text-slate-500">
+                    {item.review_status === "pending_review"
+                      ? "待人工审核"
+                      : item.review_status}
+                  </span>
+                </div>
+              ))
+            )}
+          </div>
+          {detail.status !== "closed" && (
+            <form
+              className="mt-3 grid gap-3"
+              onSubmit={(event) => {
+                event.preventDefault();
+                if (!token || !attachment) {
+                  setError("请选择一张图片后再提交。");
+                  return;
+                }
+                void run(
+                  "attachment",
+                  () =>
+                    uploadCaseAttachment(
+                      token,
+                      detail.id,
+                      attachment,
+                      resourceConfiguration.attachment_max_image_bytes,
+                    ),
+                  "图片已提交，正在等待人工审核",
+                ).then((ok) => {
+                  if (ok) setAttachment(null);
+                });
+              }}
+            >
+              <input
+                key={
+                  attachment
+                    ? `${attachment.name}-${attachment.lastModified}`
+                    : "no-file"
+                }
+                type="file"
+                accept="image/jpeg,image/png"
+                onChange={(event) =>
+                  setAttachment(event.target.files?.[0] ?? null)
+                }
+                className="block w-full text-sm text-slate-700"
+              />
+              <Button
+                type="submit"
+                variant="secondary"
+                isDisabled={busy === "attachment"}
+              >
+                上传图片
+              </Button>
+              <p className="m-0 text-xs leading-5 text-slate-500">
+                上传会由服务端重新编码并移除非必要的 EXIF/GPS
+                元数据；失败时不会显示为上传成功。
+              </p>
+            </form>
+          )}
+        </div>
       </section>
     </div>
-  )
+  );
 }
 
 const taskStatusLabels: Record<string, string> = {
-  pending_claim: '待志愿者申请',
-  assigned: '待领取',
-  accepted: '已接受',
-  active: '进行中',
-  blocked: '受阻',
-  completed: '已完成',
-  cancelled: '已取消',
-}
-const emptyTask = (): CreateTaskPayload => ({ source_clue_id: '', volunteer_user_id: undefined, title: '', objective: '', area_text: '', latitude: null, longitude: null, due_at: '', background: '', risk_level: 'low', risk_notes: '', safety_briefing: '', expected_feedback: '' })
+  pending_claim: "待志愿者申请",
+  assigned: "待领取",
+  accepted: "已接受",
+  active: "进行中",
+  blocked: "受阻",
+  completed: "已完成",
+  cancelled: "已取消",
+};
+const emptyTask = (): CreateTaskPayload => ({
+  source_clue_id: "",
+  volunteer_user_id: undefined,
+  title: "",
+  objective: "",
+  area_text: "",
+  latitude: null,
+  longitude: null,
+  due_at: "",
+  background: "",
+  risk_level: "low",
+  risk_notes: "",
+  safety_briefing: "",
+  expected_feedback: "",
+});
 
-function TaskBoard({ detail, token }: { detail: CaseDetail; token: string | null }) {
-  const [tasks, setTasks] = useState<CaseTask[]>([])
-  const [members, setMembers] = useState<CaseMember[]>([])
-  const [draft, setDraft] = useState<CreateTaskPayload>(emptyTask)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState('')
-  const [notice, setNotice] = useState('')
-  const [busy, setBusy] = useState('')
-  const [feedback, setFeedback] = useState<Record<string, string>>({})
-  const isCommander = detail.access_role === 'commander'
+function TaskBoard({
+  detail,
+  token,
+}: {
+  detail: CaseDetail;
+  token: string | null;
+}) {
+  const [tasks, setTasks] = useState<CaseTask[]>([]);
+  const [members, setMembers] = useState<CaseMember[]>([]);
+  const [draft, setDraft] = useState<CreateTaskPayload>(emptyTask);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [notice, setNotice] = useState("");
+  const [busy, setBusy] = useState("");
+  const [feedback, setFeedback] = useState<Record<string, string>>({});
+  const isCommander = detail.access_role === "commander";
   const load = useCallback(async () => {
-    if (!token) return
-    setLoading(true); setError('')
+    if (!token) return;
+    setLoading(true);
+    setError("");
     try {
-      const [page, nextMembers] = await Promise.all([listCaseTasks(token, detail.id), isCommander ? listCaseMembers(token, detail.id) : Promise.resolve([])])
-      setTasks(page.items); setMembers(nextMembers)
-    } catch (cause) { setError(messageFrom(cause)) } finally { setLoading(false) }
-  }, [detail.id, isCommander, token])
-  useEffect(() => { setDraft(emptyTask()); void load() }, [detail.id, load])
-  const volunteers = members.filter((member) => member.case_role === 'volunteer')
-  const confirmedClues = detail.clues.filter((clue) => clue.status === 'confirmed')
-  const createsOpenTask = !draft.volunteer_user_id
-  async function changeStatus(taskId: string, status: 'accepted' | 'active' | 'blocked' | 'completed' | 'cancelled') {
-    if (!token) return
-    setBusy(taskId); setError('')
-    try { await updateTaskStatus(token, taskId, status); await load() } catch (cause) { setError(messageFrom(cause)) } finally { setBusy('') }
+      const [page, nextMembers] = await Promise.all([
+        listCaseTasks(token, detail.id),
+        isCommander ? listCaseMembers(token, detail.id) : Promise.resolve([]),
+      ]);
+      setTasks(page.items);
+      setMembers(nextMembers);
+    } catch (cause) {
+      setError(messageFrom(cause));
+    } finally {
+      setLoading(false);
+    }
+  }, [detail.id, isCommander, token]);
+  useEffect(() => {
+    setDraft(emptyTask());
+    void load();
+  }, [detail.id, load]);
+  const volunteers = members.filter(
+    (member) => member.case_role === "volunteer",
+  );
+  const confirmedClues = detail.clues.filter(
+    (clue) => clue.status === "confirmed",
+  );
+  const createsOpenTask = !draft.volunteer_user_id;
+  async function changeStatus(
+    taskId: string,
+    status: "accepted" | "active" | "blocked" | "completed" | "cancelled",
+  ) {
+    if (!token) return;
+    setBusy(taskId);
+    setError("");
+    try {
+      await updateTaskStatus(token, taskId, status);
+      await load();
+    } catch (cause) {
+      setError(messageFrom(cause));
+    } finally {
+      setBusy("");
+    }
   }
   async function applyToTask(taskId: string) {
-    if (!token) return
-    setBusy(taskId); setError(''); setNotice('')
-    try { await applyForTask(token, taskId); setNotice('申请已提交，等待指挥审核。'); await load() } catch (cause) { setError(messageFrom(cause)) } finally { setBusy('') }
+    if (!token) return;
+    setBusy(taskId);
+    setError("");
+    setNotice("");
+    try {
+      await applyForTask(token, taskId);
+      setNotice("申请已提交，等待指挥审核。");
+      await load();
+    } catch (cause) {
+      setError(messageFrom(cause));
+    } finally {
+      setBusy("");
+    }
   }
   async function sendFeedback(taskId: string) {
-    const content = feedback[taskId]?.trim()
-    if (!token || !content) return
-    setBusy(`feedback-${taskId}`); setError('')
-    try { await submitTaskFeedback(token, taskId, { content, occurred_at: null, location_text: null, location_precision: null }); setFeedback((current) => ({ ...current, [taskId]: '' })) } catch (cause) { setError(messageFrom(cause)) } finally { setBusy('') }
+    const content = feedback[taskId]?.trim();
+    if (!token || !content) return;
+    setBusy(`feedback-${taskId}`);
+    setError("");
+    try {
+      await submitTaskFeedback(token, taskId, {
+        content,
+        occurred_at: null,
+        location_text: null,
+        location_precision: null,
+      });
+      setFeedback((current) => ({ ...current, [taskId]: "" }));
+    } catch (cause) {
+      setError(messageFrom(cause));
+    } finally {
+      setBusy("");
+    }
   }
   return (
-    <section className="border-b border-slate-200 px-5 py-5 sm:px-6" aria-label="任务看板">
-      <div className="flex items-start justify-between gap-3"><div><h3 className="m-0 text-base font-bold text-slate-950">任务看板</h3><p className="mb-0 mt-1 text-xs leading-5 text-slate-600">任务只由指挥人工创建和分配；状态、人员与失败结果均以服务端返回为准。</p></div><Button size="sm" variant="ghost" isDisabled={loading} onPress={() => void load()}><RefreshCw size={16} />刷新任务</Button></div>
-      {error && <div className="mt-3"><Message tone="error">{error}</Message></div>}
-      {notice && <div className="mt-3"><Message tone="success">{notice}</Message></div>}
-      {loading ? <p className="mb-0 mt-3 text-sm text-slate-500">正在加载任务…</p> : tasks.length === 0 ? <p className="mb-0 mt-3 text-sm text-slate-500">当前没有你可查看的任务。</p> : <div className="mt-3 grid gap-3 lg:grid-cols-2">{tasks.map((task) => <article key={task.id} className="rounded-md border border-slate-200 bg-white p-3"><div className="flex flex-wrap items-center gap-2"><Chip size="sm" variant="soft"><Chip.Label>{taskStatusLabels[task.status] ?? task.status}</Chip.Label></Chip><Chip size="sm" variant="soft"><Chip.Label>{task.risk_level} 风险</Chip.Label></Chip></div><h4 className="mb-0 mt-3 text-sm font-semibold text-slate-950">{task.title}</h4><p className="mb-0 mt-1 text-sm text-slate-700">{task.objective}</p><p className="mb-0 mt-2 text-xs text-slate-500">区域：{task.area_text} · 截止：{formatDate(task.due_at) ?? '待补充'}</p><p className="mb-0 mt-1 text-xs text-slate-600">安全提示：{task.safety_briefing}</p>{detail.access_role === 'volunteer' && <><div className="mt-3 flex flex-wrap gap-2">{task.status === 'pending_claim' && <Button size="sm" variant="secondary" isDisabled={busy === task.id} onPress={() => void applyToTask(task.id)}>申请协作</Button>}{task.status === 'assigned' && <Button size="sm" variant="secondary" isDisabled={busy === task.id} onPress={() => void changeStatus(task.id, 'accepted')}>接受</Button>}{task.status === 'accepted' && <Button size="sm" variant="secondary" isDisabled={busy === task.id} onPress={() => void changeStatus(task.id, 'active')}>开始执行</Button>}{task.status === 'active' && <><Button size="sm" variant="secondary" isDisabled={busy === task.id} onPress={() => void changeStatus(task.id, 'blocked')}>标记受阻</Button><Button size="sm" variant="primary" isDisabled={busy === task.id} onPress={() => void changeStatus(task.id, 'completed')}>完成</Button></>}{task.status === 'blocked' && <Button size="sm" variant="secondary" isDisabled={busy === task.id} onPress={() => void changeStatus(task.id, 'active')}>继续执行</Button>}</div>{task.status === 'active' && <div className="mt-3"><TextArea aria-label={`${task.title} 任务反馈`} value={feedback[task.id] ?? ''} maxLength={4000} rows={2} placeholder="提交现场反馈；将进入人工审核，不会直接成为确认事实" onChange={(event) => setFeedback((current) => ({ ...current, [task.id]: event.target.value }))} fullWidth /><div className="mt-2 flex justify-end"><Button size="sm" variant="secondary" isDisabled={!feedback[task.id]?.trim() || busy === `feedback-${task.id}`} onPress={() => void sendFeedback(task.id)}>提交待审核反馈</Button></div></div>}</>}{isCommander && !['completed', 'cancelled'].includes(task.status) && <div className="mt-3"><Button size="sm" variant="ghost" isDisabled={busy === task.id} onPress={() => void changeStatus(task.id, 'cancelled')}>取消任务</Button></div>}</article>)}</div>}
-      {isCommander && detail.status !== 'closed' && <form className="mt-5 grid gap-3 border-t border-slate-200 pt-5 lg:grid-cols-2" onSubmit={(event) => { event.preventDefault(); if (!token) return; setBusy('create'); setError(''); createCaseTask(token, detail.id, draft).then(async () => { setDraft(emptyTask()); await load() }).catch((cause) => setError(messageFrom(cause))).finally(() => setBusy('')) }}><h4 className="m-0 text-sm font-semibold text-slate-950 lg:col-span-2">{createsOpenTask ? '创建开放任务' : '人工创建并分配任务'}</h4><Field label="关联的已确认线索" required><select required className="min-h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm" value={draft.source_clue_id} onChange={(event) => setDraft({ ...draft, source_clue_id: event.target.value })}><option value="">请选择</option>{confirmedClues.map((clue) => <option key={clue.id} value={clue.id}>{clue.content.slice(0, 80)}</option>)}</select></Field><Field label="志愿者"><select className="min-h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm" value={draft.volunteer_user_id ?? ''} onChange={(event) => setDraft({ ...draft, volunteer_user_id: event.target.value || undefined })}><option value="">开放任务：等待志愿者申请</option>{volunteers.map((member) => <option key={member.user_id} value={member.user_id}>{member.display_name}</option>)}</select></Field><Field label="任务标题" required><Input required value={draft.title} maxLength={200} onChange={(event) => setDraft({ ...draft, title: event.target.value })} fullWidth /></Field><Field label="任务区域" required><Input required value={draft.area_text} maxLength={500} onChange={(event) => setDraft({ ...draft, area_text: event.target.value })} fullWidth /></Field><Field label="目标" required><TextArea required value={draft.objective} maxLength={4000} rows={2} onChange={(event) => setDraft({ ...draft, objective: event.target.value })} fullWidth /></Field><Field label="截止时间" required><Input required type="datetime-local" value={toDateTimeLocal(draft.due_at)} onChange={(event) => setDraft({ ...draft, due_at: event.target.value ? new Date(event.target.value).toISOString() : '' })} fullWidth /></Field><Field label="背景说明" required><TextArea required value={draft.background} maxLength={10000} rows={2} onChange={(event) => setDraft({ ...draft, background: event.target.value })} fullWidth /></Field><Field label="风险说明与安全提示" required><TextArea required value={draft.risk_notes} maxLength={4000} rows={2} onChange={(event) => setDraft({ ...draft, risk_notes: event.target.value, safety_briefing: draft.safety_briefing || event.target.value })} fullWidth /></Field><Field label="预期反馈" required><TextArea required value={draft.expected_feedback} maxLength={4000} rows={2} onChange={(event) => setDraft({ ...draft, expected_feedback: event.target.value })} fullWidth /></Field><div className="flex items-end"><Button type="submit" size="sm" variant="primary" isDisabled={busy === 'create' || confirmedClues.length === 0}>{createsOpenTask ? '创建并等待志愿者申请' : '创建并分配'}</Button></div></form>}
+    <section
+      className="border-b border-slate-200 px-5 py-5 sm:px-6"
+      aria-label="任务看板"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="m-0 text-base font-bold text-slate-950">任务看板</h3>
+          <p className="mb-0 mt-1 text-xs leading-5 text-slate-600">
+            任务只由指挥人工创建和分配；状态、人员与失败结果均以服务端返回为准。
+          </p>
+        </div>
+        <Button
+          size="sm"
+          variant="ghost"
+          isDisabled={loading}
+          onPress={() => void load()}
+        >
+          <RefreshCw size={16} />
+          刷新任务
+        </Button>
+      </div>
+      {error && (
+        <div className="mt-3">
+          <Message tone="error">{error}</Message>
+        </div>
+      )}
+      {notice && (
+        <div className="mt-3">
+          <Message tone="success">{notice}</Message>
+        </div>
+      )}
+      {loading ? (
+        <p className="mb-0 mt-3 text-sm text-slate-500">正在加载任务…</p>
+      ) : tasks.length === 0 ? (
+        <p className="mb-0 mt-3 text-sm text-slate-500">
+          当前没有你可查看的任务。
+        </p>
+      ) : (
+        <div className="mt-3 grid gap-3 lg:grid-cols-2">
+          {tasks.map((task) => (
+            <article
+              key={task.id}
+              className="rounded-md border border-slate-200 bg-white p-3"
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <Chip size="sm" variant="soft">
+                  <Chip.Label>
+                    {taskStatusLabels[task.status] ?? task.status}
+                  </Chip.Label>
+                </Chip>
+                <Chip size="sm" variant="soft">
+                  <Chip.Label>{task.risk_level} 风险</Chip.Label>
+                </Chip>
+              </div>
+              <h4 className="mb-0 mt-3 text-sm font-semibold text-slate-950">
+                {task.title}
+              </h4>
+              <p className="mb-0 mt-1 text-sm text-slate-700">
+                {task.objective}
+              </p>
+              <p className="mb-0 mt-2 text-xs text-slate-500">
+                区域：{task.area_text} · 截止：
+                {formatDate(task.due_at) ?? "待补充"}
+              </p>
+              <p className="mb-0 mt-1 text-xs text-slate-600">
+                安全提示：{task.safety_briefing}
+              </p>
+              {detail.access_role === "volunteer" && (
+                <>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {task.status === "pending_claim" && (
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        isDisabled={busy === task.id}
+                        onPress={() => void applyToTask(task.id)}
+                      >
+                        申请协作
+                      </Button>
+                    )}
+                    {task.status === "assigned" && (
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        isDisabled={busy === task.id}
+                        onPress={() => void changeStatus(task.id, "accepted")}
+                      >
+                        接受
+                      </Button>
+                    )}
+                    {task.status === "accepted" && (
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        isDisabled={busy === task.id}
+                        onPress={() => void changeStatus(task.id, "active")}
+                      >
+                        开始执行
+                      </Button>
+                    )}
+                    {task.status === "active" && (
+                      <>
+                        <Button
+                          size="sm"
+                          variant="secondary"
+                          isDisabled={busy === task.id}
+                          onPress={() => void changeStatus(task.id, "blocked")}
+                        >
+                          标记受阻
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="primary"
+                          isDisabled={busy === task.id}
+                          onPress={() =>
+                            void changeStatus(task.id, "completed")
+                          }
+                        >
+                          完成
+                        </Button>
+                      </>
+                    )}
+                    {task.status === "blocked" && (
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        isDisabled={busy === task.id}
+                        onPress={() => void changeStatus(task.id, "active")}
+                      >
+                        继续执行
+                      </Button>
+                    )}
+                  </div>
+                  {task.status === "active" && (
+                    <div className="mt-3">
+                      <TextArea
+                        aria-label={`${task.title} 任务反馈`}
+                        value={feedback[task.id] ?? ""}
+                        maxLength={4000}
+                        rows={2}
+                        placeholder="提交现场反馈；将进入人工审核，不会直接成为确认事实"
+                        onChange={(event) =>
+                          setFeedback((current) => ({
+                            ...current,
+                            [task.id]: event.target.value,
+                          }))
+                        }
+                        fullWidth
+                      />
+                      <div className="mt-2 flex justify-end">
+                        <Button
+                          size="sm"
+                          variant="secondary"
+                          isDisabled={
+                            !feedback[task.id]?.trim() ||
+                            busy === `feedback-${task.id}`
+                          }
+                          onPress={() => void sendFeedback(task.id)}
+                        >
+                          提交待审核反馈
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </>
+              )}
+              {isCommander &&
+                !["completed", "cancelled"].includes(task.status) && (
+                  <div className="mt-3">
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      isDisabled={busy === task.id}
+                      onPress={() => void changeStatus(task.id, "cancelled")}
+                    >
+                      取消任务
+                    </Button>
+                  </div>
+                )}
+            </article>
+          ))}
+        </div>
+      )}
+      {isCommander && detail.status !== "closed" && (
+        <form
+          className="mt-5 grid gap-3 border-t border-slate-200 pt-5 lg:grid-cols-2"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (!token) return;
+            setBusy("create");
+            setError("");
+            createCaseTask(token, detail.id, draft)
+              .then(async () => {
+                setDraft(emptyTask());
+                await load();
+              })
+              .catch((cause) => setError(messageFrom(cause)))
+              .finally(() => setBusy(""));
+          }}
+        >
+          <h4 className="m-0 text-sm font-semibold text-slate-950 lg:col-span-2">
+            {createsOpenTask ? "创建开放任务" : "人工创建并分配任务"}
+          </h4>
+          <Field label="关联的已确认线索" required>
+            <select
+              required
+              className="min-h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm"
+              value={draft.source_clue_id}
+              onChange={(event) =>
+                setDraft({ ...draft, source_clue_id: event.target.value })
+              }
+            >
+              <option value="">请选择</option>
+              {confirmedClues.map((clue) => (
+                <option key={clue.id} value={clue.id}>
+                  {clue.content.slice(0, 80)}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="志愿者">
+            <select
+              className="min-h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm"
+              value={draft.volunteer_user_id ?? ""}
+              onChange={(event) =>
+                setDraft({
+                  ...draft,
+                  volunteer_user_id: event.target.value || undefined,
+                })
+              }
+            >
+              <option value="">开放任务：等待志愿者申请</option>
+              {volunteers.map((member) => (
+                <option key={member.user_id} value={member.user_id}>
+                  {member.display_name}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="任务标题" required>
+            <Input
+              required
+              value={draft.title}
+              maxLength={200}
+              onChange={(event) =>
+                setDraft({ ...draft, title: event.target.value })
+              }
+              fullWidth
+            />
+          </Field>
+          <Field label="任务区域" required>
+            <Input
+              required
+              value={draft.area_text}
+              maxLength={500}
+              onChange={(event) =>
+                setDraft({ ...draft, area_text: event.target.value })
+              }
+              fullWidth
+            />
+          </Field>
+          <Field label="目标" required>
+            <TextArea
+              required
+              value={draft.objective}
+              maxLength={4000}
+              rows={2}
+              onChange={(event) =>
+                setDraft({ ...draft, objective: event.target.value })
+              }
+              fullWidth
+            />
+          </Field>
+          <Field label="截止时间" required>
+            <Input
+              required
+              type="datetime-local"
+              value={toDateTimeLocal(draft.due_at)}
+              onChange={(event) =>
+                setDraft({
+                  ...draft,
+                  due_at: event.target.value
+                    ? new Date(event.target.value).toISOString()
+                    : "",
+                })
+              }
+              fullWidth
+            />
+          </Field>
+          <Field label="背景说明" required>
+            <TextArea
+              required
+              value={draft.background}
+              maxLength={10000}
+              rows={2}
+              onChange={(event) =>
+                setDraft({ ...draft, background: event.target.value })
+              }
+              fullWidth
+            />
+          </Field>
+          <Field label="风险说明与安全提示" required>
+            <TextArea
+              required
+              value={draft.risk_notes}
+              maxLength={4000}
+              rows={2}
+              onChange={(event) =>
+                setDraft({
+                  ...draft,
+                  risk_notes: event.target.value,
+                  safety_briefing: draft.safety_briefing || event.target.value,
+                })
+              }
+              fullWidth
+            />
+          </Field>
+          <Field label="预期反馈" required>
+            <TextArea
+              required
+              value={draft.expected_feedback}
+              maxLength={4000}
+              rows={2}
+              onChange={(event) =>
+                setDraft({ ...draft, expected_feedback: event.target.value })
+              }
+              fullWidth
+            />
+          </Field>
+          <div className="flex items-end">
+            <Button
+              type="submit"
+              size="sm"
+              variant="primary"
+              isDisabled={busy === "create" || confirmedClues.length === 0}
+            >
+              {createsOpenTask ? "创建并等待志愿者申请" : "创建并分配"}
+            </Button>
+          </div>
+        </form>
+      )}
     </section>
-  )
+  );
 }
 
-const mapObjectLabels: Record<CaseMapItem['object_type'], string> = {
-  last_seen: '最后出现信息',
-  place: '补充地点',
-  clue: '已确认线索',
-  task: '任务区域',
-}
+const mapObjectLabels: Record<CaseMapItem["object_type"], string> = {
+  last_seen: "最后出现信息",
+  place: "补充地点",
+  clue: "已确认线索",
+  task: "任务区域",
+};
 
-const precisionLabels: Record<CaseMapItem['location_precision'], string> = {
-  exact: '精确位置',
-  approximate: '模糊地点',
-  unknown: '仅文字地点',
-}
+const precisionLabels: Record<CaseMapItem["location_precision"], string> = {
+  exact: "精确位置",
+  approximate: "模糊地点",
+  unknown: "仅文字地点",
+};
 
-function CaseSituationPanel({ detail, token }: { detail: CaseDetail; token: string | null }) {
-  const [mapView, setMapView] = useState<CaseMapView | null>(null)
-  const [filter, setFilter] = useState<CaseMapItem['object_type'] | 'all'>('all')
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState('')
-  const requestVersion = useRef(0)
+function CaseSituationPanel({
+  detail,
+  token,
+}: {
+  detail: CaseDetail;
+  token: string | null;
+}) {
+  const [mapView, setMapView] = useState<CaseMapView | null>(null);
+  const [filter, setFilter] = useState<CaseMapItem["object_type"] | "all">(
+    "all",
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+  const requestVersion = useRef(0);
 
   const loadMapView = useCallback(async () => {
-    const version = requestVersion.current + 1
-    requestVersion.current = version
+    const version = requestVersion.current + 1;
+    requestVersion.current = version;
     if (!token) {
-      setMapView(null)
-      setError('')
-      setIsLoading(false)
-      return
+      setMapView(null);
+      setError("");
+      setIsLoading(false);
+      return;
     }
-    setIsLoading(true)
-    setError('')
+    setIsLoading(true);
+    setError("");
     try {
-      const response = await getCaseMapView(token, detail.id)
-      if (version !== requestVersion.current) return
-      setMapView(response)
+      const response = await getCaseMapView(token, detail.id);
+      if (version !== requestVersion.current) return;
+      setMapView(response);
     } catch (cause) {
-      if (version !== requestVersion.current) return
-      setMapView(null)
-      setError(messageFrom(cause))
+      if (version !== requestVersion.current) return;
+      setMapView(null);
+      setError(messageFrom(cause));
     } finally {
-      if (version === requestVersion.current) setIsLoading(false)
+      if (version === requestVersion.current) setIsLoading(false);
     }
-  }, [detail.id, token])
+  }, [detail.id, token]);
 
   useEffect(() => {
-    setFilter('all')
-    void loadMapView()
-    return () => { requestVersion.current += 1 }
-  }, [detail.id, loadMapView])
+    setFilter("all");
+    void loadMapView();
+    return () => {
+      requestVersion.current += 1;
+    };
+  }, [detail.id, loadMapView]);
 
-  const items = useMemo(() => (
-    mapView?.items.filter((item) => filter === 'all' || item.object_type === filter) ?? []
-  ), [filter, mapView])
-  const coordinateCount = items.filter((item) => item.longitude !== null && item.latitude !== null).length
+  const items = useMemo(
+    () =>
+      mapView?.items.filter(
+        (item) => filter === "all" || item.object_type === filter,
+      ) ?? [],
+    [filter, mapView],
+  );
+  const coordinateCount = items.filter(
+    (item) => item.longitude !== null && item.latitude !== null,
+  ).length;
 
   return (
-    <section className="border-b border-slate-200 bg-slate-50 px-5 py-5 sm:px-6" aria-label="地图态势与文字降级">
+    <section
+      className="border-b border-slate-200 bg-slate-50 px-5 py-5 sm:px-6"
+      aria-label="地图态势与文字降级"
+    >
       <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-start">
         <div>
-          <h3 className="m-0 text-base font-bold text-slate-950">地图态势与文字降级</h3>
-          <p className="mb-0 mt-1 max-w-3xl text-xs leading-5 text-slate-600">仅展示服务端按当前案件角色返回的地点、已确认线索和任务区域。当前首轮使用可审查的文字态势；地图供应商不可用时，以下地点、精度和状态仍可使用。</p>
+          <h3 className="m-0 text-base font-bold text-slate-950">
+            地图态势与文字降级
+          </h3>
+          <p className="mb-0 mt-1 max-w-3xl text-xs leading-5 text-slate-600">
+            仅展示服务端按当前案件角色返回的地点、已确认线索和任务区域。当前首轮使用可审查的文字态势；地图供应商不可用时，以下地点、精度和状态仍可使用。
+          </p>
         </div>
-        <Button size="sm" variant="ghost" isDisabled={!token || isLoading} onPress={() => void loadMapView()}>
-          <RefreshCw size={16} />刷新态势
+        <Button
+          size="sm"
+          variant="ghost"
+          isDisabled={!token || isLoading}
+          onPress={() => void loadMapView()}
+        >
+          <RefreshCw size={16} />
+          刷新态势
         </Button>
       </div>
 
       <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center">
-        <label className="text-sm font-medium text-slate-700" htmlFor="map-object-filter">对象类型</label>
-        <select id="map-object-filter" aria-label="态势对象筛选" className="min-h-10 rounded-md border border-slate-300 bg-white px-3 text-sm" value={filter} onChange={(event) => setFilter(event.target.value as CaseMapItem['object_type'] | 'all')}>
+        <label
+          className="text-sm font-medium text-slate-700"
+          htmlFor="map-object-filter"
+        >
+          对象类型
+        </label>
+        <select
+          id="map-object-filter"
+          aria-label="态势对象筛选"
+          className="min-h-10 rounded-md border border-slate-300 bg-white px-3 text-sm"
+          value={filter}
+          onChange={(event) =>
+            setFilter(event.target.value as CaseMapItem["object_type"] | "all")
+          }
+        >
           <option value="all">全部对象</option>
-          {Object.entries(mapObjectLabels).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+          {Object.entries(mapObjectLabels).map(([value, label]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
         </select>
-        {mapView && <span className="text-xs text-slate-500">{items.length} 项可见，其中 {coordinateCount} 项具备已授权坐标。</span>}
+        {mapView && (
+          <span className="text-xs text-slate-500">
+            {items.length} 项可见，其中 {coordinateCount} 项具备已授权坐标。
+          </span>
+        )}
       </div>
 
-      {isLoading && <p className="mb-0 mt-4 text-sm text-slate-500" role="status">正在加载角色化态势…</p>}
-      {error && <div className="mt-4"><Message tone="error">地图态势暂不可用：{error}。请使用案件资料、任务说明和人工联系路径继续工作。</Message></div>}
-      {!isLoading && !error && mapView && items.length === 0 && <p className="mb-0 mt-4 text-sm text-slate-500">当前筛选下没有可显示的态势对象。无坐标记录也会在此以文字形式出现。</p>}
+      {isLoading && (
+        <p className="mb-0 mt-4 text-sm text-slate-500" role="status">
+          正在加载角色化态势…
+        </p>
+      )}
+      {error && (
+        <div className="mt-4">
+          <Message tone="error">
+            地图态势暂不可用：{error}
+            。请使用案件资料、任务说明和人工联系路径继续工作。
+          </Message>
+        </div>
+      )}
+      {!isLoading && !error && mapView && items.length === 0 && (
+        <p className="mb-0 mt-4 text-sm text-slate-500">
+          当前筛选下没有可显示的态势对象。无坐标记录也会在此以文字形式出现。
+        </p>
+      )}
       {!isLoading && !error && items.length > 0 && (
         <div className="mt-4 grid gap-3 lg:grid-cols-2">
           {items.map((item) => (
-            <article key={item.id} className="rounded-md border border-slate-200 bg-white p-3">
+            <article
+              key={item.id}
+              className="rounded-md border border-slate-200 bg-white p-3"
+            >
               <div className="flex flex-wrap items-center gap-2">
-                <Chip size="sm" variant="soft"><Chip.Label>{mapObjectLabels[item.object_type]}</Chip.Label></Chip>
-                <Chip size="sm" variant="soft"><Chip.Label>{precisionLabels[item.location_precision]}</Chip.Label></Chip>
-                <Chip size="sm" variant="soft"><Chip.Label>{statusLabels[item.review_status] ?? item.review_status}</Chip.Label></Chip>
+                <Chip size="sm" variant="soft">
+                  <Chip.Label>{mapObjectLabels[item.object_type]}</Chip.Label>
+                </Chip>
+                <Chip size="sm" variant="soft">
+                  <Chip.Label>
+                    {precisionLabels[item.location_precision]}
+                  </Chip.Label>
+                </Chip>
+                <Chip size="sm" variant="soft">
+                  <Chip.Label>
+                    {statusLabels[item.review_status] ?? item.review_status}
+                  </Chip.Label>
+                </Chip>
               </div>
-              <h4 className="mb-0 mt-3 text-sm font-semibold text-slate-950">{item.display_name ?? mapObjectLabels[item.object_type]}</h4>
-              <p className="mb-0 mt-1 text-sm leading-6 text-slate-700">{item.location_text ?? '未提供文字地点；请联系指挥确认。'}</p>
+              <h4 className="mb-0 mt-3 text-sm font-semibold text-slate-950">
+                {item.display_name ?? mapObjectLabels[item.object_type]}
+              </h4>
+              <p className="mb-0 mt-1 text-sm leading-6 text-slate-700">
+                {item.location_text ?? "未提供文字地点；请联系指挥确认。"}
+              </p>
               <dl className="mb-0 mt-3 grid grid-cols-2 gap-x-3 gap-y-1 text-xs text-slate-500">
-                <div><dt className="inline">来源：</dt><dd className="inline">{item.source}</dd></div>
-                <div><dt className="inline">事件/上报：</dt><dd className="inline">{formatDate(item.occurred_at ?? item.reported_at) ?? '待补充'}</dd></div>
+                <div>
+                  <dt className="inline">来源：</dt>
+                  <dd className="inline">{item.source}</dd>
+                </div>
+                <div>
+                  <dt className="inline">事件/上报：</dt>
+                  <dd className="inline">
+                    {formatDate(item.occurred_at ?? item.reported_at) ??
+                      "待补充"}
+                  </dd>
+                </div>
               </dl>
             </article>
           ))}
         </div>
       )}
-
     </section>
-  )
+  );
 }
 
-function CommandIntakePanel({ token, onAccepted }: { token: string | null; onAccepted: () => Promise<void> }) {
-  const [items, setItems] = useState<import('../api/cases').CommandIntakeCase[]>([])
-  const [error, setError] = useState('')
-  const [busy, setBusy] = useState('')
-  const load = useCallback(async () => { if (!token) return; try { setError(''); setItems(await listCommandIntake(token)) } catch (cause) { setError(messageFrom(cause)) } }, [token])
-  useEffect(() => { void load() }, [load])
-  return <section className="mb-5 border border-slate-200 bg-white p-4" aria-label="待受理案件"><div className="flex items-center justify-between gap-3"><div><h2 className="m-0 text-base font-bold text-slate-950">待受理案件</h2><p className="mb-0 mt-1 text-xs text-slate-600">仅显示接案所需的最小信息；受理后才会获得完整指挥案情权限。</p></div><Button size="sm" variant="ghost" onPress={() => void load()}>刷新</Button></div>{error && <div className="mt-3"><Message tone="error">{error}</Message></div>}{items.length === 0 ? <p className="mb-0 mt-3 text-sm text-slate-500">当前没有待受理案件。</p> : <div className="mt-3 grid gap-3 sm:grid-cols-2">{items.map((item) => <article key={item.id} className="rounded-md border border-slate-200 p-3"><strong className="text-sm text-slate-950">{item.case_code}</strong><dl className="mb-0 mt-2 grid gap-1 text-xs text-slate-600"><div><dt className="inline font-medium text-slate-700">地区：</dt><dd className="inline">{item.area_hint ?? '待补充'}</dd></div><div><dt className="inline font-medium text-slate-700">走失时间：</dt><dd className="inline">{formatDate(item.last_seen_at)}</dd></div><div><dt className="inline font-medium text-slate-700">老人年龄：</dt><dd className="inline">{item.elder_age == null ? '待补充' : `${item.elder_age} 岁`}</dd></div></dl><Button className="mt-3" size="sm" variant="primary" isDisabled={busy === item.id} onPress={() => { if (!token) return; setBusy(item.id); acceptCommandCase(token, item.id).then(onAccepted).then(load).catch((cause) => setError(messageFrom(cause))).finally(() => setBusy('')) }}>受理案件</Button></article>)}</div>}</section>
+function CommandIntakePanel({
+  token,
+  onAccepted,
+}: {
+  token: string | null;
+  onAccepted: () => Promise<void>;
+}) {
+  const [items, setItems] = useState<
+    import("../api/cases").CommandIntakeCase[]
+  >([]);
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState("");
+  const load = useCallback(async () => {
+    if (!token) return;
+    try {
+      setError("");
+      setItems(await listCommandIntake(token));
+    } catch (cause) {
+      setError(messageFrom(cause));
+    }
+  }, [token]);
+  useEffect(() => {
+    void load();
+  }, [load]);
+  return (
+    <section
+      className="mb-5 border border-slate-200 bg-white p-4"
+      aria-label="待受理案件"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="m-0 text-base font-bold text-slate-950">待受理案件</h2>
+          <p className="mb-0 mt-1 text-xs text-slate-600">
+            仅显示接案所需的最小信息；受理后才会获得完整指挥案情权限。
+          </p>
+        </div>
+        <Button size="sm" variant="ghost" onPress={() => void load()}>
+          刷新
+        </Button>
+      </div>
+      {error && (
+        <div className="mt-3">
+          <Message tone="error">{error}</Message>
+        </div>
+      )}
+      {items.length === 0 ? (
+        <p className="mb-0 mt-3 text-sm text-slate-500">当前没有待受理案件。</p>
+      ) : (
+        <div className="mt-3 grid gap-3 sm:grid-cols-2">
+          {items.map((item) => (
+            <article
+              key={item.id}
+              className="rounded-md border border-slate-200 p-3"
+            >
+              <strong className="text-sm text-slate-950">
+                {item.case_code}
+              </strong>
+              <dl className="mb-0 mt-2 grid gap-1 text-xs text-slate-600">
+                <div>
+                  <dt className="inline font-medium text-slate-700">地区：</dt>
+                  <dd className="inline">{item.area_hint ?? "待补充"}</dd>
+                </div>
+                <div>
+                  <dt className="inline font-medium text-slate-700">
+                    走失时间：
+                  </dt>
+                  <dd className="inline">{formatDate(item.last_seen_at)}</dd>
+                </div>
+                <div>
+                  <dt className="inline font-medium text-slate-700">
+                    老人年龄：
+                  </dt>
+                  <dd className="inline">
+                    {item.elder_age == null ? "待补充" : `${item.elder_age} 岁`}
+                  </dd>
+                </div>
+              </dl>
+              <Button
+                className="mt-3"
+                size="sm"
+                variant="primary"
+                isDisabled={busy === item.id}
+                onPress={() => {
+                  if (!token) return;
+                  setBusy(item.id);
+                  acceptCommandCase(token, item.id)
+                    .then(onAccepted)
+                    .then(load)
+                    .catch((cause) => setError(messageFrom(cause)))
+                    .finally(() => setBusy(""));
+                }}
+              >
+                受理案件
+              </Button>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
 }
 
-function CaseCollaborationPanel({ detail, token }: { detail: CaseDetail; token: string | null }) {
-  const [publicProgress, setPublicProgress] = useState<CasePublicProgress | null>(null)
-  const [progressError, setProgressError] = useState('')
-  const [clueDraftText, setClueDraftText] = useState('')
-  const [clueDrafts, setClueDrafts] = useState<ClueDraft[]>([])
-  const [poiCategory, setPoiCategory] = useState('hospital')
-  const [pois, setPois] = useState<CasePois | null>(null)
-  const [summaryDraft, setSummaryDraft] = useState<SummaryDraft | null>(null)
-  const [summary, setSummary] = useState<CaseSummary | null>(null)
-  const [reviewReason, setReviewReason] = useState('')
-  const [error, setError] = useState('')
-  const [busy, setBusy] = useState('')
-  const progressRequestVersion = useRef(0)
-  const isFamily = detail.access_role === 'family'
-  const canFindPois = detail.access_role === 'commander' || detail.access_role === 'volunteer'
-  const isCommander = detail.access_role === 'commander'
+function CaseCollaborationPanel({
+  detail,
+  token,
+}: {
+  detail: CaseDetail;
+  token: string | null;
+}) {
+  const [publicProgress, setPublicProgress] =
+    useState<CasePublicProgress | null>(null);
+  const [progressError, setProgressError] = useState("");
+  const [clueDraftText, setClueDraftText] = useState("");
+  const [clueDrafts, setClueDrafts] = useState<ClueDraft[]>([]);
+  const [poiCategory, setPoiCategory] = useState("hospital");
+  const [pois, setPois] = useState<CasePois | null>(null);
+  const [summaryDraft, setSummaryDraft] = useState<SummaryDraft | null>(null);
+  const [summary, setSummary] = useState<CaseSummary | null>(null);
+  const [reviewReason, setReviewReason] = useState("");
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState("");
+  const progressRequestVersion = useRef(0);
+  const isFamily = detail.access_role === "family";
+  const canFindPois =
+    detail.access_role === "commander" || detail.access_role === "volunteer";
+  const isCommander = detail.access_role === "commander";
 
   const loadPublicProgress = useCallback(async () => {
-    const requestVersion = progressRequestVersion.current + 1
-    progressRequestVersion.current = requestVersion
+    const requestVersion = progressRequestVersion.current + 1;
+    progressRequestVersion.current = requestVersion;
     if (!token || !isFamily) {
-      setPublicProgress(null)
-      setProgressError('')
-      return
+      setPublicProgress(null);
+      setProgressError("");
+      return;
     }
     try {
-      setProgressError('')
-      const progress = await getCasePublicProgress(token, detail.id)
-      if (requestVersion !== progressRequestVersion.current) return
-      setPublicProgress(progress)
+      setProgressError("");
+      const progress = await getCasePublicProgress(token, detail.id);
+      if (requestVersion !== progressRequestVersion.current) return;
+      setPublicProgress(progress);
     } catch (cause) {
-      if (requestVersion !== progressRequestVersion.current) return
-      setProgressError(messageFrom(cause))
+      if (requestVersion !== progressRequestVersion.current) return;
+      setProgressError(messageFrom(cause));
     }
-  }, [detail.id, isFamily, token])
+  }, [detail.id, isFamily, token]);
 
   const loadSummary = useCallback(async () => {
-    if (!token || !isCommander) { setSummary(null); return }
+    if (!token || !isCommander) {
+      setSummary(null);
+      return;
+    }
     try {
       const [loadedSummary, latestDraft] = await Promise.all([
         getCaseSummary(token, detail.id),
         getLatestSummaryDraft(token, detail.id),
-      ])
-      setSummary(loadedSummary)
-      setSummaryDraft(latestDraft)
-    } catch (cause) { setError(messageFrom(cause)) }
-  }, [detail.id, isCommander, token])
+      ]);
+      setSummary(loadedSummary);
+      setSummaryDraft(latestDraft);
+    } catch (cause) {
+      setError(messageFrom(cause));
+    }
+  }, [detail.id, isCommander, token]);
 
   useEffect(() => {
-    setPublicProgress(null)
-    setProgressError('')
-    setClueDraftText('')
-    setClueDrafts([])
-    setPois(null)
-    setSummaryDraft(null)
-    setSummary(null)
-    setReviewReason('')
-    setError('')
-    void loadPublicProgress()
-    void loadSummary()
-  }, [detail.id, loadPublicProgress, loadSummary])
+    setPublicProgress(null);
+    setProgressError("");
+    setClueDraftText("");
+    setClueDrafts([]);
+    setPois(null);
+    setSummaryDraft(null);
+    setSummary(null);
+    setReviewReason("");
+    setError("");
+    void loadPublicProgress();
+    void loadSummary();
+  }, [detail.id, loadPublicProgress, loadSummary]);
 
   async function run(key: string, action: () => Promise<void>) {
-    setBusy(key)
-    setError('')
+    setBusy(key);
+    setError("");
     try {
-      await action()
+      await action();
     } catch (cause) {
-      setError(messageFrom(cause))
+      setError(messageFrom(cause));
     } finally {
-      setBusy('')
+      setBusy("");
     }
   }
 
-  if (!isFamily && !canFindPois && !isCommander) return null
+  if (!isFamily && !canFindPois && !isCommander) return null;
 
   return (
-    <section className="grid gap-5 border-b border-slate-200 bg-slate-50 px-5 py-5 sm:px-6 lg:grid-cols-2" aria-label="协作工具">
+    <section
+      className="grid gap-5 border-b border-slate-200 bg-slate-50 px-5 py-5 sm:px-6 lg:grid-cols-2"
+      aria-label="协作工具"
+    >
       {isFamily && (
         <div className="min-w-0">
           <div className="flex items-center justify-between gap-3">
-            <h3 className="m-0 text-base font-bold text-slate-950">已核实公开进展</h3>
-            <Button size="sm" variant="ghost" isDisabled={busy !== ''} onPress={() => void loadPublicProgress()}>刷新</Button>
+            <h3 className="m-0 text-base font-bold text-slate-950">
+              已核实公开进展
+            </h3>
+            <Button
+              size="sm"
+              variant="ghost"
+              isDisabled={busy !== ""}
+              onPress={() => void loadPublicProgress()}
+            >
+              刷新
+            </Button>
           </div>
-          {progressError && <div className="mt-3"><Message tone="error">{progressError}</Message></div>}
-          {!progressError && !publicProgress && <p className="mt-3 text-sm text-slate-500">正在加载仅供家属查看的进展…</p>}
-          {publicProgress && <div className="mt-3 space-y-3">
-            <div className="rounded-md border border-emerald-200 bg-white p-3">
-              <h4 className="m-0 text-sm font-semibold text-slate-900">已确认信息</h4>
-              {publicProgress.confirmed_progress.length === 0 ? <p className="mb-0 mt-2 text-sm text-slate-500">暂时没有可公开的已确认信息。</p> : publicProgress.confirmed_progress.map((item) => <p key={item.clue_id} className="mb-0 mt-2 text-sm leading-6 text-slate-700">已确认一项案件进展。<span className="ml-2 text-xs text-slate-500">{formatDate(item.updated_at)}</span></p>)}
+          {progressError && (
+            <div className="mt-3">
+              <Message tone="error">{progressError}</Message>
             </div>
-            <div className="rounded-md border border-amber-200 bg-white p-3">
-              <h4 className="m-0 text-sm font-semibold text-slate-900">需要补充或核实</h4>
-              {publicProgress.requested_family_information.length === 0 ? <p className="mb-0 mt-2 text-sm text-slate-500">当前没有需要你补充的项目。</p> : publicProgress.requested_family_information.map((item) => <p key={item.clue_id} className="mb-0 mt-2 text-sm leading-6 text-slate-700">你提交的一项信息仍待补充或核实。<span className="ml-2 text-xs text-slate-500">{statusLabels[item.review_status] ?? item.review_status}</span></p>)}
+          )}
+          {!progressError && !publicProgress && (
+            <p className="mt-3 text-sm text-slate-500">
+              正在加载仅供家属查看的进展…
+            </p>
+          )}
+          {publicProgress && (
+            <div className="mt-3 space-y-3">
+              <div className="rounded-md border border-emerald-200 bg-white p-3">
+                <h4 className="m-0 text-sm font-semibold text-slate-900">
+                  已确认信息
+                </h4>
+                {publicProgress.confirmed_progress.length === 0 ? (
+                  <p className="mb-0 mt-2 text-sm text-slate-500">
+                    暂时没有可公开的已确认信息。
+                  </p>
+                ) : (
+                  publicProgress.confirmed_progress.map((item) => (
+                    <p
+                      key={item.clue_id}
+                      className="mb-0 mt-2 text-sm leading-6 text-slate-700"
+                    >
+                      已确认一项案件进展。
+                      <span className="ml-2 text-xs text-slate-500">
+                        {formatDate(item.updated_at)}
+                      </span>
+                    </p>
+                  ))
+                )}
+              </div>
+              <div className="rounded-md border border-amber-200 bg-white p-3">
+                <h4 className="m-0 text-sm font-semibold text-slate-900">
+                  需要补充或核实
+                </h4>
+                {publicProgress.requested_family_information.length === 0 ? (
+                  <p className="mb-0 mt-2 text-sm text-slate-500">
+                    当前没有需要你补充的项目。
+                  </p>
+                ) : (
+                  publicProgress.requested_family_information.map((item) => (
+                    <p
+                      key={item.clue_id}
+                      className="mb-0 mt-2 text-sm leading-6 text-slate-700"
+                    >
+                      你提交的一项信息仍待补充或核实。
+                      <span className="ml-2 text-xs text-slate-500">
+                        {statusLabels[item.review_status] ?? item.review_status}
+                      </span>
+                    </p>
+                  ))
+                )}
+              </div>
+              <ul className="m-0 list-disc space-y-1 pl-5 text-xs leading-5 text-slate-600">
+                {publicProgress.safety_and_contact_reminders.map((reminder) => (
+                  <li key={reminder}>{reminder}</li>
+                ))}
+              </ul>
             </div>
-            <ul className="m-0 list-disc space-y-1 pl-5 text-xs leading-5 text-slate-600">{publicProgress.safety_and_contact_reminders.map((reminder) => <li key={reminder}>{reminder}</li>)}</ul>
-          </div>}
+          )}
         </div>
       )}
 
       {canFindPois && (
         <div className="min-w-0">
-          <h3 className="m-0 text-base font-bold text-slate-950">任务区域周边资源</h3>
-          <p className="mb-0 mt-1 text-xs leading-5 text-slate-600">检索中心由服务端按案件任务或已确认地点确定；此处不会提交任意坐标。</p>
+          <h3 className="m-0 text-base font-bold text-slate-950">
+            任务区域周边资源
+          </h3>
+          <p className="mb-0 mt-1 text-xs leading-5 text-slate-600">
+            检索中心由服务端按案件任务或已确认地点确定；此处不会提交任意坐标。
+          </p>
           <div className="mt-3 flex gap-2">
-            <select aria-label="周边资源类别" className="min-h-10 flex-1 rounded-md border border-slate-300 bg-white px-3 text-sm" value={poiCategory} onChange={(event) => { setPoiCategory(event.target.value); setPois(null) }}>
-              <option value="hospital">医院</option><option value="police">派出所</option><option value="transit">公交站</option><option value="market">市场</option><option value="community_service">社区服务中心</option>
+            <select
+              aria-label="周边资源类别"
+              className="min-h-10 flex-1 rounded-md border border-slate-300 bg-white px-3 text-sm"
+              value={poiCategory}
+              onChange={(event) => {
+                setPoiCategory(event.target.value);
+                setPois(null);
+              }}
+            >
+              <option value="hospital">医院</option>
+              <option value="police">派出所</option>
+              <option value="transit">公交站</option>
+              <option value="market">市场</option>
+              <option value="community_service">社区服务中心</option>
             </select>
-            <Button size="sm" variant="secondary" isDisabled={!token || busy === 'pois'} onPress={() => void run('pois', async () => { if (!token) return; setPois(await listCasePois(token, detail.id, poiCategory)) })}>查询</Button>
+            <Button
+              size="sm"
+              variant="secondary"
+              isDisabled={!token || busy === "pois"}
+              onPress={() =>
+                void run("pois", async () => {
+                  if (!token) return;
+                  setPois(await listCasePois(token, detail.id, poiCategory));
+                })
+              }
+            >
+              查询
+            </Button>
           </div>
-          {pois && <div className="mt-3 rounded-md border border-slate-200 bg-white p-3">
-            {pois.fallback_message && <p className="m-0 text-xs leading-5 text-amber-800">{pois.fallback_message}</p>}
-            <ul className="m-0 mt-2 space-y-2 p-0">{pois.items.map((item) => <li key={item.id} className="list-none text-sm text-slate-700"><strong className="text-slate-950">{item.name}</strong>{item.address && <span className="ml-2 text-xs text-slate-500">{item.address}</span>}</li>)}</ul>
-          </div>}
+          {pois && (
+            <div className="mt-3 rounded-md border border-slate-200 bg-white p-3">
+              {pois.fallback_message && (
+                <p className="m-0 text-xs leading-5 text-amber-800">
+                  {pois.fallback_message}
+                </p>
+              )}
+              <ul className="m-0 mt-2 space-y-2 p-0">
+                {pois.items.map((item) => (
+                  <li
+                    key={item.id}
+                    className="list-none text-sm text-slate-700"
+                  >
+                    <strong className="text-slate-950">{item.name}</strong>
+                    {item.address && (
+                      <span className="ml-2 text-xs text-slate-500">
+                        {item.address}
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
       )}
 
       <div className="min-w-0">
-        <h3 className="m-0 text-base font-bold text-slate-950">文本整理为待审核线索</h3>
-        <p className="mb-0 mt-1 text-xs leading-5 text-slate-600">只生成可回看的草稿，不会直接创建已确认线索。</p>
-        <TextArea className="mt-3" value={clueDraftText} maxLength={4000} rows={3} placeholder="粘贴需要整理的受控文本" onChange={(event) => setClueDraftText(event.target.value)} fullWidth />
-        <div className="mt-2 flex justify-end"><Button size="sm" variant="secondary" isDisabled={!token || !clueDraftText.trim() || busy === 'clue-draft'} onPress={() => void run('clue-draft', async () => { if (!token) return; const created = await createClueDraft(token, detail.id, { text: clueDraftText, source_type: 'manual_report' }); setClueDrafts(created); setClueDraftText('') })}>生成待审核草稿</Button></div>
-        {clueDrafts.map((draft) => <div key={draft.id} className="mt-3 rounded-md border border-amber-200 bg-white p-3"><p className="m-0 whitespace-pre-wrap text-sm leading-6 text-slate-700">{draft.content}</p><p className="mb-0 mt-2 text-xs text-amber-800">{draft.uncertainty_notice}</p></div>)}
+        <h3 className="m-0 text-base font-bold text-slate-950">
+          文本整理为待审核线索
+        </h3>
+        <p className="mb-0 mt-1 text-xs leading-5 text-slate-600">
+          只生成可回看的草稿，不会直接创建已确认线索。
+        </p>
+        <TextArea
+          className="mt-3"
+          value={clueDraftText}
+          maxLength={4000}
+          rows={3}
+          placeholder="粘贴需要整理的受控文本"
+          onChange={(event) => setClueDraftText(event.target.value)}
+          fullWidth
+        />
+        <div className="mt-2 flex justify-end">
+          <Button
+            size="sm"
+            variant="secondary"
+            isDisabled={
+              !token || !clueDraftText.trim() || busy === "clue-draft"
+            }
+            onPress={() =>
+              void run("clue-draft", async () => {
+                if (!token) return;
+                const created = await createClueDraft(token, detail.id, {
+                  text: clueDraftText,
+                  source_type: "manual_report",
+                });
+                setClueDrafts(created);
+                setClueDraftText("");
+              })
+            }
+          >
+            生成待审核草稿
+          </Button>
+        </div>
+        {clueDrafts.map((draft) => (
+          <div
+            key={draft.id}
+            className="mt-3 rounded-md border border-amber-200 bg-white p-3"
+          >
+            <p className="m-0 whitespace-pre-wrap text-sm leading-6 text-slate-700">
+              {draft.content}
+            </p>
+            <p className="mb-0 mt-2 text-xs text-amber-800">
+              {draft.uncertainty_notice}
+            </p>
+          </div>
+        ))}
       </div>
 
-      {isCommander && <div className="min-w-0">
-        <div className="rounded-md border border-slate-200 bg-white p-3">
-          <div className="flex items-center justify-between gap-3"><h3 className="m-0 text-base font-bold text-slate-950">经授权案件摘要</h3><Button size="sm" variant="ghost" isDisabled={!token || busy !== ''} onPress={() => void loadSummary()}>刷新摘要</Button></div>
-          {!summary ? <p className="mb-0 mt-2 text-sm text-slate-500">正在加载服务端确定性摘要…</p> : <><p className="mb-0 mt-2 text-xs text-slate-500">生成于 {formatDate(summary.generated_at)} · 来源范围：{summary.source_scope.join('、')}</p><div className="mt-3 grid gap-3 sm:grid-cols-2"><div><strong className="text-sm text-slate-900">最后确认信息</strong><p className="mb-0 mt-1 text-sm leading-6 text-slate-700">{summary.last_confirmed_information?.content ?? '暂无已确认信息。'}</p></div><div><strong className="text-sm text-slate-900">待核实事项</strong><p className="mb-0 mt-1 text-sm leading-6 text-slate-700">{summary.pending_verification.length === 0 ? '暂无。' : `${summary.pending_verification.length} 项仍需人工核实，未作为确认事实发布。`}</p></div></div>{summary.safety_reminders.length > 0 && <ul className="mb-0 mt-3 list-disc space-y-1 pl-5 text-xs leading-5 text-slate-600">{summary.safety_reminders.map((item) => <li key={item}>{item}</li>)}</ul>}</>}
+      {isCommander && (
+        <div className="min-w-0">
+          <div className="rounded-md border border-slate-200 bg-white p-3">
+            <div className="flex items-center justify-between gap-3">
+              <h3 className="m-0 text-base font-bold text-slate-950">
+                经授权案件摘要
+              </h3>
+              <Button
+                size="sm"
+                variant="ghost"
+                isDisabled={!token || busy !== ""}
+                onPress={() => void loadSummary()}
+              >
+                刷新摘要
+              </Button>
+            </div>
+            {!summary ? (
+              <p className="mb-0 mt-2 text-sm text-slate-500">
+                正在加载服务端确定性摘要…
+              </p>
+            ) : (
+              <>
+                <p className="mb-0 mt-2 text-xs text-slate-500">
+                  生成于 {formatDate(summary.generated_at)} · 来源范围：
+                  {summary.source_scope.join("、")}
+                </p>
+                <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                  <div>
+                    <strong className="text-sm text-slate-900">
+                      最后确认信息
+                    </strong>
+                    <p className="mb-0 mt-1 text-sm leading-6 text-slate-700">
+                      {summary.last_confirmed_information?.content ??
+                        "暂无已确认信息。"}
+                    </p>
+                  </div>
+                  <div>
+                    <strong className="text-sm text-slate-900">
+                      待核实事项
+                    </strong>
+                    <p className="mb-0 mt-1 text-sm leading-6 text-slate-700">
+                      {summary.pending_verification.length === 0
+                        ? "暂无。"
+                        : `${summary.pending_verification.length} 项仍需人工核实，未作为确认事实发布。`}
+                    </p>
+                  </div>
+                </div>
+                {summary.safety_reminders.length > 0 && (
+                  <ul className="mb-0 mt-3 list-disc space-y-1 pl-5 text-xs leading-5 text-slate-600">
+                    {summary.safety_reminders.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                )}
+              </>
+            )}
+          </div>
+          <h3 className="m-0 text-base font-bold text-slate-950">
+            案件摘要草稿审核
+          </h3>
+          <p className="mb-0 mt-1 text-xs leading-5 text-slate-600">
+            线索完成人工审核后，系统会依据已授权来源范围自动生成待审核摘要；发布会替代该案件旧的已发布版本。
+          </p>
+          {!summaryDraft ? (
+            <p className="mb-0 mt-3 text-sm text-slate-500">
+              暂无待审核摘要。审核一条线索后，系统会自动生成。
+            </p>
+          ) : (
+            <div className="mt-3 rounded-md border border-slate-200 bg-white p-3">
+              <Chip size="sm" variant="soft">
+                <Chip.Label>
+                  {statusLabels[summaryDraft.status] ?? summaryDraft.status}
+                </Chip.Label>
+              </Chip>
+              {summaryDraft.provider_model == null && (
+                <p className="mb-0 mt-2 text-xs text-amber-800">
+                  当前使用受控规则降级摘要；仍须人工审核后才能发布。
+                </p>
+              )}
+              <p className="mb-0 mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-700">
+                {summaryDraft.content}
+              </p>
+              {summaryDraft.status === "pending_review" && (
+                <>
+                  <Field label="审核理由" required>
+                    <Input
+                      value={reviewReason}
+                      maxLength={1000}
+                      onChange={(event) => setReviewReason(event.target.value)}
+                      fullWidth
+                    />
+                  </Field>
+                  <div className="mt-3 flex flex-wrap justify-end gap-2">
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      isDisabled={
+                        !token ||
+                        !reviewReason.trim() ||
+                        busy === "summary-review"
+                      }
+                      onPress={() =>
+                        void run("summary-review", async () => {
+                          if (!token) return;
+                          setSummaryDraft(
+                            await reviewSummaryDraft(
+                              token,
+                              detail.id,
+                              summaryDraft.id,
+                              { action: "reject", reason: reviewReason },
+                            ),
+                          );
+                        })
+                      }
+                    >
+                      驳回
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="primary"
+                      isDisabled={
+                        !token ||
+                        !summaryDraft.publication_eligible ||
+                        !reviewReason.trim() ||
+                        busy === "summary-review"
+                      }
+                      onPress={() =>
+                        void run("summary-review", async () => {
+                          if (!token) return;
+                          setSummaryDraft(
+                            await reviewSummaryDraft(
+                              token,
+                              detail.id,
+                              summaryDraft.id,
+                              { action: "publish", reason: reviewReason },
+                            ),
+                          );
+                        })
+                      }
+                    >
+                      审核发布
+                    </Button>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
         </div>
-        <h3 className="m-0 text-base font-bold text-slate-950">案件摘要草稿审核</h3>
-        <p className="mb-0 mt-1 text-xs leading-5 text-slate-600">线索完成人工审核后，系统会依据已授权来源范围自动生成待审核摘要；发布会替代该案件旧的已发布版本。</p>
-        {!summaryDraft ? <p className="mb-0 mt-3 text-sm text-slate-500">暂无待审核摘要。审核一条线索后，系统会自动生成。</p> : <div className="mt-3 rounded-md border border-slate-200 bg-white p-3"><Chip size="sm" variant="soft"><Chip.Label>{statusLabels[summaryDraft.status] ?? summaryDraft.status}</Chip.Label></Chip>{summaryDraft.provider_model == null && <p className="mb-0 mt-2 text-xs text-amber-800">当前使用受控规则降级摘要；仍须人工审核后才能发布。</p>}<p className="mb-0 mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-700">{summaryDraft.content}</p>{summaryDraft.status === 'pending_review' && <><Field label="审核理由" required><Input value={reviewReason} maxLength={1000} onChange={(event) => setReviewReason(event.target.value)} fullWidth /></Field><div className="mt-3 flex flex-wrap justify-end gap-2"><Button size="sm" variant="ghost" isDisabled={!token || !reviewReason.trim() || busy === 'summary-review'} onPress={() => void run('summary-review', async () => { if (!token) return; setSummaryDraft(await reviewSummaryDraft(token, detail.id, summaryDraft.id, { action: 'reject', reason: reviewReason })) })}>驳回</Button><Button size="sm" variant="primary" isDisabled={!token || !summaryDraft.publication_eligible || !reviewReason.trim() || busy === 'summary-review'} onPress={() => void run('summary-review', async () => { if (!token) return; setSummaryDraft(await reviewSummaryDraft(token, detail.id, summaryDraft.id, { action: 'publish', reason: reviewReason })) })}>审核发布</Button></div></>}</div>}
-      </div>}
+      )}
 
-      {error && <div className="lg:col-span-2"><Message tone="error">{error}</Message></div>}
+      {error && (
+        <div className="lg:col-span-2">
+          <Message tone="error">{error}</Message>
+        </div>
+      )}
     </section>
-  )
+  );
 }
 
 function ReviewButton({
@@ -1078,76 +2734,125 @@ function ReviewButton({
   run,
   onReviewed,
 }: {
-  label: string
-  status: ClueReviewStatus
-  clueId: string
-  reason: string
-  relatedClueId: string
-  busy: string
-  run: (key: string, action: () => Promise<unknown>, message: string) => Promise<boolean>
-  onReviewed: () => void
+  label: string;
+  status: ClueReviewStatus;
+  clueId: string;
+  reason: string;
+  relatedClueId: string;
+  busy: string;
+  run: (
+    key: string,
+    action: () => Promise<unknown>,
+    message: string,
+  ) => Promise<boolean>;
+  onReviewed: () => void;
 }) {
-  const { token } = useAuth()
-  const key = `review:${clueId}:${status}`
-  const requiresRelationship = status === 'duplicate' || status === 'conflicting'
-  const isReady = Boolean(reason.trim()) && (!requiresRelationship || Boolean(relatedClueId.trim()))
-  const [isConfirming, setIsConfirming] = useState(false)
-  const reviewTriggerRef = useRef<HTMLButtonElement>(null)
-  const hadConfirmationOpen = useRef(false)
+  const { token } = useAuth();
+  const key = `review:${clueId}:${status}`;
+  const requiresRelationship =
+    status === "duplicate" || status === "conflicting";
+  const isReady =
+    Boolean(reason.trim()) &&
+    (!requiresRelationship || Boolean(relatedClueId.trim()));
+  const [isConfirming, setIsConfirming] = useState(false);
+  const reviewTriggerRef = useRef<HTMLButtonElement>(null);
+  const hadConfirmationOpen = useRef(false);
 
   useEffect(() => {
     if (isConfirming) {
-      hadConfirmationOpen.current = true
-      return
+      hadConfirmationOpen.current = true;
+      return;
     }
     if (hadConfirmationOpen.current) {
-      reviewTriggerRef.current?.focus()
-      hadConfirmationOpen.current = false
+      reviewTriggerRef.current?.focus();
+      hadConfirmationOpen.current = false;
     }
-  }, [isConfirming])
+  }, [isConfirming]);
 
   function submitReview() {
-    const normalizedReason = reason.trim()
-    if (!token || !normalizedReason || (requiresRelationship && !relatedClueId.trim())) return
-    void run(key, () => reviewClue(token, clueId, {
-      status,
-      reason: normalizedReason,
-      related_clue_id: requiresRelationship ? relatedClueId.trim() : null,
-      relationship_type: status === 'duplicate' ? 'duplicate_of' : status === 'conflicting' ? 'conflicts_with' : null,
-    }), `线索已更新为${statusLabels[status]}`).then((succeeded) => {
-      if (succeeded) onReviewed()
-      setIsConfirming(false)
-    })
+    const normalizedReason = reason.trim();
+    if (
+      !token ||
+      !normalizedReason ||
+      (requiresRelationship && !relatedClueId.trim())
+    )
+      return;
+    void run(
+      key,
+      () =>
+        reviewClue(token, clueId, {
+          status,
+          reason: normalizedReason,
+          related_clue_id: requiresRelationship ? relatedClueId.trim() : null,
+          relationship_type:
+            status === "duplicate"
+              ? "duplicate_of"
+              : status === "conflicting"
+                ? "conflicts_with"
+                : null,
+        }),
+      `线索已更新为${statusLabels[status]}`,
+    ).then((succeeded) => {
+      if (succeeded) onReviewed();
+      setIsConfirming(false);
+    });
   }
   return (
     <AlertDialog isOpen={isConfirming} onOpenChange={setIsConfirming}>
-    <Button
-      ref={reviewTriggerRef}
-      size="sm"
-      variant={status === 'confirmed' ? 'secondary' : 'ghost'}
-      isDisabled={busy === key || !isReady}
-      onPress={() => setIsConfirming(true)}
-    >
-      {status === 'confirmed' && <CheckCircle2 size={15} />}
-      {label}
-    </Button>
-    <AlertDialog.Backdrop
-      className="fixed inset-0 z-50 bg-slate-950/40 p-4"
-      isKeyboardDismissDisabled={false}
-    >
-      <AlertDialog.Container className="grid min-h-full place-items-center">
-        <AlertDialog.Dialog role="dialog" aria-labelledby={`review-confirmation-${clueId}`} className="w-full max-w-md rounded-md bg-white p-5 shadow-xl">
-          <h4 id={`review-confirmation-${clueId}`} className="m-0 text-base font-bold text-slate-950">确认审核操作</h4>
-          <p className="mb-0 mt-3 text-sm leading-6 text-slate-700">将把该线索从“{statusLabels.pending_review}”改为“{statusLabels[status]}”。此操作会记录审核理由和操作者，并更新其他角色可见的内容。</p>
-          <div className="mt-5 flex justify-end gap-2">
-            <Button size="sm" variant="ghost" isDisabled={busy === key} onPress={() => setIsConfirming(false)}>取消</Button>
-            <Button size="sm" variant="primary" isDisabled={busy === key} onPress={submitReview}>确认提交</Button>
-          </div>
-        </AlertDialog.Dialog>
-      </AlertDialog.Container>
-    </AlertDialog.Backdrop>
+      <Button
+        ref={reviewTriggerRef}
+        size="sm"
+        variant={status === "confirmed" ? "secondary" : "ghost"}
+        isDisabled={busy === key || !isReady}
+        onPress={() => setIsConfirming(true)}
+      >
+        {status === "confirmed" && <CheckCircle2 size={15} />}
+        {label}
+      </Button>
+      <AlertDialog.Backdrop
+        className="fixed inset-0 z-50 bg-slate-950/40 p-4"
+        isKeyboardDismissDisabled={false}
+      >
+        <AlertDialog.Container className="grid min-h-full place-items-center">
+          <AlertDialog.Dialog
+            role="dialog"
+            aria-labelledby={`review-confirmation-${clueId}`}
+            className="w-full max-w-md rounded-md bg-white p-5 shadow-xl"
+          >
+            <h4
+              id={`review-confirmation-${clueId}`}
+              className="m-0 text-base font-bold text-slate-950"
+            >
+              确认审核操作
+            </h4>
+            <p className="mb-0 mt-3 text-sm leading-6 text-slate-700">
+              将把该线索从“{statusLabels.pending_review}”改为“
+              {statusLabels[status]}
+              ”。此操作会记录审核理由和操作者，并更新其他角色可见的内容。
+            </p>
+            <div className="mt-5 flex justify-end gap-2">
+              <Button
+                size="sm"
+                variant="ghost"
+                isDisabled={busy === key}
+                onPress={() => setIsConfirming(false)}
+              >
+                取消
+              </Button>
+              <Button
+                size="sm"
+                variant="primary"
+                isDisabled={busy === key}
+                onPress={submitReview}
+              >
+                确认提交
+              </Button>
+            </div>
+          </AlertDialog.Dialog>
+        </AlertDialog.Container>
+      </AlertDialog.Backdrop>
     </AlertDialog>
-  )
+  );
 }
 
 function RelatedCluePicker({
@@ -1157,149 +2862,289 @@ function RelatedCluePicker({
   query,
   onChange,
 }: {
-  clueId: string
-  candidates: Clue[]
-  selectedId: string
-  query: string
-  onChange: (relatedClueId: string, relatedClueQuery: string) => void
+  clueId: string;
+  candidates: Clue[];
+  selectedId: string;
+  query: string;
+  onChange: (relatedClueId: string, relatedClueQuery: string) => void;
 }) {
-  const normalizedQuery = query.trim().toLocaleLowerCase()
+  const normalizedQuery = query.trim().toLocaleLowerCase();
   const options = candidates.filter((candidate) => {
-    if (candidate.id === clueId) return false
-    if (candidate.id === selectedId || !normalizedQuery) return true
-    return [candidate.content, candidate.status, candidate.location_text, candidate.reported_at]
+    if (candidate.id === clueId) return false;
+    if (candidate.id === selectedId || !normalizedQuery) return true;
+    return [
+      candidate.content,
+      candidate.status,
+      candidate.location_text,
+      candidate.reported_at,
+    ]
       .filter((value): value is string => Boolean(value))
-      .join(' ')
+      .join(" ")
       .toLocaleLowerCase()
-      .includes(normalizedQuery)
-  })
+      .includes(normalizedQuery);
+  });
 
-  return <div className="grid gap-2">
-    <Input
-      aria-label="搜索关联线索"
-      value={query}
-      maxLength={200}
-      placeholder="按线索内容、状态、地点或时间筛选"
-      onChange={(event) => onChange(selectedId, event.target.value)}
-      fullWidth
-    />
-    <select
-      aria-label="选择关联线索"
-      className="min-h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm"
-      value={selectedId}
-      onChange={(event) => onChange(event.target.value, query)}
-    >
-      <option value="">请选择关联线索</option>
-      {options.map((candidate) => <option key={candidate.id} value={candidate.id}>{clueOptionLabel(candidate)}</option>)}
-    </select>
-    <p className="m-0 text-xs leading-5 text-slate-600">{options.length === 0 ? '没有匹配的案件线索。' : `显示 ${options.length} 条可选线索；不会提交或显示 UUID。`}</p>
-  </div>
+  return (
+    <div className="grid gap-2">
+      <Input
+        aria-label="搜索关联线索"
+        value={query}
+        maxLength={200}
+        placeholder="按线索内容、状态、地点或时间筛选"
+        onChange={(event) => onChange(selectedId, event.target.value)}
+        fullWidth
+      />
+      <select
+        aria-label="选择关联线索"
+        className="min-h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm"
+        value={selectedId}
+        onChange={(event) => onChange(event.target.value, query)}
+      >
+        <option value="">请选择关联线索</option>
+        {options.map((candidate) => (
+          <option key={candidate.id} value={candidate.id}>
+            {clueOptionLabel(candidate)}
+          </option>
+        ))}
+      </select>
+      <p className="m-0 text-xs leading-5 text-slate-600">
+        {options.length === 0
+          ? "没有匹配的案件线索。"
+          : `显示 ${options.length} 条可选线索；不会提交或显示 UUID。`}
+      </p>
+    </div>
+  );
 }
 
 function clueOptionLabel(clue: Clue) {
-  const excerpt = clue.content.replace(/\s+/g, ' ').slice(0, 80)
-  const location = clue.location_text ? ` · ${clue.location_text}` : ''
-  return `${statusLabels[clue.status] ?? clue.status} · ${formatDate(clue.reported_at) ?? '时间未知'} · ${excerpt}${location}`
+  const excerpt = clue.content.replace(/\s+/g, " ").slice(0, 80);
+  const location = clue.location_text ? ` · ${clue.location_text}` : "";
+  return `${statusLabels[clue.status] ?? clue.status} · ${formatDate(clue.reported_at) ?? "时间未知"} · ${excerpt}${location}`;
 }
 
-function ElderProfileEditor({ detail, token, busy, onSave }: { detail: CaseDetail; token: string | null; busy: string; onSave: (payload: import('../api/cases').UpdateElderProfilePayload) => Promise<boolean> }) {
-  const [ageError, setAgeError] = useState('')
+function ElderProfileEditor({
+  detail,
+  token,
+  busy,
+  onSave,
+}: {
+  detail: CaseDetail;
+  token: string | null;
+  busy: string;
+  onSave: (
+    payload: import("../api/cases").UpdateElderProfilePayload,
+  ) => Promise<boolean>;
+}) {
+  const [ageError, setAgeError] = useState("");
   const [draft, setDraft] = useState({
     display_name: detail.elder_profile.display_name,
-    age: detail.elder_profile.age == null ? '' : String(detail.elder_profile.age),
-    gender: detail.elder_profile.gender ?? '',
-    physical_description: detail.elder_profile.physical_description ?? '',
-    clothing_description: detail.elder_profile.clothing_description ?? '',
-    health_notes: detail.elder_profile.health_notes ?? '',
-    last_seen_at: detail.elder_profile.last_seen_at ?? '',
-    last_seen_location: detail.elder_profile.last_seen_location ?? '',
-  })
-  useEffect(() => setDraft({
-    display_name: detail.elder_profile.display_name, age: detail.elder_profile.age == null ? '' : String(detail.elder_profile.age),
-    gender: detail.elder_profile.gender ?? '', physical_description: detail.elder_profile.physical_description ?? '',
-    clothing_description: detail.elder_profile.clothing_description ?? '', health_notes: detail.elder_profile.health_notes ?? '',
-    last_seen_at: detail.elder_profile.last_seen_at ?? '', last_seen_location: detail.elder_profile.last_seen_location ?? '',
-  }), [detail])
-  const field = (key: keyof typeof draft, label: string, multiline = false) => <Field label={label}>{multiline
-    ? <TextArea value={draft[key]} onChange={(event) => setDraft((value) => ({ ...value, [key]: event.target.value }))} fullWidth />
-    : <Input type={key === 'age' ? 'number' : undefined} min={key === 'age' ? 0 : undefined} max={key === 'age' ? 130 : undefined} value={draft[key]} onChange={(event) => { setAgeError(''); setDraft((value) => ({ ...value, [key]: event.target.value })) }} fullWidth />
-  }</Field>
-  return <form className="border-b border-slate-200 bg-brand-50/30 px-5 py-5 sm:px-6" onSubmit={(event) => {
-    event.preventDefault(); if (!token) return
-    const ageText = draft.age.trim()
-    const age = ageText === '' ? undefined : Number(ageText)
-    if (age !== undefined && (!Number.isInteger(age) || age < 0 || age > 130)) {
-      setAgeError('年龄必须是 0 到 130 之间的整数。')
-      return
-    }
-    void onSave({ display_name: draft.display_name, age, gender: draft.gender,
-      physical_description: draft.physical_description, clothing_description: draft.clothing_description,
-      health_notes: draft.health_notes, last_seen_at: draft.last_seen_at, last_seen_location: draft.last_seen_location })
-  }}>
-    {ageError && <p className="mb-3 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700" role="alert">{ageError}</p>}
-    <h3 className="m-0 text-sm font-bold text-slate-950">人物摘要补充 / 更正</h3>
-    <p className="mt-1 text-xs text-slate-600">每次保存都会保留前后版本；案件状态、成员和任务信息不在此表单中。</p>
-    <div className="mt-3 grid gap-3 sm:grid-cols-2">{field('display_name', '姓名')} {field('age', '年龄')} {field('gender', '性别')} {field('last_seen_location', '最后出现地点')} {field('last_seen_at', '最后出现时间')} {field('physical_description', '体貌', true)} {field('clothing_description', '衣着', true)} {field('health_notes', '健康注意', true)}</div>
-    <div className="mt-4 flex justify-end"><Button type="submit" size="sm" variant="secondary" isDisabled={busy === 'elder-profile'}>{busy === 'elder-profile' ? '正在保存' : '保存人物摘要'}</Button></div>
-  </form>
+    age:
+      detail.elder_profile.age == null ? "" : String(detail.elder_profile.age),
+    gender: detail.elder_profile.gender ?? "",
+    physical_description: detail.elder_profile.physical_description ?? "",
+    clothing_description: detail.elder_profile.clothing_description ?? "",
+    health_notes: detail.elder_profile.health_notes ?? "",
+    last_seen_at: detail.elder_profile.last_seen_at ?? "",
+    last_seen_location: detail.elder_profile.last_seen_location ?? "",
+  });
+  useEffect(
+    () =>
+      setDraft({
+        display_name: detail.elder_profile.display_name,
+        age:
+          detail.elder_profile.age == null
+            ? ""
+            : String(detail.elder_profile.age),
+        gender: detail.elder_profile.gender ?? "",
+        physical_description: detail.elder_profile.physical_description ?? "",
+        clothing_description: detail.elder_profile.clothing_description ?? "",
+        health_notes: detail.elder_profile.health_notes ?? "",
+        last_seen_at: detail.elder_profile.last_seen_at ?? "",
+        last_seen_location: detail.elder_profile.last_seen_location ?? "",
+      }),
+    [detail],
+  );
+  const field = (key: keyof typeof draft, label: string, multiline = false) => (
+    <Field label={label}>
+      {multiline ? (
+        <TextArea
+          value={draft[key]}
+          onChange={(event) =>
+            setDraft((value) => ({ ...value, [key]: event.target.value }))
+          }
+          fullWidth
+        />
+      ) : (
+        <Input
+          type={key === "age" ? "number" : undefined}
+          min={key === "age" ? 0 : undefined}
+          max={key === "age" ? 130 : undefined}
+          value={draft[key]}
+          onChange={(event) => {
+            setAgeError("");
+            setDraft((value) => ({ ...value, [key]: event.target.value }));
+          }}
+          fullWidth
+        />
+      )}
+    </Field>
+  );
+  return (
+    <form
+      className="border-b border-slate-200 bg-brand-50/30 px-5 py-5 sm:px-6"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (!token) return;
+        const ageText = draft.age.trim();
+        const age = ageText === "" ? undefined : Number(ageText);
+        if (
+          age !== undefined &&
+          (!Number.isInteger(age) || age < 0 || age > 130)
+        ) {
+          setAgeError("年龄必须是 0 到 130 之间的整数。");
+          return;
+        }
+        void onSave({
+          display_name: draft.display_name,
+          age,
+          gender: draft.gender,
+          physical_description: draft.physical_description,
+          clothing_description: draft.clothing_description,
+          health_notes: draft.health_notes,
+          last_seen_at: draft.last_seen_at,
+          last_seen_location: draft.last_seen_location,
+        });
+      }}
+    >
+      {ageError && (
+        <p
+          className="mb-3 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700"
+          role="alert"
+        >
+          {ageError}
+        </p>
+      )}
+      <h3 className="m-0 text-sm font-bold text-slate-950">
+        人物摘要补充 / 更正
+      </h3>
+      <p className="mt-1 text-xs text-slate-600">
+        每次保存都会保留前后版本；案件状态、成员和任务信息不在此表单中。
+      </p>
+      <div className="mt-3 grid gap-3 sm:grid-cols-2">
+        {field("display_name", "姓名")} {field("age", "年龄")}{" "}
+        {field("gender", "性别")} {field("last_seen_location", "最后出现地点")}{" "}
+        {field("last_seen_at", "最后出现时间")}{" "}
+        {field("physical_description", "体貌", true)}{" "}
+        {field("clothing_description", "衣着", true)}{" "}
+        {field("health_notes", "健康注意", true)}
+      </div>
+      <div className="mt-4 flex justify-end">
+        <Button
+          type="submit"
+          size="sm"
+          variant="secondary"
+          isDisabled={busy === "elder-profile"}
+        >
+          {busy === "elder-profile" ? "正在保存" : "保存人物摘要"}
+        </Button>
+      </div>
+    </form>
+  );
 }
 
-function Field({ label, required, children }: { label: string; required?: boolean; children: React.ReactNode }) {
+function Field({
+  label,
+  required,
+  children,
+}: {
+  label: string;
+  required?: boolean;
+  children: React.ReactNode;
+}) {
   return (
     <label className="block">
-      <span className="mb-1.5 block text-xs font-semibold text-slate-600">{label}{required ? ' *' : ''}</span>
+      <span className="mb-1.5 block text-xs font-semibold text-slate-600">
+        {label}
+        {required ? " *" : ""}
+      </span>
       {children}
     </label>
-  )
+  );
 }
 
-function Info({ label, value, icon }: { label: string; value: string | null; icon?: React.ReactNode }) {
+function Info({
+  label,
+  value,
+  icon,
+}: {
+  label: string;
+  value: string | null;
+  icon?: React.ReactNode;
+}) {
   return (
     <div className="min-w-0">
-      <span className="flex items-center gap-1 text-xs text-slate-500">{icon}{label}</span>
-      <strong className="mt-1 block whitespace-pre-wrap text-sm font-medium text-slate-800">{value || '未填写'}</strong>
+      <span className="flex items-center gap-1 text-xs text-slate-500">
+        {icon}
+        {label}
+      </span>
+      <strong className="mt-1 block whitespace-pre-wrap text-sm font-medium text-slate-800">
+        {value || "未填写"}
+      </strong>
     </div>
-  )
+  );
 }
 
-function Message({ tone, children }: { tone: 'error' | 'success'; children: React.ReactNode }) {
+function Message({
+  tone,
+  children,
+}: {
+  tone: "error" | "success";
+  children: React.ReactNode;
+}) {
   return (
-    <div className={`mb-3 rounded-md border px-3 py-2 text-sm ${tone === 'error' ? 'border-red-200 bg-red-50 text-red-700' : 'border-emerald-200 bg-emerald-50 text-emerald-700'}`} role={tone === 'error' ? 'alert' : 'status'}>
+    <div
+      className={`mb-3 rounded-md border px-3 py-2 text-sm ${tone === "error" ? "border-red-200 bg-red-50 text-red-700" : "border-emerald-200 bg-emerald-50 text-emerald-700"}`}
+      role={tone === "error" ? "alert" : "status"}
+    >
       {children}
     </div>
-  )
+  );
 }
 
 function nullable(value: string): string | null {
-  const trimmed = value.trim()
-  return trimmed ? trimmed : null
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
 }
 
 function toIsoOrNull(value: string): string | null {
-  if (!value) return null
-  const date = new Date(value)
-  return Number.isNaN(date.getTime()) ? null : date.toISOString()
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
 }
 
 function messageFrom(cause: unknown): string {
-  if (cause instanceof ApiClientError) return cause.message
-  return cause instanceof Error ? cause.message : '操作失败'
+  if (cause instanceof ApiClientError) return cause.message;
+  return cause instanceof Error ? cause.message : "操作失败";
 }
 
 function formatDate(value: string | null): string | null {
-  if (!value) return null
-  const date = new Date(value)
-  return Number.isNaN(date.getTime()) ? value : date.toLocaleString('zh-CN', { hour12: false })
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? value
+    : date.toLocaleString("zh-CN", { hour12: false });
 }
 
 function toDateTimeLocal(value: string): string {
-  if (!value) return ''
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return ''
-  const offset = date.getTimezoneOffset() * 60_000
-  return new Date(date.getTime() - offset).toISOString().slice(0, 16)
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  const offset = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - offset).toISOString().slice(0, 16);
 }
 
 function formatBytes(value: number): string {
-  return value >= 1024 * 1024 ? `${(value / (1024 * 1024)).toFixed(1)} MiB` : `${value} 字节`
+  return value >= 1024 * 1024
+    ? `${(value / (1024 * 1024)).toFixed(1)} MiB`
+    : `${value} 字节`;
 }

--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -1,68 +1,84 @@
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
-import { DashboardPage } from './DashboardPage'
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DashboardPage } from "./DashboardPage";
 
 const mocked = vi.hoisted(() => ({
   getCase: vi.fn(),
   listCases: vi.fn(),
   listCommandIntake: vi.fn(),
   globalCapabilities: [] as string[],
-}))
+}));
 
-vi.mock('../auth/useAuth', () => ({
+vi.mock("../auth/useAuth", () => ({
   useAuth: () => ({
-    token: 'test-session',
-    user: { id: 'family-1', email: 'family@demo.invalid', display_name: '模拟家属', account_type: 'member', global_capabilities: mocked.globalCapabilities },
+    token: "test-session",
+    user: {
+      id: "family-1",
+      email: "family@demo.invalid",
+      display_name: "模拟家属",
+      account_type: "member",
+      global_capabilities: mocked.globalCapabilities,
+    },
   }),
-}))
-vi.mock('../api/cases', () => ({
+}));
+vi.mock("../api/cases", () => ({
   getCase: (...args: unknown[]) => mocked.getCase(...args),
   listCases: (...args: unknown[]) => mocked.listCases(...args),
   listCommandIntake: (...args: unknown[]) => mocked.listCommandIntake(...args),
-}))
-vi.mock('../components/ServiceStatus', () => ({ ServiceStatus: () => <span>服务状态</span> }))
+}));
+vi.mock("../components/ServiceStatus", () => ({
+  ServiceStatus: () => <span>服务状态</span>,
+}));
 
-describe('DashboardPage', () => {
-  it('warns when the 20-detail statistics limit truncates the visible case list', async () => {
+describe("DashboardPage", () => {
+  it("warns when the 20-detail statistics limit truncates the visible case list", async () => {
     mocked.listCases.mockResolvedValue(
       Array.from({ length: 21 }, (_, index) => ({
         id: `case-${index + 1}`,
         case_code: `AG-${index + 1}`,
-        status: 'active',
-        access_role: 'family',
+        status: "active",
+        access_role: "family",
         display_name: `模拟案件 ${index + 1}`,
         last_seen_at: null,
         last_seen_location: null,
-        created_at: '2026-07-24T00:00:00Z',
-        updated_at: '2026-07-24T00:00:00Z',
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
       })),
-    )
-    mocked.getCase.mockResolvedValue({ clues: [] })
+    );
+    mocked.getCase.mockResolvedValue({ clues: [] });
 
-    render(<DashboardPage />)
+    render(<DashboardPage />);
 
-    expect(await screen.findByText('部分案件详情暂时不可用，统计数据可能不完整。')).toBeInTheDocument()
-    expect(mocked.getCase).toHaveBeenCalledTimes(20)
-  })
+    expect(
+      await screen.findByText("部分案件详情暂时不可用，统计数据可能不完整。"),
+    ).toBeInTheDocument();
+    expect(mocked.getCase).toHaveBeenCalledTimes(20);
+  });
 
-  it('shows the commander intake queue in overview metrics and real-time status', async () => {
-    mocked.globalCapabilities = ['commander']
-    mocked.listCases.mockResolvedValue([])
-    mocked.listCommandIntake.mockResolvedValue([{
-      id: 'pending-case',
-      case_code: 'AG-PENDING',
-      created_at: '2026-07-24T00:00:00Z',
-      last_seen_at: '2026-07-24T08:30:00Z',
-      area_hint: '北门区域',
-      elder_age: 76,
-    }])
+  it("shows the commander intake queue in overview metrics and real-time status", async () => {
+    mocked.globalCapabilities = ["commander"];
+    mocked.listCases.mockResolvedValue([]);
+    mocked.listCommandIntake.mockResolvedValue([
+      {
+        id: "pending-case",
+        case_code: "AG-PENDING",
+        created_at: "2026-07-24T00:00:00Z",
+        last_seen_at: "2026-07-24T08:30:00Z",
+        area_hint: "北门区域",
+        elder_age: 76,
+      },
+    ]);
 
-    render(<DashboardPage />)
+    render(<DashboardPage />);
 
-    expect(await screen.findByText('待受理案件')).toBeInTheDocument()
-    expect(screen.getByText('AG-PENDING')).toBeInTheDocument()
-    expect(screen.getByText(/地区：北门区域.*走失时间：2026-07-24T08:30:00Z.*老人年龄：76 岁/)).toBeInTheDocument()
-    expect(screen.getByText('待受理')).toBeInTheDocument()
-    expect(mocked.listCommandIntake).toHaveBeenCalledWith('test-session')
-  })
-})
+    expect(await screen.findByText("待受理案件")).toBeInTheDocument();
+    expect(screen.getByText("AG-PENDING")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /地区：北门区域.*走失时间：2026-07-24T08:30:00Z.*老人年龄：76 岁/,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("待受理")).toBeInTheDocument();
+    expect(mocked.listCommandIntake).toHaveBeenCalledWith("test-session");
+  });
+});

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,99 +1,152 @@
-import { Button, Card, Chip } from '@heroui/react'
-import { ClipboardCheck, FileSearch, RadioTower, RefreshCw, UsersRound } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { getCase, listCases, listCommandIntake } from '../api/cases'
-import type { CaseDetail, CaseListItem, CommandIntakeCase } from '../api/cases'
-import { useAuth } from '../auth/useAuth'
-import { EmptyState, ErrorState, LoadingState } from '../components/ContentState'
-import { ServiceStatus } from '../components/ServiceStatus'
+import { Button, Card, Chip } from "@heroui/react";
+import {
+  ClipboardCheck,
+  FileSearch,
+  RadioTower,
+  RefreshCw,
+  UsersRound,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { getCase, listCases, listCommandIntake } from "../api/cases";
+import type { CaseDetail, CaseListItem, CommandIntakeCase } from "../api/cases";
+import { useAuth } from "../auth/useAuth";
+import {
+  EmptyState,
+  ErrorState,
+  LoadingState,
+} from "../components/ContentState";
+import { ServiceStatus } from "../components/ServiceStatus";
 
 const caseStatusLabels: Record<string, string> = {
-  active: '进行中',
-  resolved: '已找到',
-  closed: '已关闭',
-}
+  active: "进行中",
+  resolved: "已找到",
+  closed: "已关闭",
+};
 
 export function DashboardPage() {
-  const { token, user } = useAuth()
-  const isCommander = user?.global_capabilities.includes('commander') ?? false
-  const [cases, setCases] = useState<CaseListItem[]>([])
-  const [details, setDetails] = useState<CaseDetail[]>([])
-  const [pendingIntakeCases, setPendingIntakeCases] = useState<CommandIntakeCase[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState('')
+  const { token, user } = useAuth();
+  const isCommander = user?.global_capabilities.includes("commander") ?? false;
+  const [cases, setCases] = useState<CaseListItem[]>([]);
+  const [details, setDetails] = useState<CaseDetail[]>([]);
+  const [pendingIntakeCases, setPendingIntakeCases] = useState<
+    CommandIntakeCase[]
+  >([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
 
   const loadDashboard = useCallback(async () => {
-    if (!token) return
-    setIsLoading(true)
-    setError('')
+    if (!token) return;
+    setIsLoading(true);
+    setError("");
     try {
       const [items, intakeCases] = await Promise.all([
         listCases(token),
         isCommander ? listCommandIntake(token) : Promise.resolve([]),
-      ])
+      ]);
       const settledDetails = await Promise.allSettled(
         items.slice(0, 20).map((item) => getCase(token, item.id)),
-      )
+      );
       const loaded = settledDetails.flatMap((result) =>
-        result.status === 'fulfilled' ? [result.value] : [],
-      )
+        result.status === "fulfilled" ? [result.value] : [],
+      );
 
-      setCases(items)
-      setDetails(loaded)
-      setPendingIntakeCases(intakeCases)
+      setCases(items);
+      setDetails(loaded);
+      setPendingIntakeCases(intakeCases);
       if (loaded.length !== items.length) {
-        setError('部分案件详情暂时不可用，统计数据可能不完整。')
+        setError("部分案件详情暂时不可用，统计数据可能不完整。");
       }
     } catch (cause) {
-      setCases([])
-      setDetails([])
-      setPendingIntakeCases([])
-      setError(cause instanceof Error ? cause.message : '无法连接案件服务。')
+      setCases([]);
+      setDetails([]);
+      setPendingIntakeCases([]);
+      setError(cause instanceof Error ? cause.message : "无法连接案件服务。");
     } finally {
-      setIsLoading(false)
+      setIsLoading(false);
     }
-  }, [isCommander, token])
+  }, [isCommander, token]);
 
   useEffect(() => {
-    void loadDashboard()
-  }, [loadDashboard])
+    void loadDashboard();
+  }, [loadDashboard]);
 
   const pendingClues = useMemo(
-    () => details.flatMap((item) => item.clues).filter((clue) => clue.status === 'pending_review').length,
+    () =>
+      details
+        .flatMap((item) => item.clues)
+        .filter((clue) => clue.status === "pending_review").length,
     [details],
-  )
-  const activeCases = cases.filter((item) => item.status === 'active').length
-  const confirmedClues = details.flatMap((item) => item.clues).filter((clue) => clue.status === 'confirmed').length
-  const statusRecordCount = cases.length + pendingIntakeCases.length
-  const emptyState = user?.account_type === 'learner'
-    ? {
-        title: '新人账号暂未获得案件权限',
-        description: '当前后端只会返回你作为案件成员可访问的案件；学习模块尚未提供接口。',
-      }
-    : user?.global_capabilities.includes('admin')
+  );
+  const activeCases = cases.filter((item) => item.status === "active").length;
+  const confirmedClues = details
+    .flatMap((item) => item.clues)
+    .filter((clue) => clue.status === "confirmed").length;
+  const statusRecordCount = cases.length + pendingIntakeCases.length;
+  const emptyState =
+    user?.account_type === "learner"
       ? {
-          title: '管理员账号不自动拥有案件权限',
-          description: '管理员需要先被授予具体案件成员关系，才能查看案件内容。',
+          title: "新人账号暂未获得案件权限",
+          description:
+            "当前后端只会返回你作为案件成员可访问的案件；学习模块尚未提供接口。",
         }
-      : {
-          title: '当前没有可访问案件',
-          description: '创建案件或由案件成员邀请后，案件会显示在这里。',
-        }
+      : user?.global_capabilities.includes("admin")
+        ? {
+            title: "管理员账号不自动拥有案件权限",
+            description:
+              "管理员需要先被授予具体案件成员关系，才能查看案件内容。",
+          }
+        : {
+            title: "当前没有可访问案件",
+            description: "创建案件或由案件成员邀请后，案件会显示在这里。",
+          };
 
   const metrics = [
-    { label: '活动案件', value: activeCases, icon: RadioTower, iconClass: 'bg-red-50 text-red-700' },
-    ...(isCommander ? [{ label: '待受理案件', value: pendingIntakeCases.length, icon: RadioTower, iconClass: 'bg-violet-50 text-violet-700' }] : []),
-    { label: '待审核线索', value: pendingClues, icon: FileSearch, iconClass: 'bg-amber-50 text-amber-700' },
-    { label: '已确认线索', value: confirmedClues, icon: ClipboardCheck, iconClass: 'bg-blue-50 text-blue-700' },
-    { label: '可访问案件', value: cases.length, icon: UsersRound, iconClass: 'bg-emerald-50 text-emerald-700' },
-  ]
+    {
+      label: "活动案件",
+      value: activeCases,
+      icon: RadioTower,
+      iconClass: "bg-red-50 text-red-700",
+    },
+    ...(isCommander
+      ? [
+          {
+            label: "待受理案件",
+            value: pendingIntakeCases.length,
+            icon: RadioTower,
+            iconClass: "bg-violet-50 text-violet-700",
+          },
+        ]
+      : []),
+    {
+      label: "待审核线索",
+      value: pendingClues,
+      icon: FileSearch,
+      iconClass: "bg-amber-50 text-amber-700",
+    },
+    {
+      label: "已确认线索",
+      value: confirmedClues,
+      icon: ClipboardCheck,
+      iconClass: "bg-blue-50 text-blue-700",
+    },
+    {
+      label: "可访问案件",
+      value: cases.length,
+      icon: UsersRound,
+      iconClass: "bg-emerald-50 text-emerald-700",
+    },
+  ];
 
   return (
     <div className="mx-auto w-full max-w-7xl px-4 py-7 sm:px-6 lg:px-10 lg:py-10">
       <header className="mb-7 flex min-h-14 flex-col items-start justify-between gap-3 sm:flex-row sm:items-end">
         <div>
-          <span className="mb-1 block text-xs font-semibold text-slate-500">{user?.display_name}</span>
-          <h1 className="m-0 text-2xl font-bold text-slate-950 lg:text-3xl">行动总览</h1>
+          <span className="mb-1 block text-xs font-semibold text-slate-500">
+            {user?.display_name}
+          </span>
+          <h1 className="m-0 text-2xl font-bold text-slate-950 lg:text-3xl">
+            行动总览
+          </h1>
         </div>
         <div className="flex items-center gap-2">
           <Button
@@ -110,70 +163,127 @@ export function DashboardPage() {
       </header>
 
       {error && !isLoading && cases.length > 0 && (
-        <div className="mb-5 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800" role="status">
+        <div
+          className="mb-5 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800"
+          role="status"
+        >
           {error}
         </div>
       )}
 
       {isLoading ? (
-        <section className="border-y border-slate-200 bg-white" aria-label="正在加载行动总览">
+        <section
+          className="border-y border-slate-200 bg-white"
+          aria-label="正在加载行动总览"
+        >
           <LoadingState label="正在加载案件和线索统计" />
         </section>
       ) : error && cases.length === 0 ? (
-        <section className="border-y border-slate-200 bg-white" aria-label="行动总览加载失败">
+        <section
+          className="border-y border-slate-200 bg-white"
+          aria-label="行动总览加载失败"
+        >
           <ErrorState message={error} onRetry={() => void loadDashboard()} />
         </section>
       ) : (
         <>
-      <section className="mb-7 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 lg:gap-3" aria-label="行动指标">
-        {metrics.map(({ label, value, icon: Icon, iconClass }) => (
-          <Card key={label} className="min-h-24 rounded-md! border border-slate-200 shadow-none">
-            <Card.Content className="flex h-full flex-row! items-center! gap-3 p-4">
-              <span className={`grid size-10 shrink-0 place-items-center rounded-md ${iconClass}`} aria-hidden="true">
-                <Icon size={19} />
-              </span>
-              <div className="min-w-0">
-                <span className="block whitespace-nowrap text-xs text-slate-500">{label}</span>
-                <strong className="mt-1 block text-2xl leading-none text-slate-950">{value}</strong>
-              </div>
-            </Card.Content>
-          </Card>
-        ))}
-      </section>
+          <section
+            className="mb-7 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 lg:gap-3"
+            aria-label="行动指标"
+          >
+            {metrics.map(({ label, value, icon: Icon, iconClass }) => (
+              <Card
+                key={label}
+                className="min-h-24 rounded-md! border border-slate-200 shadow-none"
+              >
+                <Card.Content className="flex h-full flex-row! items-center! gap-3 p-4">
+                  <span
+                    className={`grid size-10 shrink-0 place-items-center rounded-md ${iconClass}`}
+                    aria-hidden="true"
+                  >
+                    <Icon size={19} />
+                  </span>
+                  <div className="min-w-0">
+                    <span className="block whitespace-nowrap text-xs text-slate-500">
+                      {label}
+                    </span>
+                    <strong className="mt-1 block text-2xl leading-none text-slate-950">
+                      {value}
+                    </strong>
+                  </div>
+                </Card.Content>
+              </Card>
+            ))}
+          </section>
 
-      <section className="overflow-hidden border-y border-slate-200 bg-white" aria-labelledby="case-status-title">
-        <header className="flex min-h-18 items-center justify-between gap-5 border-b border-slate-200 px-5 py-4">
-          <div>
-            <span className="mb-0.5 block text-xs font-semibold text-slate-500">实时状态</span>
-            <h2 id="case-status-title" className="m-0 text-base font-bold text-slate-950">案件态势</h2>
-          </div>
-          <Chip size="sm" variant="soft">
-            <Chip.Label>{statusRecordCount} 条记录</Chip.Label>
-          </Chip>
-        </header>
-        {statusRecordCount === 0 ? (
-          <EmptyState icon={RadioTower} {...emptyState} />
-        ) : (
-          <div className="divide-y divide-slate-100">
-            {pendingIntakeCases.map((item) => (
-              <div key={item.id} className="grid gap-2 bg-violet-50/50 px-5 py-3 sm:grid-cols-[140px_minmax(0,1fr)_auto] sm:items-center">
-                <strong className="text-sm text-slate-950">{item.case_code}</strong>
-                <span className="text-sm text-slate-600">地区：{item.area_hint ?? '待补充'} · 走失时间：{item.last_seen_at ?? '待补充'} · 老人年龄：{item.elder_age == null ? '待补充' : `${item.elder_age} 岁`}</span>
-                <Chip size="sm" variant="soft"><Chip.Label>待受理</Chip.Label></Chip>
+          <section
+            className="overflow-hidden border-y border-slate-200 bg-white"
+            aria-labelledby="case-status-title"
+          >
+            <header className="flex min-h-18 items-center justify-between gap-5 border-b border-slate-200 px-5 py-4">
+              <div>
+                <span className="mb-0.5 block text-xs font-semibold text-slate-500">
+                  实时状态
+                </span>
+                <h2
+                  id="case-status-title"
+                  className="m-0 text-base font-bold text-slate-950"
+                >
+                  案件态势
+                </h2>
               </div>
-            ))}
-            {cases.slice(0, 6).map((item) => (
-              <div key={item.id} className="grid gap-2 px-5 py-3 sm:grid-cols-[140px_minmax(0,1fr)_auto] sm:items-center">
-                <strong className="text-sm text-slate-950">{item.case_code}</strong>
-                <span className="truncate text-sm text-slate-600">{item.display_name} · {item.last_seen_location ?? '地点待补充'}</span>
-                <Chip size="sm" variant="soft"><Chip.Label>{caseStatusLabels[item.status] ?? item.status}</Chip.Label></Chip>
+              <Chip size="sm" variant="soft">
+                <Chip.Label>{statusRecordCount} 条记录</Chip.Label>
+              </Chip>
+            </header>
+            {statusRecordCount === 0 ? (
+              <EmptyState icon={RadioTower} {...emptyState} />
+            ) : (
+              <div className="divide-y divide-slate-100">
+                {pendingIntakeCases.map((item) => (
+                  <div
+                    key={item.id}
+                    className="grid gap-2 bg-violet-50/50 px-5 py-3 sm:grid-cols-[140px_minmax(0,1fr)_auto] sm:items-center"
+                  >
+                    <strong className="text-sm text-slate-950">
+                      {item.case_code}
+                    </strong>
+                    <span className="text-sm text-slate-600">
+                      地区：{item.area_hint ?? "待补充"} · 走失时间：
+                      {item.last_seen_at ?? "待补充"} · 老人年龄：
+                      {item.elder_age == null
+                        ? "待补充"
+                        : `${item.elder_age} 岁`}
+                    </span>
+                    <Chip size="sm" variant="soft">
+                      <Chip.Label>待受理</Chip.Label>
+                    </Chip>
+                  </div>
+                ))}
+                {cases.slice(0, 6).map((item) => (
+                  <div
+                    key={item.id}
+                    className="grid gap-2 px-5 py-3 sm:grid-cols-[140px_minmax(0,1fr)_auto] sm:items-center"
+                  >
+                    <strong className="text-sm text-slate-950">
+                      {item.case_code}
+                    </strong>
+                    <span className="truncate text-sm text-slate-600">
+                      {item.display_name} ·{" "}
+                      {item.last_seen_location ?? "地点待补充"}
+                    </span>
+                    <Chip size="sm" variant="soft">
+                      <Chip.Label>
+                        {caseStatusLabels[item.status] ?? item.status}
+                      </Chip.Label>
+                    </Chip>
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
-        )}
-      </section>
+            )}
+          </section>
         </>
       )}
     </div>
-  )
+  );
 }

--- a/frontend/src/pages/FamilyIntakeForm.test.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.test.tsx
@@ -1,271 +1,445 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { IntakeDraft, IntakeSession, SubmitIntakeAnswerResponse } from '../api/intake'
-import { ApiClientError } from '../api/client'
-import { FamilyIntakeForm } from './FamilyIntakeForm'
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  IntakeDraft,
+  IntakeSession,
+  SubmitIntakeAnswerResponse,
+} from "../api/intake";
+import { ApiClientError } from "../api/client";
+import { FamilyIntakeForm } from "./FamilyIntakeForm";
 
 const mocked = vi.hoisted(() => ({
   confirmIntakeSession: vi.fn(),
   createIntakeSession: vi.fn(),
   getIntakeDraft: vi.fn(),
   submitIntakeAnswer: vi.fn(),
-}))
+}));
 
-vi.mock('../auth/useAuth', () => ({
-  useAuth: () => ({ token: 'family-session', user: { id: 'family-1' } }),
-}))
+vi.mock("../auth/useAuth", () => ({
+  useAuth: () => ({ token: "family-session", user: { id: "family-1" } }),
+}));
 
-vi.mock('../api/intake', () => ({
-  confirmIntakeSession: (...args: unknown[]) => mocked.confirmIntakeSession(...args),
-  createIntakeSession: (...args: unknown[]) => mocked.createIntakeSession(...args),
+vi.mock("../api/intake", () => ({
+  confirmIntakeSession: (...args: unknown[]) =>
+    mocked.confirmIntakeSession(...args),
+  createIntakeSession: (...args: unknown[]) =>
+    mocked.createIntakeSession(...args),
   getIntakeDraft: (...args: unknown[]) => mocked.getIntakeDraft(...args),
-  submitIntakeAnswer: (...args: unknown[]) => mocked.submitIntakeAnswer(...args),
-}))
+  submitIntakeAnswer: (...args: unknown[]) =>
+    mocked.submitIntakeAnswer(...args),
+}));
 
 const collectingSession: IntakeSession = {
-  id: 'intake-1',
-  status: 'collecting',
-  missing_fields: ['last_seen'],
-  phase: 'phase_one',
-  completed_phase_one_fields: ['basic_information'],
-  missing_phase_one_fields: ['last_seen'],
+  id: "intake-1",
+  status: "collecting",
+  missing_fields: ["last_seen"],
+  phase: "phase_one",
+  completed_phase_one_fields: ["basic_information"],
+  missing_phase_one_fields: ["last_seen"],
   phase_transition_ready: false,
-  next_question: { field: 'last_seen', prompt: '请描述最后出现的地点和时间', required: true },
-  guidance_mode: 'rule_based',
-  privacy_notice: '仅用于本次问询。',
-}
+  next_question: {
+    field: "last_seen",
+    prompt: "请描述最后出现的地点和时间",
+    required: true,
+  },
+  guidance_mode: "rule_based",
+  privacy_notice: "仅用于本次问询。",
+};
 
 const readySession: IntakeSession = {
   ...collectingSession,
-  status: 'ready_for_confirmation',
-  completed_phase_one_fields: ['basic_information', 'health_status', 'behavior_habits', 'last_seen'],
+  status: "ready_for_confirmation",
+  completed_phase_one_fields: [
+    "basic_information",
+    "health_status",
+    "behavior_habits",
+    "last_seen",
+  ],
   missing_phase_one_fields: [],
   phase_transition_ready: true,
   next_question: null,
-}
+};
 
 const basicInformationSession: IntakeSession = {
   ...collectingSession,
   completed_phase_one_fields: [],
-  missing_phase_one_fields: ['basic_information', 'last_seen'],
+  missing_phase_one_fields: ["basic_information", "last_seen"],
   next_question: {
-    field: 'basic_information',
-    prompt: '请填写可供家属核对的基础信息。',
+    field: "basic_information",
+    prompt: "请填写可供家属核对的基础信息。",
     required: true,
   },
-}
+};
 
 const afterBasicInformationSession: IntakeSession = {
   ...basicInformationSession,
-  completed_phase_one_fields: ['basic_information'],
-  missing_phase_one_fields: ['last_seen'],
+  completed_phase_one_fields: ["basic_information"],
+  missing_phase_one_fields: ["last_seen"],
   next_question: {
-    field: 'health_status',
-    prompt: '请填写健康情况。',
+    field: "health_status",
+    prompt: "请填写健康情况。",
     required: false,
   },
-}
+};
 
 const profileDraft: IntakeDraft = {
-  status: 'draft',
-  source_scope: 'family_provided intake answers from this session only',
-  generated_at: '2026-07-25T08:00:00Z',
+  status: "draft",
+  source_scope: "family_provided intake answers from this session only",
+  generated_at: "2026-07-25T08:00:00Z",
   requires_human_confirmation: true,
   profile: {
-    physical_description: '佩戴眼镜，穿蓝色外套。',
+    physical_description: "佩戴眼镜，穿蓝色外套。",
     clothing_description: null,
-    health_notes: '行动较慢，需要留意。',
-    mobility_notes: '行动较慢，需要留意。',
+    health_notes: "行动较慢，需要留意。",
+    mobility_notes: "行动较慢，需要留意。",
     transportation_ability: null,
     frequent_locations: null,
-    last_seen_information: '模拟社区北门',
+    last_seen_information: "模拟社区北门",
     behavior_habits: null,
     suspicious_motive: null,
   },
   field_metadata: [
-    { field: 'physical_description', source_field: 'basic_information', source: 'family_provided', status: 'draft', generated_at: '2026-07-25T08:00:00Z' },
-    { field: 'health_notes', source_field: 'health_status', source: 'family_provided', status: 'draft', generated_at: '2026-07-25T08:01:00Z' },
-    { field: 'last_seen_information', source_field: 'last_seen', source: 'family_provided', status: 'draft', generated_at: '2026-07-25T08:02:00Z' },
+    {
+      field: "physical_description",
+      source_field: "basic_information",
+      source: "family_provided",
+      status: "draft",
+      generated_at: "2026-07-25T08:00:00Z",
+    },
+    {
+      field: "health_notes",
+      source_field: "health_status",
+      source: "family_provided",
+      status: "draft",
+      generated_at: "2026-07-25T08:01:00Z",
+    },
+    {
+      field: "last_seen_information",
+      source_field: "last_seen",
+      source: "family_provided",
+      status: "draft",
+      generated_at: "2026-07-25T08:02:00Z",
+    },
   ],
   missing_fields: [],
   assessments: [],
   confirmation_blocked_reasons: [],
   direction_hypotheses: [],
-}
+};
 
 function answerResponse(session: IntakeSession): SubmitIntakeAnswerResponse {
-  const { id: session_id, ...sessionUpdate } = session
+  const { id: session_id, ...sessionUpdate } = session;
   return {
     ...sessionUpdate,
     session_id,
-    raw_answer: '模拟社区北门',
-    candidate_fields: [{
-      field: 'last_seen',
-      value: '模拟社区北门',
-      source: 'family_provided',
-      status: 'draft',
-      generated_at: '2026-07-25T08:02:00Z',
-      model: null,
-      template_version: null,
-      source_text: '模拟社区北门',
-      confidence: null,
-    }],
+    raw_answer: "模拟社区北门",
+    candidate_fields: [
+      {
+        field: "last_seen",
+        value: "模拟社区北门",
+        source: "family_provided",
+        status: "draft",
+        generated_at: "2026-07-25T08:02:00Z",
+        model: null,
+        template_version: null,
+        source_text: "模拟社区北门",
+        confidence: null,
+      },
+    ],
     assessments: [],
-  }
+  };
 }
 
-describe('FamilyIntakeForm', () => {
+describe("FamilyIntakeForm", () => {
   beforeEach(() => {
-    window.sessionStorage.clear()
-    vi.clearAllMocks()
-  })
+    window.sessionStorage.clear();
+    vi.clearAllMocks();
+  });
 
-  it('restores the current-tab draft and does not create a second intake session', async () => {
-    window.sessionStorage.setItem('angui:intake-tab-draft:family-1', JSON.stringify({ session: collectingSession, answer: '尚未提交的地点描述' }))
+  it("restores the current-tab draft and does not create a second intake session", async () => {
+    window.sessionStorage.setItem(
+      "angui:intake-tab-draft:family-1",
+      JSON.stringify({
+        session: collectingSession,
+        answer: "尚未提交的地点描述",
+      }),
+    );
 
-    render(<FamilyIntakeForm onCancel={vi.fn()} onConfirmed={vi.fn().mockResolvedValue(undefined)} />)
+    render(
+      <FamilyIntakeForm
+        onCancel={vi.fn()}
+        onConfirmed={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
 
-    expect(await screen.findByRole('heading', { name: '最后出现情况' })).toBeInTheDocument()
-    expect(screen.getByDisplayValue('尚未提交的地点描述')).toBeInTheDocument()
-    expect(mocked.createIntakeSession).not.toHaveBeenCalled()
-  })
+    expect(
+      await screen.findByRole("heading", { name: "最后出现情况" }),
+    ).toBeInTheDocument();
+    expect(screen.getByDisplayValue("尚未提交的地点描述")).toBeInTheDocument();
+    expect(mocked.createIntakeSession).not.toHaveBeenCalled();
+  });
 
-  it('discards a malformed stored session before rendering the intake flow', async () => {
-    const malformedSession = { ...collectingSession, missing_phase_one_fields: undefined }
-    window.sessionStorage.setItem('angui:intake-tab-draft:family-1', JSON.stringify({ session: malformedSession, answer: 'stale answer' }))
+  it("discards a malformed stored session before rendering the intake flow", async () => {
+    const malformedSession = {
+      ...collectingSession,
+      missing_phase_one_fields: undefined,
+    };
+    window.sessionStorage.setItem(
+      "angui:intake-tab-draft:family-1",
+      JSON.stringify({ session: malformedSession, answer: "stale answer" }),
+    );
 
-    render(<FamilyIntakeForm onCancel={vi.fn()} onConfirmed={vi.fn().mockResolvedValue(undefined)} />)
+    render(
+      <FamilyIntakeForm
+        onCancel={vi.fn()}
+        onConfirmed={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
 
-    expect(await screen.findByRole('button', { name: '开始问询' })).toBeInTheDocument()
-    expect(window.sessionStorage.getItem('angui:intake-tab-draft:family-1')).toBeNull()
-  })
+    expect(
+      await screen.findByRole("button", { name: "开始问询" }),
+    ).toBeInTheDocument();
+    expect(
+      window.sessionStorage.getItem("angui:intake-tab-draft:family-1"),
+    ).toBeNull();
+  });
 
   it.each([
-    ['an invalid status', { ...collectingSession, status: 'stale' }],
-    ['an invalid phase', { ...collectingSession, phase: 'unknown_phase' }],
-    ['a malformed next question', { ...collectingSession, next_question: { field: 'last_seen', prompt: 'Missing required flag' } }],
-  ])('discards cached sessions with %s', async (_description, malformedSession) => {
-    window.sessionStorage.setItem('angui:intake-tab-draft:family-1', JSON.stringify({ session: malformedSession, answer: '' }))
-
-    render(<FamilyIntakeForm onCancel={vi.fn()} onConfirmed={vi.fn().mockResolvedValue(undefined)} />)
-
-    expect(await screen.findByRole('button', { name: '开始问询' })).toBeInTheDocument()
-    expect(window.sessionStorage.getItem('angui:intake-tab-draft:family-1')).toBeNull()
-  })
-
-  it.each([403, 404])('clears a %i unavailable ready-for-confirmation session', async (status) => {
-    window.sessionStorage.setItem('angui:intake-tab-draft:family-1', JSON.stringify({ session: readySession, answer: '' }))
-    const message = `Draft is no longer available (${status})`
-    mocked.getIntakeDraft.mockRejectedValue(new ApiClientError(status, status === 403 ? 'forbidden' : 'not_found', message))
-
-    render(<FamilyIntakeForm onCancel={vi.fn()} onConfirmed={vi.fn().mockResolvedValue(undefined)} />)
-
-    expect(await screen.findByRole('button', { name: '开始问询' })).toBeInTheDocument()
-    expect(window.sessionStorage.getItem('angui:intake-tab-draft:family-1')).toBeNull()
-    expect(screen.getByText(message)).toBeInTheDocument()
-  })
-
-  it('submits basic information from labelled fields instead of a single free-text box', async () => {
-    mocked.createIntakeSession.mockResolvedValue(basicInformationSession)
-    mocked.submitIntakeAnswer.mockResolvedValue(answerResponse(afterBasicInformationSession))
-
-    render(<FamilyIntakeForm onCancel={vi.fn()} onConfirmed={vi.fn().mockResolvedValue(undefined)} />)
-
-    fireEvent.click(screen.getByRole('button', { name: '开始问询' }))
-    await screen.findByRole('heading', { name: '基本信息' })
-    fireEvent.change(screen.getByRole('textbox', { name: '姓名或称呼' }), { target: { value: '王女士' } })
-    fireEvent.change(screen.getByRole('combobox', { name: '性别' }), { target: { value: '女' } })
-    fireEvent.change(screen.getByRole('spinbutton', { name: '年龄' }), { target: { value: '0' } })
-    fireEvent.change(screen.getByRole('spinbutton', { name: '身高（厘米）' }), { target: { value: '158' } })
-    fireEvent.change(screen.getByRole('textbox', { name: '便于识别的外观特征' }), { target: { value: '短发，戴眼镜' } })
-    fireEvent.click(screen.getByRole('button', { name: '保存并继续' }))
-
-    await waitFor(() => expect(mocked.submitIntakeAnswer).toHaveBeenCalledWith(
-      'family-session',
-      'intake-1',
+    ["an invalid status", { ...collectingSession, status: "stale" }],
+    ["an invalid phase", { ...collectingSession, phase: "unknown_phase" }],
+    [
+      "a malformed next question",
       {
-        field: 'basic_information',
-        answer: '姓名或称呼：王女士\n性别：女\n年龄：0 岁\n身高：158 厘米\n外观特征：短发，戴眼镜',
-        replace: false,
+        ...collectingSession,
+        next_question: { field: "last_seen", prompt: "Missing required flag" },
       },
-    ))
-  })
+    ],
+  ])(
+    "discards cached sessions with %s",
+    async (_description, malformedSession) => {
+      window.sessionStorage.setItem(
+        "angui:intake-tab-draft:family-1",
+        JSON.stringify({ session: malformedSession, answer: "" }),
+      );
 
-  it('omits a blank age from the structured basic-information answer', async () => {
-    mocked.createIntakeSession.mockResolvedValue(basicInformationSession)
-    mocked.submitIntakeAnswer.mockResolvedValue(answerResponse(afterBasicInformationSession))
+      render(
+        <FamilyIntakeForm
+          onCancel={vi.fn()}
+          onConfirmed={vi.fn().mockResolvedValue(undefined)}
+        />,
+      );
 
-    render(<FamilyIntakeForm onCancel={vi.fn()} onConfirmed={vi.fn().mockResolvedValue(undefined)} />)
+      expect(
+        await screen.findByRole("button", { name: "开始问询" }),
+      ).toBeInTheDocument();
+      expect(
+        window.sessionStorage.getItem("angui:intake-tab-draft:family-1"),
+      ).toBeNull();
+    },
+  );
 
-    fireEvent.click(screen.getByRole('button', { name: '开始问询' }))
-    await screen.findByRole('heading', { name: '基本信息' })
-    fireEvent.change(screen.getByRole('textbox', { name: '姓名或称呼' }), { target: { value: '王女士' } })
-    fireEvent.change(screen.getByRole('spinbutton', { name: '年龄' }), { target: { value: '   ' } })
-    fireEvent.click(screen.getByRole('button', { name: '保存并继续' }))
+  it.each([403, 404])(
+    "clears a %i unavailable ready-for-confirmation session",
+    async (status) => {
+      window.sessionStorage.setItem(
+        "angui:intake-tab-draft:family-1",
+        JSON.stringify({ session: readySession, answer: "" }),
+      );
+      const message = `Draft is no longer available (${status})`;
+      mocked.getIntakeDraft.mockRejectedValue(
+        new ApiClientError(
+          status,
+          status === 403 ? "forbidden" : "not_found",
+          message,
+        ),
+      );
 
-    await waitFor(() => expect(mocked.submitIntakeAnswer).toHaveBeenCalledWith(
-      'family-session',
-      'intake-1',
-      {
-        field: 'basic_information',
-        answer: '姓名或称呼：王女士',
-        replace: false,
-      },
-    ))
-  })
+      render(
+        <FamilyIntakeForm
+          onCancel={vi.fn()}
+          onConfirmed={vi.fn().mockResolvedValue(undefined)}
+        />,
+      );
 
-  it('shows field-level provenance and sends a replacement when the family corrects a draft answer', async () => {
-    mocked.createIntakeSession.mockResolvedValue(collectingSession)
-    mocked.submitIntakeAnswer.mockResolvedValue(answerResponse(readySession))
-    mocked.getIntakeDraft.mockResolvedValue(profileDraft)
+      expect(
+        await screen.findByRole("button", { name: "开始问询" }),
+      ).toBeInTheDocument();
+      expect(
+        window.sessionStorage.getItem("angui:intake-tab-draft:family-1"),
+      ).toBeNull();
+      expect(screen.getByText(message)).toBeInTheDocument();
+    },
+  );
 
-    render(<FamilyIntakeForm onCancel={vi.fn()} onConfirmed={vi.fn().mockResolvedValue(undefined)} />)
+  it("submits basic information from labelled fields instead of a single free-text box", async () => {
+    mocked.createIntakeSession.mockResolvedValue(basicInformationSession);
+    mocked.submitIntakeAnswer.mockResolvedValue(
+      answerResponse(afterBasicInformationSession),
+    );
 
-    fireEvent.click(screen.getByRole('button', { name: '开始问询' }))
-    await screen.findByRole('heading', { name: '最后出现情况' })
-    fireEvent.change(screen.getByRole('textbox', { name: /请描述最后出现的地点和时间/ }), { target: { value: '模拟社区北门' } })
-    fireEvent.click(screen.getByRole('button', { name: '保存并继续' }))
+    render(
+      <FamilyIntakeForm
+        onCancel={vi.fn()}
+        onConfirmed={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
 
-    expect(await screen.findByText('问询整理出的画像草稿')).toBeInTheDocument()
-    expect(mocked.getIntakeDraft).toHaveBeenCalledWith('family-session', 'intake-1')
-    expect(screen.getByText('来源：家属提供 · 健康情况')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "开始问询" }));
+    await screen.findByRole("heading", { name: "基本信息" });
+    fireEvent.change(screen.getByRole("textbox", { name: "姓名或称呼" }), {
+      target: { value: "王女士" },
+    });
+    fireEvent.change(screen.getByRole("combobox", { name: "性别" }), {
+      target: { value: "女" },
+    });
+    fireEvent.change(screen.getByRole("spinbutton", { name: "年龄" }), {
+      target: { value: "0" },
+    });
+    fireEvent.change(screen.getByRole("spinbutton", { name: "身高（厘米）" }), {
+      target: { value: "158" },
+    });
+    fireEvent.change(
+      screen.getByRole("textbox", { name: "便于识别的外观特征" }),
+      { target: { value: "短发，戴眼镜" } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "保存并继续" }));
 
-    fireEvent.click(screen.getByRole('button', { name: '修改健康情况' }))
-    const editInput = screen.getByRole('textbox', { name: '修订后的家属回答' })
-    fireEvent.change(editInput, { target: { value: '家属已核对：行动不受限。' } })
-    fireEvent.click(screen.getByRole('button', { name: '保存修订并刷新草稿' }))
+    await waitFor(() =>
+      expect(mocked.submitIntakeAnswer).toHaveBeenCalledWith(
+        "family-session",
+        "intake-1",
+        {
+          field: "basic_information",
+          answer:
+            "姓名或称呼：王女士\n性别：女\n年龄：0 岁\n身高：158 厘米\n外观特征：短发，戴眼镜",
+          replace: false,
+        },
+      ),
+    );
+  });
 
-    await waitFor(() => expect(mocked.submitIntakeAnswer).toHaveBeenLastCalledWith(
-      'family-session',
-      'intake-1',
-      { field: 'health_status', answer: '家属已核对：行动不受限。', replace: true },
-    ))
-  })
+  it("omits a blank age from the structured basic-information answer", async () => {
+    mocked.createIntakeSession.mockResolvedValue(basicInformationSession);
+    mocked.submitIntakeAnswer.mockResolvedValue(
+      answerResponse(afterBasicInformationSession),
+    );
 
-  it('requires an explicit second confirmation before it creates a case', async () => {
-    window.sessionStorage.setItem('angui:intake-tab-draft:family-1', JSON.stringify({ session: readySession, answer: '' }))
-    mocked.getIntakeDraft.mockResolvedValue(profileDraft)
-    mocked.confirmIntakeSession.mockResolvedValue({ case_id: 'case-1', case_code: 'AG-0001', status: 'active', confirmation_status: 'human_confirmed', confirmed_at: '2026-07-25T08:10:00Z' })
-    const onConfirmed = vi.fn().mockResolvedValue(undefined)
+    render(
+      <FamilyIntakeForm
+        onCancel={vi.fn()}
+        onConfirmed={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
 
-    render(<FamilyIntakeForm onCancel={vi.fn()} onConfirmed={onConfirmed} />)
+    fireEvent.click(screen.getByRole("button", { name: "开始问询" }));
+    await screen.findByRole("heading", { name: "基本信息" });
+    fireEvent.change(screen.getByRole("textbox", { name: "姓名或称呼" }), {
+      target: { value: "王女士" },
+    });
+    fireEvent.change(screen.getByRole("spinbutton", { name: "年龄" }), {
+      target: { value: "   " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "保存并继续" }));
 
-    await screen.findByText('确认后写入案件的资料')
-    fireEvent.change(screen.getByRole('textbox', { name: '姓名或称呼' }), { target: { value: '模拟老人' } })
-    fireEvent.click(screen.getByRole('button', { name: '人工确认并创建案件' }))
+    await waitFor(() =>
+      expect(mocked.submitIntakeAnswer).toHaveBeenCalledWith(
+        "family-session",
+        "intake-1",
+        {
+          field: "basic_information",
+          answer: "姓名或称呼：王女士",
+          replace: false,
+        },
+      ),
+    );
+  });
 
-    expect(mocked.confirmIntakeSession).not.toHaveBeenCalled()
-    const confirmationDialog = screen.getByRole('alertdialog')
-    expect(confirmationDialog).toHaveFocus()
-    expect(screen.getByRole('button', { name: '请完成二次确认' })).toBeDisabled()
+  it("shows field-level provenance and sends a replacement when the family corrects a draft answer", async () => {
+    mocked.createIntakeSession.mockResolvedValue(collectingSession);
+    mocked.submitIntakeAnswer.mockResolvedValue(answerResponse(readySession));
+    mocked.getIntakeDraft.mockResolvedValue(profileDraft);
 
-    fireEvent.click(screen.getByRole('button', { name: '确认并创建案件' }))
-    await waitFor(() => expect(mocked.confirmIntakeSession).toHaveBeenCalledTimes(1))
+    render(
+      <FamilyIntakeForm
+        onCancel={vi.fn()}
+        onConfirmed={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "开始问询" }));
+    await screen.findByRole("heading", { name: "最后出现情况" });
+    fireEvent.change(
+      screen.getByRole("textbox", { name: /请描述最后出现的地点和时间/ }),
+      { target: { value: "模拟社区北门" } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "保存并继续" }));
+
+    expect(await screen.findByText("问询整理出的画像草稿")).toBeInTheDocument();
+    expect(mocked.getIntakeDraft).toHaveBeenCalledWith(
+      "family-session",
+      "intake-1",
+    );
+    expect(screen.getByText("来源：家属提供 · 健康情况")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "修改健康情况" }));
+    const editInput = screen.getByRole("textbox", { name: "修订后的家属回答" });
+    fireEvent.change(editInput, {
+      target: { value: "家属已核对：行动不受限。" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "保存修订并刷新草稿" }));
+
+    await waitFor(() =>
+      expect(mocked.submitIntakeAnswer).toHaveBeenLastCalledWith(
+        "family-session",
+        "intake-1",
+        {
+          field: "health_status",
+          answer: "家属已核对：行动不受限。",
+          replace: true,
+        },
+      ),
+    );
+  });
+
+  it("requires an explicit second confirmation before it creates a case", async () => {
+    window.sessionStorage.setItem(
+      "angui:intake-tab-draft:family-1",
+      JSON.stringify({ session: readySession, answer: "" }),
+    );
+    mocked.getIntakeDraft.mockResolvedValue(profileDraft);
+    mocked.confirmIntakeSession.mockResolvedValue({
+      case_id: "case-1",
+      case_code: "AG-0001",
+      status: "active",
+      confirmation_status: "human_confirmed",
+      confirmed_at: "2026-07-25T08:10:00Z",
+    });
+    const onConfirmed = vi.fn().mockResolvedValue(undefined);
+
+    render(<FamilyIntakeForm onCancel={vi.fn()} onConfirmed={onConfirmed} />);
+
+    await screen.findByText("确认后写入案件的资料");
+    fireEvent.change(screen.getByRole("textbox", { name: "姓名或称呼" }), {
+      target: { value: "模拟老人" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "人工确认并创建案件" }));
+
+    expect(mocked.confirmIntakeSession).not.toHaveBeenCalled();
+    const confirmationDialog = screen.getByRole("alertdialog");
+    expect(confirmationDialog).toHaveFocus();
+    expect(
+      screen.getByRole("button", { name: "请完成二次确认" }),
+    ).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "确认并创建案件" }));
+    await waitFor(() =>
+      expect(mocked.confirmIntakeSession).toHaveBeenCalledTimes(1),
+    );
     expect(mocked.confirmIntakeSession).toHaveBeenCalledWith(
-      'family-session',
-      'intake-1',
+      "family-session",
+      "intake-1",
       expect.objectContaining({ age: null }),
-    )
-    expect(onConfirmed).toHaveBeenCalledWith('case-1', 'AG-0001')
-  })
-})
+    );
+    expect(onConfirmed).toHaveBeenCalledWith("case-1", "AG-0001");
+  });
+});

--- a/frontend/src/pages/FamilyIntakeForm.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.tsx
@@ -1,13 +1,20 @@
-import { Button, Chip, Input, Spinner, TextArea } from '@heroui/react'
-import { AlertTriangle, ArrowLeft, CheckCircle2, CircleHelp, FilePenLine, ShieldCheck } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ApiClientError } from '../api/client'
+import { Button, Chip, Input, Spinner, TextArea } from "@heroui/react";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  CheckCircle2,
+  CircleHelp,
+  FilePenLine,
+  ShieldCheck,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ApiClientError } from "../api/client";
 import {
   confirmIntakeSession,
   createIntakeSession,
   getIntakeDraft,
   submitIntakeAnswer,
-} from '../api/intake'
+} from "../api/intake";
 import type {
   ConfirmedIntakeProfile,
   IntakeAssessment,
@@ -16,346 +23,422 @@ import type {
   IntakeProfileDraftFieldMetadata,
   IntakeSession,
   SubmitIntakeAnswerResponse,
-} from '../api/intake'
-import { useAuth } from '../auth/useAuth'
+} from "../api/intake";
+import { useAuth } from "../auth/useAuth";
 
 const questionLabels: Record<string, string> = {
-  basic_information: '基本信息',
-  health_status: '健康情况',
-  behavior_habits: '行为习惯',
-  last_seen: '最后出现情况',
-  frequent_locations: '常去地点',
-  suspicious_motive: '可疑动机',
-  belongings: '随身物品与衣着',
-  transport_ability: '出行能力',
-  follow_up_clues: '后续线索',
-}
+  basic_information: "基本信息",
+  health_status: "健康情况",
+  behavior_habits: "行为习惯",
+  last_seen: "最后出现情况",
+  frequent_locations: "常去地点",
+  suspicious_motive: "可疑动机",
+  belongings: "随身物品与衣着",
+  transport_ability: "出行能力",
+  follow_up_clues: "后续线索",
+};
 
 const questionReasons: Record<string, string> = {
-  basic_information: '用于区分被寻找的人，后续仍需要家属逐项核对。',
-  health_status: '帮助现场人员理解可能需要的照护与沟通方式。',
-  behavior_habits: '帮助判断可能的行动习惯，不会自动成为正式事实。',
-  last_seen: '用于建立初始的时间和地点线索。',
-  frequent_locations: '可作为待核实的寻找方向，不会直接发布。',
-  suspicious_motive: '仅用于记录家属的待核实判断。',
-  belongings: '便于后续人工比对衣着和随身物品。',
-  transport_ability: '帮助评估可能的行动范围。',
-  follow_up_clues: '记录家属尚待核实的补充信息。',
-}
+  basic_information: "用于区分被寻找的人，后续仍需要家属逐项核对。",
+  health_status: "帮助现场人员理解可能需要的照护与沟通方式。",
+  behavior_habits: "帮助判断可能的行动习惯，不会自动成为正式事实。",
+  last_seen: "用于建立初始的时间和地点线索。",
+  frequent_locations: "可作为待核实的寻找方向，不会直接发布。",
+  suspicious_motive: "仅用于记录家属的待核实判断。",
+  belongings: "便于后续人工比对衣着和随身物品。",
+  transport_ability: "帮助评估可能的行动范围。",
+  follow_up_clues: "记录家属尚待核实的补充信息。",
+};
 
 const blankProfile: ConfirmedIntakeProfile = {
-  display_name: '',
+  display_name: "",
   age: null,
   gender: null,
   physical_description: null,
   clothing_description: null,
   health_notes: null,
   last_seen_at: null,
-  last_seen_location: '',
-}
+  last_seen_location: "",
+};
 
 type StoredIntakeSession = Pick<
   IntakeSession,
-  | 'id'
-  | 'status'
-  | 'missing_fields'
-  | 'phase'
-  | 'completed_phase_one_fields'
-  | 'missing_phase_one_fields'
-  | 'phase_transition_ready'
-  | 'next_question'
-  | 'guidance_mode'
-  | 'privacy_notice'
->
+  | "id"
+  | "status"
+  | "missing_fields"
+  | "phase"
+  | "completed_phase_one_fields"
+  | "missing_phase_one_fields"
+  | "phase_transition_ready"
+  | "next_question"
+  | "guidance_mode"
+  | "privacy_notice"
+>;
 
 interface StoredIntakeState {
-  session: StoredIntakeSession
-  answer: string
-  basicInformation: BasicInformationDraft
+  session: StoredIntakeSession;
+  answer: string;
+  basicInformation: BasicInformationDraft;
 }
 
 interface BasicInformationDraft {
-  name: string
-  gender: string
-  age: string
-  height: string
-  appearance: string
+  name: string;
+  gender: string;
+  age: string;
+  height: string;
+  appearance: string;
 }
 
 const blankBasicInformation: BasicInformationDraft = {
-  name: '',
-  gender: '',
-  age: '',
-  height: '',
-  appearance: '',
-}
+  name: "",
+  gender: "",
+  age: "",
+  height: "",
+  appearance: "",
+};
 
 export function FamilyIntakeForm({
   onCancel,
   onConfirmed,
 }: {
-  onCancel: () => void
-  onConfirmed: (caseId: string, caseCode: string) => Promise<void>
+  onCancel: () => void;
+  onConfirmed: (caseId: string, caseCode: string) => Promise<void>;
 }) {
-  const { token, user } = useAuth()
-  const storageKey = `angui:intake-tab-draft:${user?.id ?? 'anonymous'}`
-  const [session, setSession] = useState<IntakeSession | null>(null)
-  const [draft, setDraft] = useState<IntakeDraft | null>(null)
-  const [answer, setAnswer] = useState('')
-  const [basicInformation, setBasicInformation] = useState<BasicInformationDraft>(blankBasicInformation)
-  const [profile, setProfile] = useState<ConfirmedIntakeProfile>(blankProfile)
-  const [assessments, setAssessments] = useState<IntakeAssessment[]>([])
-  const [editSource, setEditSource] = useState<IntakeProfileDraftFieldMetadata | null>(null)
-  const [editAnswer, setEditAnswer] = useState('')
-  const [confirmReviewOpen, setConfirmReviewOpen] = useState(false)
-  const [busyAction, setBusyAction] = useState<'begin' | 'answer' | 'replace' | 'confirm' | null>(null)
-  const [error, setError] = useState('')
-  const [hasHydrated, setHasHydrated] = useState(false)
-  const confirmDialogRef = useRef<HTMLDivElement>(null)
+  const { token, user } = useAuth();
+  const storageKey = `angui:intake-tab-draft:${user?.id ?? "anonymous"}`;
+  const [session, setSession] = useState<IntakeSession | null>(null);
+  const [draft, setDraft] = useState<IntakeDraft | null>(null);
+  const [answer, setAnswer] = useState("");
+  const [basicInformation, setBasicInformation] =
+    useState<BasicInformationDraft>(blankBasicInformation);
+  const [profile, setProfile] = useState<ConfirmedIntakeProfile>(blankProfile);
+  const [assessments, setAssessments] = useState<IntakeAssessment[]>([]);
+  const [editSource, setEditSource] =
+    useState<IntakeProfileDraftFieldMetadata | null>(null);
+  const [editAnswer, setEditAnswer] = useState("");
+  const [confirmReviewOpen, setConfirmReviewOpen] = useState(false);
+  const [busyAction, setBusyAction] = useState<
+    "begin" | "answer" | "replace" | "confirm" | null
+  >(null);
+  const [error, setError] = useState("");
+  const [hasHydrated, setHasHydrated] = useState(false);
+  const confirmDialogRef = useRef<HTMLDivElement>(null);
 
-  const isBusy = busyAction !== null
-  const displayedAssessments = draft?.assessments ?? assessments
-  const sourceOptions = useMemo(() => uniqueSourceOptions(draft), [draft])
+  const isBusy = busyAction !== null;
+  const displayedAssessments = draft?.assessments ?? assessments;
+  const sourceOptions = useMemo(() => uniqueSourceOptions(draft), [draft]);
 
   useEffect(() => {
-    if (confirmReviewOpen) confirmDialogRef.current?.focus()
-  }, [confirmReviewOpen])
+    if (confirmReviewOpen) confirmDialogRef.current?.focus();
+  }, [confirmReviewOpen]);
 
-  const loadDraft = useCallback(async (
-    sessionId: string,
-    initializeProfile: boolean,
-    basicInformationForProfile: BasicInformationDraft = blankBasicInformation,
-  ) => {
-    if (!token) return null
-    try {
-      const nextDraft = await getIntakeDraft(token, sessionId)
-      setDraft(nextDraft)
-      setAssessments(nextDraft.assessments)
-      if (initializeProfile) setProfile(profileFromDraft(nextDraft, basicInformationForProfile))
-      return nextDraft
-    } catch (cause) {
-      setError(messageFrom(cause))
-      if (cause instanceof ApiClientError && (cause.status === 403 || cause.status === 404)) {
-        clearStoredState(storageKey)
-        setSession(null)
-        setDraft(null)
-        setAssessments([])
-        setAnswer('')
-        setBasicInformation(blankBasicInformation)
-        setProfile(blankProfile)
-        setEditSource(null)
-        setEditAnswer('')
-        setConfirmReviewOpen(false)
+  const loadDraft = useCallback(
+    async (
+      sessionId: string,
+      initializeProfile: boolean,
+      basicInformationForProfile: BasicInformationDraft = blankBasicInformation,
+    ) => {
+      if (!token) return null;
+      try {
+        const nextDraft = await getIntakeDraft(token, sessionId);
+        setDraft(nextDraft);
+        setAssessments(nextDraft.assessments);
+        if (initializeProfile)
+          setProfile(profileFromDraft(nextDraft, basicInformationForProfile));
+        return nextDraft;
+      } catch (cause) {
+        setError(messageFrom(cause));
+        if (
+          cause instanceof ApiClientError &&
+          (cause.status === 403 || cause.status === 404)
+        ) {
+          clearStoredState(storageKey);
+          setSession(null);
+          setDraft(null);
+          setAssessments([]);
+          setAnswer("");
+          setBasicInformation(blankBasicInformation);
+          setProfile(blankProfile);
+          setEditSource(null);
+          setEditAnswer("");
+          setConfirmReviewOpen(false);
+        }
+        return null;
       }
-      return null
-    }
-  }, [storageKey, token])
+    },
+    [storageKey, token],
+  );
 
   useEffect(() => {
-    setHasHydrated(false)
-    if (!token || typeof window === 'undefined') {
-      setHasHydrated(true)
-      return
+    setHasHydrated(false);
+    if (!token || typeof window === "undefined") {
+      setHasHydrated(true);
+      return;
     }
 
-    const stored = readStoredState(storageKey)
+    const stored = readStoredState(storageKey);
     if (stored) {
-      setSession(stored.session)
-      setAnswer(stored.answer)
-      setBasicInformation(stored.basicInformation)
-      if (stored.session.status === 'ready_for_confirmation') {
-        void loadDraft(stored.session.id, true, stored.basicInformation)
+      setSession(stored.session);
+      setAnswer(stored.answer);
+      setBasicInformation(stored.basicInformation);
+      if (stored.session.status === "ready_for_confirmation") {
+        void loadDraft(stored.session.id, true, stored.basicInformation);
       }
     }
-    setHasHydrated(true)
-  }, [loadDraft, storageKey, token])
+    setHasHydrated(true);
+  }, [loadDraft, storageKey, token]);
 
   useEffect(() => {
-    if (!hasHydrated || typeof window === 'undefined') return
+    if (!hasHydrated || typeof window === "undefined") return;
     if (!session) {
-      window.sessionStorage.removeItem(storageKey)
-      return
+      window.sessionStorage.removeItem(storageKey);
+      return;
     }
     const stored: StoredIntakeState = {
       session: toStoredSession(session),
       answer,
       basicInformation,
-    }
-    window.sessionStorage.setItem(storageKey, JSON.stringify(stored))
-  }, [answer, basicInformation, hasHydrated, session, storageKey])
+    };
+    window.sessionStorage.setItem(storageKey, JSON.stringify(stored));
+  }, [answer, basicInformation, hasHydrated, session, storageKey]);
 
   useEffect(() => {
-    if (!answer.trim() || typeof window === 'undefined') return
+    if (!answer.trim() || typeof window === "undefined") return;
     const warnBeforeLeave = (event: BeforeUnloadEvent) => {
-      event.preventDefault()
-      event.returnValue = ''
-    }
-    window.addEventListener('beforeunload', warnBeforeLeave)
-    return () => window.removeEventListener('beforeunload', warnBeforeLeave)
-  }, [answer])
+      event.preventDefault();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", warnBeforeLeave);
+    return () => window.removeEventListener("beforeunload", warnBeforeLeave);
+  }, [answer]);
 
   async function begin() {
-    if (!token) return
-    setBusyAction('begin')
-    setError('')
+    if (!token) return;
+    setBusyAction("begin");
+    setError("");
     try {
-      const nextSession = await createIntakeSession(token)
-      setSession(nextSession)
-      setDraft(null)
-      setAssessments([])
-      setAnswer('')
-      setBasicInformation(blankBasicInformation)
+      const nextSession = await createIntakeSession(token);
+      setSession(nextSession);
+      setDraft(null);
+      setAssessments([]);
+      setAnswer("");
+      setBasicInformation(blankBasicInformation);
     } catch (cause) {
-      setError(messageFrom(cause))
+      setError(messageFrom(cause));
     } finally {
-      setBusyAction(null)
+      setBusyAction(null);
     }
   }
 
   async function sendAnswer(field: string, value: string, replace = false) {
     if (!token || !session || !value.trim()) {
-      setError('请填写答案，或选择“标记为未知”。')
-      return
+      setError("请填写答案，或选择“标记为未知”。");
+      return;
     }
-    setBusyAction(replace ? 'replace' : 'answer')
-    setError('')
+    setBusyAction(replace ? "replace" : "answer");
+    setError("");
     try {
       const response = await submitIntakeAnswer(token, session.id, {
         field,
         answer: value.trim(),
         replace,
-      })
-      const next = sessionFromAnswerResponse(response)
-      setSession(next)
-      setAssessments(response.assessments)
+      });
+      const next = sessionFromAnswerResponse(response);
+      setSession(next);
+      setAssessments(response.assessments);
       if (replace) {
-        const replacedFields = draft?.field_metadata
-          .filter((item) => item.source_field === field)
-          .map((item) => item.field) ?? []
-        setEditSource(null)
-        setEditAnswer('')
-        const refreshed = await loadDraft(next.id, false)
-        if (refreshed) setProfile((current) => syncProfileFields(current, refreshed, replacedFields))
+        const replacedFields =
+          draft?.field_metadata
+            .filter((item) => item.source_field === field)
+            .map((item) => item.field) ?? [];
+        setEditSource(null);
+        setEditAnswer("");
+        const refreshed = await loadDraft(next.id, false);
+        if (refreshed)
+          setProfile((current) =>
+            syncProfileFields(current, refreshed, replacedFields),
+          );
       } else {
-        setAnswer('')
-        if (next.status === 'ready_for_confirmation') {
-          await loadDraft(next.id, true, basicInformation)
+        setAnswer("");
+        if (next.status === "ready_for_confirmation") {
+          await loadDraft(next.id, true, basicInformation);
         }
       }
     } catch (cause) {
-      setError(messageFrom(cause))
-      if (cause instanceof ApiClientError && cause.status === 409 && session.status === 'ready_for_confirmation') {
-        await loadDraft(session.id, false)
+      setError(messageFrom(cause));
+      if (
+        cause instanceof ApiClientError &&
+        cause.status === 409 &&
+        session.status === "ready_for_confirmation"
+      ) {
+        await loadDraft(session.id, false);
       }
     } finally {
-      setBusyAction(null)
+      setBusyAction(null);
     }
   }
 
   async function submitCurrentAnswer(value?: string) {
     if (!session?.next_question) {
-      setError('当前问询状态已变化，请刷新后继续。')
-      return
+      setError("当前问询状态已变化，请刷新后继续。");
+      return;
     }
-    const answerToSubmit = value ?? (
-      session.next_question.field === 'basic_information'
+    const answerToSubmit =
+      value ??
+      (session.next_question.field === "basic_information"
         ? basicInformationAnswer(basicInformation)
-        : answer
-    )
+        : answer);
     if (!answerToSubmit) {
-      setError('请填写姓名或称呼，或选择“标记为未知”。')
-      return
+      setError("请填写姓名或称呼，或选择“标记为未知”。");
+      return;
     }
-    await sendAnswer(session.next_question.field, answerToSubmit)
+    await sendAnswer(session.next_question.field, answerToSubmit);
   }
 
   async function confirmCase() {
-    if (!token || !session || !draft) return
+    if (!token || !session || !draft) return;
     if (draft.confirmation_blocked_reasons.length > 0) {
-      setError('当前存在阻断性核对项。请返回修改相关问询内容，再重新确认。')
-      return
+      setError("当前存在阻断性核对项。请返回修改相关问询内容，再重新确认。");
+      return;
     }
     if (!profile.display_name.trim() || !profile.last_seen_location.trim()) {
-      setError('请先确认姓名或称呼，以及最后出现地点。')
-      return
+      setError("请先确认姓名或称呼，以及最后出现地点。");
+      return;
     }
     if (!confirmReviewOpen) {
-      setConfirmReviewOpen(true)
-      return
+      setConfirmReviewOpen(true);
+      return;
     }
 
-    setBusyAction('confirm')
-    setError('')
+    setBusyAction("confirm");
+    setError("");
     try {
-      const response = await confirmIntakeSession(token, session.id, normalizedProfile(profile))
-      await onConfirmed(response.case_id, response.case_code)
-      clearStoredState(storageKey)
+      const response = await confirmIntakeSession(
+        token,
+        session.id,
+        normalizedProfile(profile),
+      );
+      await onConfirmed(response.case_id, response.case_code);
+      clearStoredState(storageKey);
     } catch (cause) {
-      setError(messageFrom(cause))
-      setConfirmReviewOpen(false)
+      setError(messageFrom(cause));
+      setConfirmReviewOpen(false);
       if (cause instanceof ApiClientError && cause.status === 409) {
-        await loadDraft(session.id, false)
+        await loadDraft(session.id, false);
       }
     } finally {
-      setBusyAction(null)
+      setBusyAction(null);
     }
   }
 
   function openSourceEditor(source: IntakeProfileDraftFieldMetadata) {
-    const value = draft?.profile[source.field as keyof IntakeDraftProfile] ?? ''
-    setEditSource(source)
-    setEditAnswer(value ?? '')
-    setConfirmReviewOpen(false)
-    setError('')
+    const value =
+      draft?.profile[source.field as keyof IntakeDraftProfile] ?? "";
+    setEditSource(source);
+    setEditAnswer(value ?? "");
+    setConfirmReviewOpen(false);
+    setError("");
   }
 
   function requestCancel() {
-    if (answer.trim() && typeof window !== 'undefined') {
-      const proceed = window.confirm('当前答案尚未提交。它会仅保留在此标签页草稿中；确定暂时离开吗？')
-      if (!proceed) return
+    if (answer.trim() && typeof window !== "undefined") {
+      const proceed = window.confirm(
+        "当前答案尚未提交。它会仅保留在此标签页草稿中；确定暂时离开吗？",
+      );
+      if (!proceed) return;
     }
-    onCancel()
+    onCancel();
   }
 
   if (!session) {
     return (
-      <section className="border-y border-slate-200 bg-white px-4 py-6 sm:px-5" aria-labelledby="intake-start-title">
-        <span className="text-xs font-semibold text-brand-700">家属建档 · 规则化问询</span>
-        <h2 id="intake-start-title" className="mt-1 text-xl font-bold text-slate-950">先整理信息，再由您确认建案</h2>
+      <section
+        className="border-y border-slate-200 bg-white px-4 py-6 sm:px-5"
+        aria-labelledby="intake-start-title"
+      >
+        <span className="text-xs font-semibold text-brand-700">
+          家属建档 · 规则化问询
+        </span>
+        <h2
+          id="intake-start-title"
+          className="mt-1 text-xl font-bold text-slate-950"
+        >
+          先整理信息，再由您确认建案
+        </h2>
         <p className="max-w-2xl text-sm leading-6 text-slate-600">
           问询分阶段进行。家属提供的内容会先作为待确认草稿，系统不会将规则整理结果直接写成案件事实。
         </p>
         <ul className="mt-4 grid gap-2 text-sm text-slate-700 sm:grid-cols-3">
-          <li className="rounded-md bg-slate-50 px-3 py-2">1. 分步填写，随时标记未知</li>
-          <li className="rounded-md bg-slate-50 px-3 py-2">2. 查看来源与待核对项</li>
-          <li className="rounded-md bg-slate-50 px-3 py-2">3. 人工确认后才创建案件</li>
+          <li className="rounded-md bg-slate-50 px-3 py-2">
+            1. 分步填写，随时标记未知
+          </li>
+          <li className="rounded-md bg-slate-50 px-3 py-2">
+            2. 查看来源与待核对项
+          </li>
+          <li className="rounded-md bg-slate-50 px-3 py-2">
+            3. 人工确认后才创建案件
+          </li>
         </ul>
         {error && <Alert>{error}</Alert>}
         <div className="mt-5 flex flex-wrap gap-2">
-          <Button variant="primary" onPress={() => void begin()} isDisabled={!hasHydrated || isBusy}>
-            {busyAction === 'begin' && <Spinner size="sm" aria-label="正在创建问询" />}
+          <Button
+            variant="primary"
+            onPress={() => void begin()}
+            isDisabled={!hasHydrated || isBusy}
+          >
+            {busyAction === "begin" && (
+              <Spinner size="sm" aria-label="正在创建问询" />
+            )}
             开始问询
           </Button>
-          <Button variant="ghost" onPress={requestCancel} isDisabled={isBusy}>暂不开始</Button>
+          <Button variant="ghost" onPress={requestCancel} isDisabled={isBusy}>
+            暂不开始
+          </Button>
         </div>
       </section>
-    )
+    );
   }
 
   if (draft) {
     return (
-      <section className="border-y border-slate-200 bg-white px-4 py-6 sm:px-5" aria-labelledby="intake-draft-title">
+      <section
+        className="border-y border-slate-200 bg-white px-4 py-6 sm:px-5"
+        aria-labelledby="intake-draft-title"
+      >
         <header className="flex flex-col justify-between gap-3 border-b border-slate-100 pb-4 sm:flex-row sm:items-start">
           <div>
-            <span className="text-xs font-semibold text-brand-700">第 3 步 · 人工确认</span>
-            <h2 id="intake-draft-title" className="mt-1 text-xl font-bold text-slate-950">核对老人画像草稿</h2>
-            <p className="mb-0 mt-1 text-sm leading-6 text-slate-600">每项内容均保持为草稿，只有您完成确认后才会创建正式案件。</p>
+            <span className="text-xs font-semibold text-brand-700">
+              第 3 步 · 人工确认
+            </span>
+            <h2
+              id="intake-draft-title"
+              className="mt-1 text-xl font-bold text-slate-950"
+            >
+              核对老人画像草稿
+            </h2>
+            <p className="mb-0 mt-1 text-sm leading-6 text-slate-600">
+              每项内容均保持为草稿，只有您完成确认后才会创建正式案件。
+            </p>
           </div>
-          <Chip size="sm" variant="soft"><Chip.Label>需要人工确认</Chip.Label></Chip>
+          <Chip size="sm" variant="soft">
+            <Chip.Label>需要人工确认</Chip.Label>
+          </Chip>
         </header>
 
-        <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-3 text-sm leading-6 text-amber-950" role="status">
-          <div className="flex items-start gap-2"><ShieldCheck className="mt-0.5 shrink-0" size={17} aria-hidden="true" /><span>以下信息仅来自本次家属问询。请核对来源、时间与内容；未确认前，它们不是正式案件事实。</span></div>
+        <div
+          className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-3 text-sm leading-6 text-amber-950"
+          role="status"
+        >
+          <div className="flex items-start gap-2">
+            <ShieldCheck
+              className="mt-0.5 shrink-0"
+              size={17}
+              aria-hidden="true"
+            />
+            <span>
+              以下信息仅来自本次家属问询。请核对来源、时间与内容；未确认前，它们不是正式案件事实。
+            </span>
+          </div>
         </div>
 
         {error && <Alert>{error}</Alert>}
@@ -363,14 +446,29 @@ export function FamilyIntakeForm({
         <DraftProfileReview draft={draft} onEditSource={openSourceEditor} />
 
         {draft.direction_hypotheses.length > 0 && (
-          <section className="mt-5" aria-labelledby="direction-hypotheses-title">
-            <h3 id="direction-hypotheses-title" className="text-sm font-bold text-slate-950">待核实方向</h3>
+          <section
+            className="mt-5"
+            aria-labelledby="direction-hypotheses-title"
+          >
+            <h3
+              id="direction-hypotheses-title"
+              className="text-sm font-bold text-slate-950"
+            >
+              待核实方向
+            </h3>
             <div className="grid gap-3 md:grid-cols-2">
               {draft.direction_hypotheses.map((item, index) => (
-                <article key={`${item.generated_at}-${index}`} className="rounded-md border border-slate-200 bg-slate-50 p-3 text-sm">
+                <article
+                  key={`${item.generated_at}-${index}`}
+                  className="rounded-md border border-slate-200 bg-slate-50 p-3 text-sm"
+                >
                   <strong className="text-slate-900">可能方向（不确定）</strong>
-                  <p className="mb-1 mt-2 leading-6 text-slate-700">{item.description}</p>
-                  <p className="m-0 text-xs leading-5 text-slate-600">{item.uncertainty_notice}</p>
+                  <p className="mb-1 mt-2 leading-6 text-slate-700">
+                    {item.description}
+                  </p>
+                  <p className="m-0 text-xs leading-5 text-slate-600">
+                    {item.uncertainty_notice}
+                  </p>
                 </article>
               ))}
             </div>
@@ -378,53 +476,136 @@ export function FamilyIntakeForm({
         )}
 
         {editSource && (
-          <section className="mt-5 rounded-md border border-brand-100 bg-brand-50 p-4" aria-labelledby="source-editor-title">
+          <section
+            className="mt-5 rounded-md border border-brand-100 bg-brand-50 p-4"
+            aria-labelledby="source-editor-title"
+          >
             <div className="flex flex-wrap items-center justify-between gap-2">
               <div>
-                <span className="text-xs font-semibold text-brand-700">返回问询修改</span>
-                <h3 id="source-editor-title" className="m-0 text-base font-bold text-slate-950">修改“{questionLabels[editSource.source_field] ?? editSource.source_field}”</h3>
+                <span className="text-xs font-semibold text-brand-700">
+                  返回问询修改
+                </span>
+                <h3
+                  id="source-editor-title"
+                  className="m-0 text-base font-bold text-slate-950"
+                >
+                  修改“
+                  {questionLabels[editSource.source_field] ??
+                    editSource.source_field}
+                  ”
+                </h3>
               </div>
-              <Button size="sm" variant="ghost" onPress={() => setEditSource(null)} isDisabled={isBusy}>取消修改</Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onPress={() => setEditSource(null)}
+                isDisabled={isBusy}
+              >
+                取消修改
+              </Button>
             </div>
             <Field label="修订后的家属回答" required>
-              <TextArea value={editAnswer} rows={4} maxLength={2000} onChange={(event) => setEditAnswer(event.target.value)} fullWidth />
+              <TextArea
+                value={editAnswer}
+                rows={4}
+                maxLength={2000}
+                onChange={(event) => setEditAnswer(event.target.value)}
+                fullWidth
+              />
             </Field>
             <div className="mt-3 flex flex-wrap gap-2">
-              <Button variant="secondary" onPress={() => void sendAnswer(editSource.source_field, editAnswer, true)} isDisabled={isBusy}>
-                {busyAction === 'replace' && <Spinner size="sm" aria-label="正在保存修订" />}
+              <Button
+                variant="secondary"
+                onPress={() =>
+                  void sendAnswer(editSource.source_field, editAnswer, true)
+                }
+                isDisabled={isBusy}
+              >
+                {busyAction === "replace" && (
+                  <Spinner size="sm" aria-label="正在保存修订" />
+                )}
                 保存修订并刷新草稿
               </Button>
-              <Button variant="ghost" onPress={() => void sendAnswer(editSource.source_field, '未知', true)} isDisabled={isBusy}>标记为未知</Button>
+              <Button
+                variant="ghost"
+                onPress={() =>
+                  void sendAnswer(editSource.source_field, "未知", true)
+                }
+                isDisabled={isBusy}
+              >
+                标记为未知
+              </Button>
             </div>
           </section>
         )}
 
         {!editSource && (
-          <section className="mt-5 border-t border-slate-200 pt-5" aria-labelledby="confirmed-profile-title">
+          <section
+            className="mt-5 border-t border-slate-200 pt-5"
+            aria-labelledby="confirmed-profile-title"
+          >
             <div className="flex items-start gap-2">
-              <CheckCircle2 className="mt-0.5 shrink-0 text-brand-700" size={18} aria-hidden="true" />
+              <CheckCircle2
+                className="mt-0.5 shrink-0 text-brand-700"
+                size={18}
+                aria-hidden="true"
+              />
               <div>
-                <h3 id="confirmed-profile-title" className="m-0 text-base font-bold text-slate-950">确认后写入案件的资料</h3>
-                <p className="mb-0 mt-1 text-sm leading-6 text-slate-600">请在这里修订正式资料。带 * 的两项为当前服务端真正必填内容。</p>
+                <h3
+                  id="confirmed-profile-title"
+                  className="m-0 text-base font-bold text-slate-950"
+                >
+                  确认后写入案件的资料
+                </h3>
+                <p className="mb-0 mt-1 text-sm leading-6 text-slate-600">
+                  请在这里修订正式资料。带 * 的两项为当前服务端真正必填内容。
+                </p>
               </div>
             </div>
             <ProfileForm
               profile={profile}
               onChange={(nextProfile) => {
-                setProfile(nextProfile)
-                setConfirmReviewOpen(false)
+                setProfile(nextProfile);
+                setConfirmReviewOpen(false);
               }}
             />
             {confirmReviewOpen && (
-              <div ref={confirmDialogRef} tabIndex={-1} className="mt-4 rounded-md border border-brand-100 bg-brand-50 p-4" role="alertdialog" aria-labelledby="confirm-case-title">
-                <h4 id="confirm-case-title" className="m-0 text-sm font-bold text-slate-950">确认创建案件？</h4>
-                <p className="mb-3 mt-1 text-sm leading-6 text-slate-700">创建后将生成正式案件。问询草稿会保留为本次确认的依据，但不会替代您刚刚核对的资料。</p>
+              <div
+                ref={confirmDialogRef}
+                tabIndex={-1}
+                className="mt-4 rounded-md border border-brand-100 bg-brand-50 p-4"
+                role="alertdialog"
+                aria-labelledby="confirm-case-title"
+              >
+                <h4
+                  id="confirm-case-title"
+                  className="m-0 text-sm font-bold text-slate-950"
+                >
+                  确认创建案件？
+                </h4>
+                <p className="mb-3 mt-1 text-sm leading-6 text-slate-700">
+                  创建后将生成正式案件。问询草稿会保留为本次确认的依据，但不会替代您刚刚核对的资料。
+                </p>
                 <div className="flex flex-wrap gap-2">
-                  <Button variant="primary" onPress={() => void confirmCase()} isDisabled={isBusy || draft.confirmation_blocked_reasons.length > 0}>
-                    {busyAction === 'confirm' && <Spinner size="sm" aria-label="正在创建案件" />}
+                  <Button
+                    variant="primary"
+                    onPress={() => void confirmCase()}
+                    isDisabled={
+                      isBusy || draft.confirmation_blocked_reasons.length > 0
+                    }
+                  >
+                    {busyAction === "confirm" && (
+                      <Spinner size="sm" aria-label="正在创建案件" />
+                    )}
                     确认并创建案件
                   </Button>
-                  <Button variant="ghost" onPress={() => setConfirmReviewOpen(false)} isDisabled={isBusy}>返回编辑</Button>
+                  <Button
+                    variant="ghost"
+                    onPress={() => setConfirmReviewOpen(false)}
+                    isDisabled={isBusy}
+                  >
+                    返回编辑
+                  </Button>
                 </div>
               </div>
             )}
@@ -432,54 +613,104 @@ export function FamilyIntakeForm({
               <Button
                 variant="primary"
                 onPress={() => void confirmCase()}
-                isDisabled={isBusy || confirmReviewOpen || draft.confirmation_blocked_reasons.length > 0}
+                isDisabled={
+                  isBusy ||
+                  confirmReviewOpen ||
+                  draft.confirmation_blocked_reasons.length > 0
+                }
               >
-                {confirmReviewOpen ? '请完成二次确认' : '人工确认并创建案件'}
+                {confirmReviewOpen ? "请完成二次确认" : "人工确认并创建案件"}
               </Button>
-              <Button variant="ghost" onPress={requestCancel} isDisabled={isBusy}>暂不确认</Button>
+              <Button
+                variant="ghost"
+                onPress={requestCancel}
+                isDisabled={isBusy}
+              >
+                暂不确认
+              </Button>
             </div>
           </section>
         )}
 
         {!editSource && sourceOptions.length > 0 && (
           <section className="mt-5 border-t border-slate-200 pt-4">
-            <h3 className="m-0 text-sm font-bold text-slate-950">需要补充或修改问询？</h3>
-            <p className="mb-3 mt-1 text-xs leading-5 text-slate-600">修订会作为新的草稿答案保存，并刷新当前画像与核对项。</p>
+            <h3 className="m-0 text-sm font-bold text-slate-950">
+              需要补充或修改问询？
+            </h3>
+            <p className="mb-3 mt-1 text-xs leading-5 text-slate-600">
+              修订会作为新的草稿答案保存，并刷新当前画像与核对项。
+            </p>
             <div className="flex flex-wrap gap-2">
               {sourceOptions.map((source) => (
-                <Button key={source.source_field} size="sm" variant="ghost" onPress={() => openSourceEditor(source)} isDisabled={isBusy}>
-                  <FilePenLine size={15} aria-hidden="true" /> 修改{questionLabels[source.source_field] ?? source.source_field}
+                <Button
+                  key={source.source_field}
+                  size="sm"
+                  variant="ghost"
+                  onPress={() => openSourceEditor(source)}
+                  isDisabled={isBusy}
+                >
+                  <FilePenLine size={15} aria-hidden="true" /> 修改
+                  {questionLabels[source.source_field] ?? source.source_field}
                 </Button>
               ))}
             </div>
           </section>
         )}
       </section>
-    )
+    );
   }
 
-  const question = session.next_question
-  const completed = session.completed_phase_one_fields.length
-  const phaseTotal = 4
-  const currentLabel = question ? questionLabels[question.field] ?? question.field : '正在整理草稿'
+  const question = session.next_question;
+  const completed = session.completed_phase_one_fields.length;
+  const phaseTotal = 4;
+  const currentLabel = question
+    ? (questionLabels[question.field] ?? question.field)
+    : "正在整理草稿";
 
   return (
-    <section className="border-y border-slate-200 bg-white px-4 py-6 sm:px-5" aria-labelledby="intake-question-title">
+    <section
+      className="border-y border-slate-200 bg-white px-4 py-6 sm:px-5"
+      aria-labelledby="intake-question-title"
+    >
       <header className="border-b border-slate-100 pb-4">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <span className="text-xs font-semibold text-brand-700">{session.phase === 'phase_one' ? '第 1 步 · 基本情况' : '第 2 步 · 补充线索'}</span>
-            <h2 id="intake-question-title" className="mt-1 text-xl font-bold text-slate-950">{currentLabel}</h2>
+            <span className="text-xs font-semibold text-brand-700">
+              {session.phase === "phase_one"
+                ? "第 1 步 · 基本情况"
+                : "第 2 步 · 补充线索"}
+            </span>
+            <h2
+              id="intake-question-title"
+              className="mt-1 text-xl font-bold text-slate-950"
+            >
+              {currentLabel}
+            </h2>
           </div>
-          <Chip size="sm" variant="soft"><Chip.Label>{session.guidance_mode === 'rule_based' ? '规则化问询' : '问询中'}</Chip.Label></Chip>
+          <Chip size="sm" variant="soft">
+            <Chip.Label>
+              {session.guidance_mode === "rule_based" ? "规则化问询" : "问询中"}
+            </Chip.Label>
+          </Chip>
         </div>
         <div className="mt-4" aria-label="问询进度">
           <div className="flex items-center justify-between text-xs text-slate-600">
-            <span>第一阶段已填写 {completed} / {phaseTotal} 项</span>
-            <span>{session.phase_transition_ready ? '必要信息已齐全' : `仍缺：${session.missing_phase_one_fields.map(questionLabel).join('、')}`}</span>
+            <span>
+              第一阶段已填写 {completed} / {phaseTotal} 项
+            </span>
+            <span>
+              {session.phase_transition_ready
+                ? "必要信息已齐全"
+                : `仍缺：${session.missing_phase_one_fields.map(questionLabel).join("、")}`}
+            </span>
           </div>
           <div className="mt-2 h-2 overflow-hidden rounded-full bg-slate-100">
-            <div className="h-full rounded-full bg-brand-600 transition-[width] duration-200 motion-reduce:transition-none" style={{ width: `${Math.min(100, (completed / phaseTotal) * 100)}%` }} />
+            <div
+              className="h-full rounded-full bg-brand-600 transition-[width] duration-200 motion-reduce:transition-none"
+              style={{
+                width: `${Math.min(100, (completed / phaseTotal) * 100)}%`,
+              }}
+            />
           </div>
         </div>
       </header>
@@ -491,11 +722,11 @@ export function FamilyIntakeForm({
         <form
           className="mt-5"
           onSubmit={(event) => {
-            event.preventDefault()
-            void submitCurrentAnswer()
+            event.preventDefault();
+            void submitCurrentAnswer();
           }}
         >
-          {question.field === 'basic_information' ? (
+          {question.field === "basic_information" ? (
             <BasicInformationForm
               value={basicInformation}
               onChange={setBasicInformation}
@@ -503,89 +734,268 @@ export function FamilyIntakeForm({
               hint={questionReasons[question.field]}
             />
           ) : (
-            <Field label={question.prompt} required={question.required} hint={questionReasons[question.field]}>
-              <TextArea value={answer} onChange={(event) => setAnswer(event.target.value)} rows={5} maxLength={2000} fullWidth />
+            <Field
+              label={question.prompt}
+              required={question.required}
+              hint={questionReasons[question.field]}
+            >
+              <TextArea
+                value={answer}
+                onChange={(event) => setAnswer(event.target.value)}
+                rows={5}
+                maxLength={2000}
+                fullWidth
+              />
             </Field>
           )}
-          <p className="mt-2 text-xs leading-5 text-slate-500">仅在当前浏览器标签页暂存尚未提交的答案；不会写入 URL、日志或跨设备存储。</p>
+          <p className="mt-2 text-xs leading-5 text-slate-500">
+            仅在当前浏览器标签页暂存尚未提交的答案；不会写入
+            URL、日志或跨设备存储。
+          </p>
           <div className="mt-4 flex flex-wrap gap-2">
             <Button type="submit" variant="primary" isDisabled={isBusy}>
-              {busyAction === 'answer' && <Spinner size="sm" aria-label="正在保存答案" />}
+              {busyAction === "answer" && (
+                <Spinner size="sm" aria-label="正在保存答案" />
+              )}
               保存并继续
             </Button>
-            <Button type="button" variant="ghost" onPress={() => void submitCurrentAnswer('未知')} isDisabled={isBusy}>标记为未知</Button>
-            <Button type="button" variant="ghost" onPress={requestCancel} isDisabled={isBusy}><ArrowLeft size={16} aria-hidden="true" />暂时离开</Button>
+            <Button
+              type="button"
+              variant="ghost"
+              onPress={() => void submitCurrentAnswer("未知")}
+              isDisabled={isBusy}
+            >
+              标记为未知
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              onPress={requestCancel}
+              isDisabled={isBusy}
+            >
+              <ArrowLeft size={16} aria-hidden="true" />
+              暂时离开
+            </Button>
           </div>
         </form>
       ) : (
         <div className="mt-5 rounded-md border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
-          <div className="flex items-center gap-2"><Spinner size="sm" /><span>问询已完成，正在获取需要人工确认的画像草稿。</span></div>
-          <Button className="mt-3" size="sm" variant="ghost" onPress={() => void loadDraft(session.id, true)} isDisabled={isBusy}>重新获取草稿</Button>
+          <div className="flex items-center gap-2">
+            <Spinner size="sm" />
+            <span>问询已完成，正在获取需要人工确认的画像草稿。</span>
+          </div>
+          <Button
+            className="mt-3"
+            size="sm"
+            variant="ghost"
+            onPress={() => void loadDraft(session.id, true)}
+            isDisabled={isBusy}
+          >
+            重新获取草稿
+          </Button>
         </div>
       )}
     </section>
-  )
+  );
 }
 
-function DraftProfileReview({ draft, onEditSource }: { draft: IntakeDraft; onEditSource: (source: IntakeProfileDraftFieldMetadata) => void }) {
-  const metadata = new Map(draft.field_metadata.map((item) => [item.field, item]))
+function DraftProfileReview({
+  draft,
+  onEditSource,
+}: {
+  draft: IntakeDraft;
+  onEditSource: (source: IntakeProfileDraftFieldMetadata) => void;
+}) {
+  const metadata = new Map(
+    draft.field_metadata.map((item) => [item.field, item]),
+  );
   const fields: Array<{ field: keyof IntakeDraftProfile; label: string }> = [
-    { field: 'physical_description', label: '体貌描述' },
-    { field: 'clothing_description', label: '衣着与随身物品' },
-    { field: 'health_notes', label: '健康注意事项' },
-    { field: 'mobility_notes', label: '行动与移动' },
-    { field: 'transportation_ability', label: '出行能力' },
-    { field: 'frequent_locations', label: '常去地点' },
-    { field: 'last_seen_information', label: '最后出现信息' },
-    { field: 'behavior_habits', label: '行为习惯' },
-    { field: 'suspicious_motive', label: '可疑动机' },
-  ]
+    { field: "physical_description", label: "体貌描述" },
+    { field: "clothing_description", label: "衣着与随身物品" },
+    { field: "health_notes", label: "健康注意事项" },
+    { field: "mobility_notes", label: "行动与移动" },
+    { field: "transportation_ability", label: "出行能力" },
+    { field: "frequent_locations", label: "常去地点" },
+    { field: "last_seen_information", label: "最后出现信息" },
+    { field: "behavior_habits", label: "行为习惯" },
+    { field: "suspicious_motive", label: "可疑动机" },
+  ];
 
   return (
     <section className="mt-5" aria-labelledby="draft-profile-title">
-      <h3 id="draft-profile-title" className="m-0 text-base font-bold text-slate-950">问询整理出的画像草稿</h3>
+      <h3
+        id="draft-profile-title"
+        className="m-0 text-base font-bold text-slate-950"
+      >
+        问询整理出的画像草稿
+      </h3>
       <div className="mt-3 grid gap-3 md:grid-cols-2">
         {fields.map(({ field, label }) => {
-          const value = draft.profile[field]
-          const source = metadata.get(field)
+          const value = draft.profile[field];
+          const source = metadata.get(field);
           return (
-            <article key={field} className="rounded-md border border-slate-200 bg-white p-4">
+            <article
+              key={field}
+              className="rounded-md border border-slate-200 bg-white p-4"
+            >
               <div className="flex flex-wrap items-start justify-between gap-2">
-                <h4 className="m-0 text-sm font-bold text-slate-950">{label}</h4>
-                <Chip size="sm" variant="soft"><Chip.Label>草稿</Chip.Label></Chip>
+                <h4 className="m-0 text-sm font-bold text-slate-950">
+                  {label}
+                </h4>
+                <Chip size="sm" variant="soft">
+                  <Chip.Label>草稿</Chip.Label>
+                </Chip>
               </div>
-              <p className="mb-3 mt-3 min-h-12 whitespace-pre-wrap text-sm leading-6 text-slate-700">{value ?? '尚未提供'}</p>
+              <p className="mb-3 mt-3 min-h-12 whitespace-pre-wrap text-sm leading-6 text-slate-700">
+                {value ?? "尚未提供"}
+              </p>
               {source ? (
                 <div className="border-t border-slate-100 pt-3 text-xs leading-5 text-slate-600">
-                  <span className="block">来源：{source.source === 'family_provided' ? '家属提供' : '待核实提取'} · {questionLabels[source.source_field] ?? source.source_field}</span>
-                  <span className="block">生成于：{formatDate(source.generated_at)} · 状态：需人工确认</span>
-                  <Button className="mt-2" size="sm" variant="ghost" onPress={() => onEditSource(source)}><FilePenLine size={14} aria-hidden="true" />返回修改</Button>
+                  <span className="block">
+                    来源：
+                    {source.source === "family_provided"
+                      ? "家属提供"
+                      : "待核实提取"}{" "}
+                    ·{" "}
+                    {questionLabels[source.source_field] ?? source.source_field}
+                  </span>
+                  <span className="block">
+                    生成于：{formatDate(source.generated_at)} · 状态：需人工确认
+                  </span>
+                  <Button
+                    className="mt-2"
+                    size="sm"
+                    variant="ghost"
+                    onPress={() => onEditSource(source)}
+                  >
+                    <FilePenLine size={14} aria-hidden="true" />
+                    返回修改
+                  </Button>
                 </div>
               ) : (
-                <p className="m-0 border-t border-slate-100 pt-3 text-xs text-slate-500">暂无可核对的来源记录</p>
+                <p className="m-0 border-t border-slate-100 pt-3 text-xs text-slate-500">
+                  暂无可核对的来源记录
+                </p>
               )}
             </article>
-          )
+          );
         })}
       </div>
     </section>
-  )
+  );
 }
 
-function ProfileForm({ profile, onChange }: { profile: ConfirmedIntakeProfile; onChange: (next: ConfirmedIntakeProfile) => void }) {
+function ProfileForm({
+  profile,
+  onChange,
+}: {
+  profile: ConfirmedIntakeProfile;
+  onChange: (next: ConfirmedIntakeProfile) => void;
+}) {
   return (
     <div className="mt-4 grid gap-3 sm:grid-cols-2">
-      <Field label="姓名或称呼" required><Input value={profile.display_name} maxLength={120} onChange={(event) => onChange({ ...profile, display_name: event.target.value })} fullWidth /></Field>
-      <Field label="最后出现地点" required><Input value={profile.last_seen_location} onChange={(event) => onChange({ ...profile, last_seen_location: event.target.value })} fullWidth /></Field>
-      <Field label="年龄"><Input type="number" min={0} max={130} value={profile.age ?? ''} onChange={(event) => onChange({ ...profile, age: event.target.value ? Number(event.target.value) : null })} fullWidth /></Field>
-      <Field label="性别"><Input value={profile.gender ?? ''} onChange={(event) => onChange({ ...profile, gender: nullable(event.target.value) })} fullWidth /></Field>
-      <Field label="最后出现时间"><Input type="datetime-local" value={toDateTimeLocal(profile.last_seen_at)} onChange={(event) => onChange({ ...profile, last_seen_at: event.target.value ? new Date(event.target.value).toISOString() : null })} fullWidth /></Field>
+      <Field label="姓名或称呼" required>
+        <Input
+          value={profile.display_name}
+          maxLength={120}
+          onChange={(event) =>
+            onChange({ ...profile, display_name: event.target.value })
+          }
+          fullWidth
+        />
+      </Field>
+      <Field label="最后出现地点" required>
+        <Input
+          value={profile.last_seen_location}
+          onChange={(event) =>
+            onChange({ ...profile, last_seen_location: event.target.value })
+          }
+          fullWidth
+        />
+      </Field>
+      <Field label="年龄">
+        <Input
+          type="number"
+          min={0}
+          max={130}
+          value={profile.age ?? ""}
+          onChange={(event) =>
+            onChange({
+              ...profile,
+              age: event.target.value ? Number(event.target.value) : null,
+            })
+          }
+          fullWidth
+        />
+      </Field>
+      <Field label="性别">
+        <Input
+          value={profile.gender ?? ""}
+          onChange={(event) =>
+            onChange({ ...profile, gender: nullable(event.target.value) })
+          }
+          fullWidth
+        />
+      </Field>
+      <Field label="最后出现时间">
+        <Input
+          type="datetime-local"
+          value={toDateTimeLocal(profile.last_seen_at)}
+          onChange={(event) =>
+            onChange({
+              ...profile,
+              last_seen_at: event.target.value
+                ? new Date(event.target.value).toISOString()
+                : null,
+            })
+          }
+          fullWidth
+        />
+      </Field>
       <div className="hidden sm:block" aria-hidden="true" />
-      <Field label="体貌描述"><TextArea value={profile.physical_description ?? ''} onChange={(event) => onChange({ ...profile, physical_description: nullable(event.target.value) })} rows={3} fullWidth /></Field>
-      <Field label="衣着描述"><TextArea value={profile.clothing_description ?? ''} onChange={(event) => onChange({ ...profile, clothing_description: nullable(event.target.value) })} rows={3} fullWidth /></Field>
-      <div className="sm:col-span-2"><Field label="健康注意事项"><TextArea value={profile.health_notes ?? ''} onChange={(event) => onChange({ ...profile, health_notes: nullable(event.target.value) })} rows={3} fullWidth /></Field></div>
+      <Field label="体貌描述">
+        <TextArea
+          value={profile.physical_description ?? ""}
+          onChange={(event) =>
+            onChange({
+              ...profile,
+              physical_description: nullable(event.target.value),
+            })
+          }
+          rows={3}
+          fullWidth
+        />
+      </Field>
+      <Field label="衣着描述">
+        <TextArea
+          value={profile.clothing_description ?? ""}
+          onChange={(event) =>
+            onChange({
+              ...profile,
+              clothing_description: nullable(event.target.value),
+            })
+          }
+          rows={3}
+          fullWidth
+        />
+      </Field>
+      <div className="sm:col-span-2">
+        <Field label="健康注意事项">
+          <TextArea
+            value={profile.health_notes ?? ""}
+            onChange={(event) =>
+              onChange({
+                ...profile,
+                health_notes: nullable(event.target.value),
+              })
+            }
+            rows={3}
+            fullWidth
+          />
+        </Field>
+      </div>
     </div>
-  )
+  );
 }
 
 function BasicInformationForm({
@@ -594,21 +1004,47 @@ function BasicInformationForm({
   required,
   hint,
 }: {
-  value: BasicInformationDraft
-  onChange: (next: BasicInformationDraft) => void
-  required: boolean
-  hint?: string
+  value: BasicInformationDraft;
+  onChange: (next: BasicInformationDraft) => void;
+  required: boolean;
+  hint?: string;
 }) {
   return (
     <fieldset className="rounded-lg border border-slate-200 bg-slate-50/70 p-4">
-      <legend className="px-1 text-sm font-semibold text-slate-800">基本信息{required ? <span aria-hidden="true"> *</span> : null}</legend>
-      {hint && <p className="mb-4 mt-1 flex items-start gap-1 text-xs leading-5 text-slate-500"><CircleHelp className="mt-0.5 shrink-0" size={14} aria-hidden="true" />{hint}</p>}
+      <legend className="px-1 text-sm font-semibold text-slate-800">
+        基本信息{required ? <span aria-hidden="true"> *</span> : null}
+      </legend>
+      {hint && (
+        <p className="mb-4 mt-1 flex items-start gap-1 text-xs leading-5 text-slate-500">
+          <CircleHelp
+            className="mt-0.5 shrink-0"
+            size={14}
+            aria-hidden="true"
+          />
+          {hint}
+        </p>
+      )}
       <div className="grid gap-3 sm:grid-cols-2">
         <Field label="姓名或称呼" required>
-          <Input value={value.name} maxLength={120} autoComplete="name" onChange={(event) => onChange({ ...value, name: event.target.value })} fullWidth />
+          <Input
+            value={value.name}
+            maxLength={120}
+            autoComplete="name"
+            onChange={(event) =>
+              onChange({ ...value, name: event.target.value })
+            }
+            fullWidth
+          />
         </Field>
         <Field label="性别">
-          <select aria-label="性别" value={value.gender} onChange={(event) => onChange({ ...value, gender: event.target.value })} className="h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-brand-600 focus:ring-2 focus:ring-brand-100">
+          <select
+            aria-label="性别"
+            value={value.gender}
+            onChange={(event) =>
+              onChange({ ...value, gender: event.target.value })
+            }
+            className="h-10 w-full rounded-md border border-slate-300 bg-white px-3 text-sm text-slate-900 outline-none transition focus:border-brand-600 focus:ring-2 focus:ring-brand-100"
+          >
             <option value="">暂不确定</option>
             <option value="男">男</option>
             <option value="女">女</option>
@@ -616,72 +1052,152 @@ function BasicInformationForm({
           </select>
         </Field>
         <Field label="年龄">
-          <Input type="number" inputMode="numeric" min={0} max={130} value={value.age} onChange={(event) => onChange({ ...value, age: event.target.value })} fullWidth />
+          <Input
+            type="number"
+            inputMode="numeric"
+            min={0}
+            max={130}
+            value={value.age}
+            onChange={(event) =>
+              onChange({ ...value, age: event.target.value })
+            }
+            fullWidth
+          />
         </Field>
         <Field label="身高（厘米）">
-          <Input type="number" inputMode="numeric" min={30} max={250} value={value.height} onChange={(event) => onChange({ ...value, height: event.target.value })} fullWidth />
+          <Input
+            type="number"
+            inputMode="numeric"
+            min={30}
+            max={250}
+            value={value.height}
+            onChange={(event) =>
+              onChange({ ...value, height: event.target.value })
+            }
+            fullWidth
+          />
         </Field>
         <div className="sm:col-span-2">
           <Field label="便于识别的外观特征">
-            <TextArea value={value.appearance} onChange={(event) => onChange({ ...value, appearance: event.target.value })} rows={3} maxLength={300} fullWidth />
+            <TextArea
+              value={value.appearance}
+              onChange={(event) =>
+                onChange({ ...value, appearance: event.target.value })
+              }
+              rows={3}
+              maxLength={300}
+              fullWidth
+            />
           </Field>
         </div>
       </div>
     </fieldset>
-  )
+  );
 }
 
 function AssessmentList({ items }: { items: IntakeAssessment[] }) {
-  if (items.length === 0) return null
+  if (items.length === 0) return null;
   return (
     <section className="mt-4 space-y-2" aria-label="规则核对结果">
       {items.map((item, index) => (
-        <div key={`${item.field_path}-${item.conflict_type}-${index}`} className={`rounded-md border px-3 py-3 text-sm ${assessmentClass(item.severity)}`}>
-          <div className="flex items-start gap-2"><AlertTriangle className="mt-0.5 shrink-0" size={16} aria-hidden="true" /><div><strong>{assessmentLabel(item.severity)}</strong><span className="ml-2">{item.evidence_summary}</span><p className="mb-0 mt-1 text-xs leading-5">{item.suggested_action}</p></div></div>
+        <div
+          key={`${item.field_path}-${item.conflict_type}-${index}`}
+          className={`rounded-md border px-3 py-3 text-sm ${assessmentClass(item.severity)}`}
+        >
+          <div className="flex items-start gap-2">
+            <AlertTriangle
+              className="mt-0.5 shrink-0"
+              size={16}
+              aria-hidden="true"
+            />
+            <div>
+              <strong>{assessmentLabel(item.severity)}</strong>
+              <span className="ml-2">{item.evidence_summary}</span>
+              <p className="mb-0 mt-1 text-xs leading-5">
+                {item.suggested_action}
+              </p>
+            </div>
+          </div>
         </div>
       ))}
     </section>
-  )
+  );
 }
 
-function Field({ label, hint, required, children }: { label: string; hint?: string; required?: boolean; children: React.ReactNode }) {
+function Field({
+  label,
+  hint,
+  required,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  required?: boolean;
+  children: React.ReactNode;
+}) {
   return (
     <label className="block">
-      <span className="mb-1.5 block text-sm font-semibold text-slate-800">{label}{required ? <span aria-hidden="true"> *</span> : null}</span>
-      {hint && <span className="mb-2 flex items-start gap-1 text-xs leading-5 text-slate-500"><CircleHelp className="mt-0.5 shrink-0" size={14} aria-hidden="true" />{hint}</span>}
+      <span className="mb-1.5 block text-sm font-semibold text-slate-800">
+        {label}
+        {required ? <span aria-hidden="true"> *</span> : null}
+      </span>
+      {hint && (
+        <span className="mb-2 flex items-start gap-1 text-xs leading-5 text-slate-500">
+          <CircleHelp
+            className="mt-0.5 shrink-0"
+            size={14}
+            aria-hidden="true"
+          />
+          {hint}
+        </span>
+      )}
       {children}
     </label>
-  )
+  );
 }
 
 function Alert({ children }: { children: React.ReactNode }) {
-  return <div className="mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-3 text-sm leading-6 text-red-800" role="alert">{children}</div>
+  return (
+    <div
+      className="mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-3 text-sm leading-6 text-red-800"
+      role="alert"
+    >
+      {children}
+    </div>
+  );
 }
 
 function uniqueSourceOptions(draft: IntakeDraft | null) {
-  if (!draft) return []
-  const seen = new Set<string>()
+  if (!draft) return [];
+  const seen = new Set<string>();
   return draft.field_metadata.filter((item) => {
-    if (seen.has(item.source_field)) return false
-    seen.add(item.source_field)
-    return true
-  })
+    if (seen.has(item.source_field)) return false;
+    seen.add(item.source_field);
+    return true;
+  });
 }
 
-function profileFromDraft(draft: IntakeDraft, basicInformation: BasicInformationDraft): ConfirmedIntakeProfile {
+function profileFromDraft(
+  draft: IntakeDraft,
+  basicInformation: BasicInformationDraft,
+): ConfirmedIntakeProfile {
   return {
     ...blankProfile,
     display_name: basicInformation.name.trim(),
     age: validInteger(basicInformation.age, 0, 130),
     gender: nullable(basicInformation.gender),
-    physical_description: basicInformationDescription(basicInformation) ?? draft.profile.physical_description,
+    physical_description:
+      basicInformationDescription(basicInformation) ??
+      draft.profile.physical_description,
     clothing_description: draft.profile.clothing_description,
     health_notes: draft.profile.health_notes,
-    last_seen_location: draft.profile.last_seen_information ?? '',
-  }
+    last_seen_location: draft.profile.last_seen_information ?? "",
+  };
 }
 
-function sessionFromAnswerResponse(response: SubmitIntakeAnswerResponse): IntakeSession {
+function sessionFromAnswerResponse(
+  response: SubmitIntakeAnswerResponse,
+): IntakeSession {
   return {
     id: response.session_id,
     status: response.status,
@@ -693,66 +1209,84 @@ function sessionFromAnswerResponse(response: SubmitIntakeAnswerResponse): Intake
     next_question: response.next_question,
     guidance_mode: response.guidance_mode,
     privacy_notice: response.privacy_notice,
-  }
+  };
 }
 
 function basicInformationAnswer(value: BasicInformationDraft): string | null {
-  const name = value.name.trim()
-  if (!name) return null
-  const age = validInteger(value.age, 0, 130)
-  const height = validInteger(value.height, 30, 250)
-  const lines = [`姓名或称呼：${name}`]
-  if (value.gender) lines.push(`性别：${value.gender}`)
-  if (age !== null) lines.push(`年龄：${age} 岁`)
-  if (height !== null) lines.push(`身高：${height} 厘米`)
-  if (value.appearance.trim()) lines.push(`外观特征：${value.appearance.trim()}`)
-  return lines.join('\n')
+  const name = value.name.trim();
+  if (!name) return null;
+  const age = validInteger(value.age, 0, 130);
+  const height = validInteger(value.height, 30, 250);
+  const lines = [`姓名或称呼：${name}`];
+  if (value.gender) lines.push(`性别：${value.gender}`);
+  if (age !== null) lines.push(`年龄：${age} 岁`);
+  if (height !== null) lines.push(`身高：${height} 厘米`);
+  if (value.appearance.trim())
+    lines.push(`外观特征：${value.appearance.trim()}`);
+  return lines.join("\n");
 }
 
-function basicInformationDescription(value: BasicInformationDraft): string | null {
-  const height = validInteger(value.height, 30, 250)
-  const lines = [height === null ? null : `身高约 ${height} 厘米`, value.appearance.trim() || null].filter((item): item is string => item !== null)
-  return lines.length > 0 ? lines.join('；') : null
+function basicInformationDescription(
+  value: BasicInformationDraft,
+): string | null {
+  const height = validInteger(value.height, 30, 250);
+  const lines = [
+    height === null ? null : `身高约 ${height} 厘米`,
+    value.appearance.trim() || null,
+  ].filter((item): item is string => item !== null);
+  return lines.length > 0 ? lines.join("；") : null;
 }
 
-function validInteger(value: string, minimum: number, maximum: number): number | null {
-  const normalized = value.trim()
-  if (!normalized) return null
-  const number = Number(normalized)
-  return Number.isInteger(number) && number >= minimum && number <= maximum ? number : null
+function validInteger(
+  value: string,
+  minimum: number,
+  maximum: number,
+): number | null {
+  const normalized = value.trim();
+  if (!normalized) return null;
+  const number = Number(normalized);
+  return Number.isInteger(number) && number >= minimum && number <= maximum
+    ? number
+    : null;
 }
 
-function syncProfileFields(current: ConfirmedIntakeProfile, draft: IntakeDraft, replacedFields: string[]) {
-  const next = { ...current }
+function syncProfileFields(
+  current: ConfirmedIntakeProfile,
+  draft: IntakeDraft,
+  replacedFields: string[],
+) {
+  const next = { ...current };
   for (const field of replacedFields) {
     switch (field) {
-      case 'physical_description':
-        next.physical_description = draft.profile.physical_description
-        break
-      case 'clothing_description':
-        next.clothing_description = draft.profile.clothing_description
-        break
-      case 'health_notes':
-        next.health_notes = draft.profile.health_notes
-        break
-      case 'last_seen_information':
-        next.last_seen_location = draft.profile.last_seen_information ?? ''
-        break
+      case "physical_description":
+        next.physical_description = draft.profile.physical_description;
+        break;
+      case "clothing_description":
+        next.clothing_description = draft.profile.clothing_description;
+        break;
+      case "health_notes":
+        next.health_notes = draft.profile.health_notes;
+        break;
+      case "last_seen_information":
+        next.last_seen_location = draft.profile.last_seen_information ?? "";
+        break;
     }
   }
-  return next
+  return next;
 }
 
-function normalizedProfile(profile: ConfirmedIntakeProfile): ConfirmedIntakeProfile {
+function normalizedProfile(
+  profile: ConfirmedIntakeProfile,
+): ConfirmedIntakeProfile {
   return {
     ...profile,
     display_name: profile.display_name.trim(),
     last_seen_location: profile.last_seen_location.trim(),
-    gender: nullable(profile.gender ?? ''),
-    physical_description: nullable(profile.physical_description ?? ''),
-    clothing_description: nullable(profile.clothing_description ?? ''),
-    health_notes: nullable(profile.health_notes ?? ''),
-  }
+    gender: nullable(profile.gender ?? ""),
+    physical_description: nullable(profile.physical_description ?? ""),
+    clothing_description: nullable(profile.clothing_description ?? ""),
+    health_notes: nullable(profile.health_notes ?? ""),
+  };
 }
 
 function toStoredSession(session: IntakeSession): StoredIntakeSession {
@@ -767,92 +1301,112 @@ function toStoredSession(session: IntakeSession): StoredIntakeSession {
     next_question: session.next_question,
     guidance_mode: session.guidance_mode,
     privacy_notice: session.privacy_notice,
-  }
+  };
 }
 
 function readStoredState(storageKey: string): StoredIntakeState | null {
   try {
-    const value = window.sessionStorage.getItem(storageKey)
-    if (!value) return null
-    const parsed = JSON.parse(value) as Partial<StoredIntakeState>
-    const session = parsed.session
-    if (!session || typeof session.id !== 'string') return discardStoredState(storageKey)
-    if (!['collecting', 'ready_for_confirmation'].includes(session.status)) return discardStoredState(storageKey)
-    if (!['phase_one', 'phase_two'].includes(session.phase)) return discardStoredState(storageKey)
-    if (!Array.isArray(session.missing_fields)) return discardStoredState(storageKey)
-    if (!Array.isArray(session.completed_phase_one_fields)) return discardStoredState(storageKey)
-    if (!Array.isArray(session.missing_phase_one_fields)) return discardStoredState(storageKey)
-    if (typeof session.phase_transition_ready !== 'boolean') return discardStoredState(storageKey)
-    if (session.next_question !== null && (
-      typeof session.next_question !== 'object'
-      || typeof session.next_question.field !== 'string'
-      || typeof session.next_question.prompt !== 'string'
-      || typeof session.next_question.required !== 'boolean'
-    )) return discardStoredState(storageKey)
-    if (!session.next_question && (session.status !== 'ready_for_confirmation')) return discardStoredState(storageKey)
+    const value = window.sessionStorage.getItem(storageKey);
+    if (!value) return null;
+    const parsed = JSON.parse(value) as Partial<StoredIntakeState>;
+    const session = parsed.session;
+    if (!session || typeof session.id !== "string")
+      return discardStoredState(storageKey);
+    if (!["collecting", "ready_for_confirmation"].includes(session.status))
+      return discardStoredState(storageKey);
+    if (!["phase_one", "phase_two"].includes(session.phase))
+      return discardStoredState(storageKey);
+    if (!Array.isArray(session.missing_fields))
+      return discardStoredState(storageKey);
+    if (!Array.isArray(session.completed_phase_one_fields))
+      return discardStoredState(storageKey);
+    if (!Array.isArray(session.missing_phase_one_fields))
+      return discardStoredState(storageKey);
+    if (typeof session.phase_transition_ready !== "boolean")
+      return discardStoredState(storageKey);
+    if (
+      session.next_question !== null &&
+      (typeof session.next_question !== "object" ||
+        typeof session.next_question.field !== "string" ||
+        typeof session.next_question.prompt !== "string" ||
+        typeof session.next_question.required !== "boolean")
+    )
+      return discardStoredState(storageKey);
+    if (!session.next_question && session.status !== "ready_for_confirmation")
+      return discardStoredState(storageKey);
     return {
       session: session as StoredIntakeSession,
-      answer: typeof parsed.answer === 'string' ? parsed.answer : '',
+      answer: typeof parsed.answer === "string" ? parsed.answer : "",
       basicInformation: readBasicInformation(parsed.basicInformation),
-    }
+    };
   } catch {
-    return discardStoredState(storageKey)
+    return discardStoredState(storageKey);
   }
 }
 
 function readBasicInformation(value: unknown): BasicInformationDraft {
-  if (!value || typeof value !== 'object') return blankBasicInformation
-  const draft = value as Partial<BasicInformationDraft>
+  if (!value || typeof value !== "object") return blankBasicInformation;
+  const draft = value as Partial<BasicInformationDraft>;
   return {
-    name: typeof draft.name === 'string' ? draft.name : '',
-    gender: typeof draft.gender === 'string' ? draft.gender : '',
-    age: typeof draft.age === 'string' ? draft.age : '',
-    height: typeof draft.height === 'string' ? draft.height : '',
-    appearance: typeof draft.appearance === 'string' ? draft.appearance : '',
-  }
+    name: typeof draft.name === "string" ? draft.name : "",
+    gender: typeof draft.gender === "string" ? draft.gender : "",
+    age: typeof draft.age === "string" ? draft.age : "",
+    height: typeof draft.height === "string" ? draft.height : "",
+    appearance: typeof draft.appearance === "string" ? draft.appearance : "",
+  };
 }
 
 function discardStoredState(storageKey: string): null {
-  window.sessionStorage.removeItem(storageKey)
-  return null
+  window.sessionStorage.removeItem(storageKey);
+  return null;
 }
 
 function clearStoredState(storageKey: string) {
-  if (typeof window !== 'undefined') window.sessionStorage.removeItem(storageKey)
+  if (typeof window !== "undefined")
+    window.sessionStorage.removeItem(storageKey);
 }
 
 function questionLabel(field: string) {
-  return questionLabels[field] ?? field
+  return questionLabels[field] ?? field;
 }
 
-function assessmentLabel(severity: IntakeAssessment['severity']) {
-  return severity === 'blocking' ? '需要先处理' : severity === 'warning' ? '请注意' : '提示'
+function assessmentLabel(severity: IntakeAssessment["severity"]) {
+  return severity === "blocking"
+    ? "需要先处理"
+    : severity === "warning"
+      ? "请注意"
+      : "提示";
 }
 
-function assessmentClass(severity: IntakeAssessment['severity']) {
-  return severity === 'blocking'
-    ? 'border-red-200 bg-red-50 text-red-800'
-    : severity === 'warning'
-      ? 'border-amber-200 bg-amber-50 text-amber-900'
-      : 'border-blue-200 bg-blue-50 text-blue-900'
+function assessmentClass(severity: IntakeAssessment["severity"]) {
+  return severity === "blocking"
+    ? "border-red-200 bg-red-50 text-red-800"
+    : severity === "warning"
+      ? "border-amber-200 bg-amber-50 text-amber-900"
+      : "border-blue-200 bg-blue-50 text-blue-900";
 }
 
 function nullable(value: string): string | null {
-  const trimmed = value.trim()
-  return trimmed || null
+  const trimmed = value.trim();
+  return trimmed || null;
 }
 
 function formatDate(value: string) {
-  const date = new Date(value)
-  return Number.isNaN(date.getTime()) ? value : new Intl.DateTimeFormat('zh-CN', { dateStyle: 'medium', timeStyle: 'short' }).format(date)
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? value
+    : new Intl.DateTimeFormat("zh-CN", {
+        dateStyle: "medium",
+        timeStyle: "short",
+      }).format(date);
 }
 
 function toDateTimeLocal(value: string | null) {
-  if (!value) return ''
-  const date = new Date(value)
-  if (Number.isNaN(date.getTime())) return ''
-  const offset = date.getTimezoneOffset() * 60_000
-  return new Date(date.getTime() - offset).toISOString().slice(0, 16)
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  const offset = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - offset).toISOString().slice(0, 16);
 }
 
 function messageFrom(cause: unknown) {
@@ -860,5 +1414,5 @@ function messageFrom(cause: unknown) {
     ? cause.message
     : cause instanceof Error
       ? cause.message
-      : '操作失败，请稍后重试。'
+      : "操作失败，请稍后重试。";
 }

--- a/frontend/src/pages/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage.test.tsx
@@ -1,15 +1,17 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
-import type { AuthContextValue } from '../auth/auth-context'
-import { LoginPage } from './LoginPage'
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AuthContextValue } from "../auth/auth-context";
+import { LoginPage } from "./LoginPage";
 
 const mocked = vi.hoisted(() => ({
   auth: null as AuthContextValue | null,
-}))
+}));
 
-vi.mock('../auth/useAuth', () => ({ useAuth: () => mocked.auth }))
+vi.mock("../auth/useAuth", () => ({ useAuth: () => mocked.auth }));
 
-function setAuth(login: AuthContextValue['login'] = vi.fn().mockResolvedValue(undefined)) {
+function setAuth(
+  login: AuthContextValue["login"] = vi.fn().mockResolvedValue(undefined),
+) {
   mocked.auth = {
     user: null,
     token: null,
@@ -19,47 +21,67 @@ function setAuth(login: AuthContextValue['login'] = vi.fn().mockResolvedValue(un
     login,
     logout: vi.fn(),
     refreshUser: vi.fn(),
-  }
+  };
 }
 
-describe('LoginPage', () => {
-  it('shows field errors and returns focus to the first missing field', () => {
-    setAuth()
-    render(<LoginPage />)
+describe("LoginPage", () => {
+  it("shows field errors and returns focus to the first missing field", () => {
+    setAuth();
+    render(<LoginPage />);
 
-    fireEvent.click(screen.getByRole('button', { name: '登录' }))
+    fireEvent.click(screen.getByRole("button", { name: "登录" }));
 
-    expect(screen.getByText('请输入邮箱地址。')).toHaveAttribute('role', 'alert')
-    expect(screen.getByLabelText('邮箱')).toHaveFocus()
-  })
+    expect(screen.getByText("请输入邮箱地址。")).toHaveAttribute(
+      "role",
+      "alert",
+    );
+    expect(screen.getByLabelText("邮箱")).toHaveFocus();
+  });
 
-  it('lets people reveal or conceal their password while typing', () => {
-    setAuth()
-    render(<LoginPage />)
+  it("lets people reveal or conceal their password while typing", () => {
+    setAuth();
+    render(<LoginPage />);
 
-    const passwordInput = screen.getByLabelText('密码')
-    expect(passwordInput).toHaveAttribute('type', 'password')
+    const passwordInput = screen.getByLabelText("密码");
+    expect(passwordInput).toHaveAttribute("type", "password");
 
-    fireEvent.click(screen.getByRole('button', { name: '显示密码' }))
-    expect(passwordInput).toHaveAttribute('type', 'text')
+    fireEvent.click(screen.getByRole("button", { name: "显示密码" }));
+    expect(passwordInput).toHaveAttribute("type", "text");
 
-    fireEvent.click(screen.getByRole('button', { name: '隐藏密码' }))
-    expect(passwordInput).toHaveAttribute('type', 'password')
-  })
+    fireEvent.click(screen.getByRole("button", { name: "隐藏密码" }));
+    expect(passwordInput).toHaveAttribute("type", "password");
+  });
 
-  it('uses a trimmed email and removes a server error when credentials change', async () => {
-    const login = vi.fn().mockRejectedValue(new Error('邮箱或密码错误，请重新输入。'))
-    setAuth(login)
-    render(<LoginPage />)
+  it("uses a trimmed email and removes a server error when credentials change", async () => {
+    const login = vi
+      .fn()
+      .mockRejectedValue(new Error("邮箱或密码错误，请重新输入。"));
+    setAuth(login);
+    render(<LoginPage />);
 
-    fireEvent.change(screen.getByLabelText('邮箱'), { target: { value: ' family@demo.invalid ' } })
-    fireEvent.change(screen.getByLabelText('密码'), { target: { value: 'local-test-input' } })
-    fireEvent.click(screen.getByRole('button', { name: '登录' }))
+    fireEvent.change(screen.getByLabelText("邮箱"), {
+      target: { value: " family@demo.invalid " },
+    });
+    fireEvent.change(screen.getByLabelText("密码"), {
+      target: { value: "local-test-input" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "登录" }));
 
-    expect(await screen.findByRole('alert')).toHaveTextContent('邮箱或密码错误，请重新输入。')
-    expect(login).toHaveBeenCalledWith('family@demo.invalid', 'local-test-input')
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "邮箱或密码错误，请重新输入。",
+    );
+    expect(login).toHaveBeenCalledWith(
+      "family@demo.invalid",
+      "local-test-input",
+    );
 
-    fireEvent.change(screen.getByLabelText('密码'), { target: { value: 'new-input' } })
-    await waitFor(() => expect(screen.queryByText('邮箱或密码错误，请重新输入。')).not.toBeInTheDocument())
-  })
-})
+    fireEvent.change(screen.getByLabelText("密码"), {
+      target: { value: "new-input" },
+    });
+    await waitFor(() =>
+      expect(
+        screen.queryByText("邮箱或密码错误，请重新输入。"),
+      ).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,63 +1,67 @@
-import { Button, Card, Chip, Input, Spinner } from '@heroui/react'
-import { Eye, EyeOff, LogIn, ShieldCheck } from 'lucide-react'
-import { useRef, useState } from 'react'
-import type { FormEvent } from 'react'
-import brandMark from '../../../assets/brand/angui-mark.svg'
-import { useAuth } from '../auth/useAuth'
+import { Button, Card, Chip, Input, Spinner } from "@heroui/react";
+import { Eye, EyeOff, LogIn, ShieldCheck } from "lucide-react";
+import { useRef, useState } from "react";
+import type { FormEvent } from "react";
+import brandMark from "../../../assets/brand/angui-mark.svg";
+import { useAuth } from "../auth/useAuth";
 
 function hasValidEmail(value: string) {
-  return value.trim().includes('@')
+  return value.trim().includes("@");
 }
 
 export function LoginPage() {
-  const { login, sessionNotice } = useAuth()
-  const [email, setEmail] = useState('')
-  const [password, setPassword] = useState('')
-  const [error, setError] = useState('')
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-  const [isEmailTouched, setIsEmailTouched] = useState(false)
-  const [isPasswordTouched, setIsPasswordTouched] = useState(false)
-  const emailInputRef = useRef<HTMLInputElement>(null)
-  const passwordInputRef = useRef<HTMLInputElement>(null)
+  const { login, sessionNotice } = useAuth();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const [isEmailTouched, setIsEmailTouched] = useState(false);
+  const [isPasswordTouched, setIsPasswordTouched] = useState(false);
+  const emailInputRef = useRef<HTMLInputElement>(null);
+  const passwordInputRef = useRef<HTMLInputElement>(null);
 
   const emailError = isEmailTouched
-    ? (email.trim() ? (hasValidEmail(email) ? '' : '请输入有效的邮箱地址。') : '请输入邮箱地址。')
-    : ''
-  const passwordError = isPasswordTouched && !password ? '请输入密码。' : ''
+    ? email.trim()
+      ? hasValidEmail(email)
+        ? ""
+        : "请输入有效的邮箱地址。"
+      : "请输入邮箱地址。"
+    : "";
+  const passwordError = isPasswordTouched && !password ? "请输入密码。" : "";
 
   function updateEmail(value: string) {
-    setEmail(value)
-    if (error) setError('')
+    setEmail(value);
+    if (error) setError("");
   }
 
   function updatePassword(value: string) {
-    setPassword(value)
-    if (error) setError('')
+    setPassword(value);
+    if (error) setError("");
   }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    setIsEmailTouched(true)
-    setIsPasswordTouched(true)
+    event.preventDefault();
+    setIsEmailTouched(true);
+    setIsPasswordTouched(true);
 
     if (!hasValidEmail(email)) {
-      emailInputRef.current?.focus()
-      return
+      emailInputRef.current?.focus();
+      return;
     }
     if (!password) {
-      passwordInputRef.current?.focus()
-      return
+      passwordInputRef.current?.focus();
+      return;
     }
 
-    setError('')
-    setIsSubmitting(true)
+    setError("");
+    setIsSubmitting(true);
     try {
-      await login(email.trim(), password)
+      await login(email.trim(), password);
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : '登录失败')
+      setError(cause instanceof Error ? cause.message : "登录失败");
     } finally {
-      setIsSubmitting(false)
+      setIsSubmitting(false);
     }
   }
 
@@ -76,8 +80,12 @@ export function LoginPage() {
           <Card.Header className="border-b border-slate-200 px-5 py-4">
             <div className="flex w-full items-center justify-between gap-4">
               <div>
-                <Card.Title className="text-base font-bold text-slate-950">账号登录</Card.Title>
-                <p className="m-0 mt-1 text-xs text-slate-500">使用已批准的项目账号进入</p>
+                <Card.Title className="text-base font-bold text-slate-950">
+                  账号登录
+                </Card.Title>
+                <p className="m-0 mt-1 text-xs text-slate-500">
+                  使用已批准的项目账号进入
+                </p>
               </div>
               <Chip size="sm" variant="soft">
                 <ShieldCheck size={14} aria-hidden="true" />
@@ -88,12 +96,21 @@ export function LoginPage() {
           <Card.Content className="p-5">
             <form className="space-y-4" noValidate onSubmit={handleSubmit}>
               {sessionNotice && (
-                <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-950" role="status" aria-live="polite">
+                <div
+                  className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-950"
+                  role="status"
+                  aria-live="polite"
+                >
                   {sessionNotice}
                 </div>
               )}
               <div>
-                <label className="mb-1.5 block text-sm font-semibold text-slate-700" htmlFor="login-email">邮箱</label>
+                <label
+                  className="mb-1.5 block text-sm font-semibold text-slate-700"
+                  htmlFor="login-email"
+                >
+                  邮箱
+                </label>
                 <Input
                   ref={emailInputRef}
                   id="login-email"
@@ -105,32 +122,51 @@ export function LoginPage() {
                   value={email}
                   onBlur={() => setIsEmailTouched(true)}
                   onChange={(event) => updateEmail(event.target.value)}
-                  aria-describedby={emailError ? 'login-email-error' : undefined}
-                  aria-invalid={emailError ? 'true' : undefined}
+                  aria-describedby={
+                    emailError ? "login-email-error" : undefined
+                  }
+                  aria-invalid={emailError ? "true" : undefined}
                   className="min-h-11"
                   disabled={isSubmitting}
                   fullWidth
                   placeholder="name@example.com"
                 />
-                {emailError && <p id="login-email-error" className="mt-1.5 text-sm text-red-700" role="alert">{emailError}</p>}
+                {emailError && (
+                  <p
+                    id="login-email-error"
+                    className="mt-1.5 text-sm text-red-700"
+                    role="alert"
+                  >
+                    {emailError}
+                  </p>
+                )}
               </div>
               <div>
-                <label className="mb-1.5 block text-sm font-semibold text-slate-700" htmlFor="login-password">密码</label>
+                <label
+                  className="mb-1.5 block text-sm font-semibold text-slate-700"
+                  htmlFor="login-password"
+                >
+                  密码
+                </label>
                 <div className="relative">
                   <Input
-                  ref={passwordInputRef}
-                  id="login-password"
-                  type={isPasswordVisible ? 'text' : 'password'}
-                  autoComplete="current-password"
-                  enterKeyHint="go"
-                  value={password}
-                  onBlur={() => setIsPasswordTouched(true)}
-                  onChange={(event) => updatePassword(event.target.value)}
-                  aria-describedby={passwordError || error ? 'login-password-error' : undefined}
-                  aria-invalid={passwordError || error ? 'true' : undefined}
-                  className="min-h-11 pr-12"
-                  disabled={isSubmitting}
-                  fullWidth
+                    ref={passwordInputRef}
+                    id="login-password"
+                    type={isPasswordVisible ? "text" : "password"}
+                    autoComplete="current-password"
+                    enterKeyHint="go"
+                    value={password}
+                    onBlur={() => setIsPasswordTouched(true)}
+                    onChange={(event) => updatePassword(event.target.value)}
+                    aria-describedby={
+                      passwordError || error
+                        ? "login-password-error"
+                        : undefined
+                    }
+                    aria-invalid={passwordError || error ? "true" : undefined}
+                    className="min-h-11 pr-12"
+                    disabled={isSubmitting}
+                    fullWidth
                   />
                   <Button
                     type="button"
@@ -138,30 +174,55 @@ export function LoginPage() {
                     variant="ghost"
                     isIconOnly
                     className="absolute right-0.5 top-1/2 size-11 min-h-11 min-w-11 -translate-y-1/2"
-                    aria-label={isPasswordVisible ? '隐藏密码' : '显示密码'}
+                    aria-label={isPasswordVisible ? "隐藏密码" : "显示密码"}
                     isDisabled={isSubmitting}
                     onPress={() => setIsPasswordVisible((visible) => !visible)}
                   >
-                    {isPasswordVisible ? <EyeOff size={18} aria-hidden="true" /> : <Eye size={18} aria-hidden="true" />}
+                    {isPasswordVisible ? (
+                      <EyeOff size={18} aria-hidden="true" />
+                    ) : (
+                      <Eye size={18} aria-hidden="true" />
+                    )}
                   </Button>
                 </div>
-                {passwordError && <p id="login-password-error" className="mt-1.5 text-sm text-red-700" role="alert">{passwordError}</p>}
+                {passwordError && (
+                  <p
+                    id="login-password-error"
+                    className="mt-1.5 text-sm text-red-700"
+                    role="alert"
+                  >
+                    {passwordError}
+                  </p>
+                )}
               </div>
 
               {error && (
-                <div id="login-password-error" className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700" role="alert">
+                <div
+                  id="login-password-error"
+                  className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+                  role="alert"
+                >
                   {error}
                 </div>
               )}
 
-              <Button type="submit" variant="primary" fullWidth isDisabled={isSubmitting}>
-                {isSubmitting ? <Spinner size="sm" aria-label="正在验证登录信息" /> : <LogIn size={17} aria-hidden="true" />}
-                {isSubmitting ? '正在验证' : '登录'}
+              <Button
+                type="submit"
+                variant="primary"
+                fullWidth
+                isDisabled={isSubmitting}
+              >
+                {isSubmitting ? (
+                  <Spinner size="sm" aria-label="正在验证登录信息" />
+                ) : (
+                  <LogIn size={17} aria-hidden="true" />
+                )}
+                {isSubmitting ? "正在验证" : "登录"}
               </Button>
             </form>
           </Card.Content>
         </Card>
       </div>
     </main>
-  )
+  );
 }

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,97 +1,199 @@
-import { Button, Input, Spinner } from '@heroui/react'
-import { Save, UserRound } from 'lucide-react'
-import { useCallback, useEffect, useState } from 'react'
-import type { ReactNode } from 'react'
-import { getMyProfile, updateMyProfile } from '../api/auth'
-import type { UserProfile } from '../api/auth'
-import { ApiClientError } from '../api/client'
-import { useAuth } from '../auth/useAuth'
-import { ErrorState, LoadingState } from '../components/ContentState'
+import { Button, Input, Spinner } from "@heroui/react";
+import { Save, UserRound } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import { getMyProfile, updateMyProfile } from "../api/auth";
+import type { UserProfile } from "../api/auth";
+import { ApiClientError } from "../api/client";
+import { useAuth } from "../auth/useAuth";
+import { ErrorState, LoadingState } from "../components/ContentState";
 
 function messageFrom(cause: unknown) {
-  return cause instanceof ApiClientError ? cause.message : '暂时无法完成操作，请稍后重试。'
+  return cause instanceof ApiClientError
+    ? cause.message
+    : "暂时无法完成操作，请稍后重试。";
 }
 
 export function ProfilePage() {
-  const { token, refreshUser } = useAuth()
-  const [profile, setProfile] = useState<UserProfile | null>(null)
-  const [displayName, setDisplayName] = useState('')
-  const [avatarReference, setAvatarReference] = useState('')
-  const [locale, setLocale] = useState<'zh-CN' | 'en-US'>('zh-CN')
-  const [reducedMotion, setReducedMotion] = useState(false)
-  const [isLoading, setIsLoading] = useState(true)
-  const [isSaving, setIsSaving] = useState(false)
-  const [error, setError] = useState('')
-  const [notice, setNotice] = useState('')
+  const { token, refreshUser } = useAuth();
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [displayName, setDisplayName] = useState("");
+  const [avatarReference, setAvatarReference] = useState("");
+  const [locale, setLocale] = useState<"zh-CN" | "en-US">("zh-CN");
+  const [reducedMotion, setReducedMotion] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [notice, setNotice] = useState("");
 
   const load = useCallback(async () => {
-    if (!token) return
-    setIsLoading(true)
-    setError('')
+    if (!token) return;
+    setIsLoading(true);
+    setError("");
     try {
-      const next = await getMyProfile(token)
-      setProfile(next)
-      setDisplayName(next.display_name)
-      setAvatarReference(next.avatar_reference ?? '')
-      setLocale(next.preferences.locale)
-      setReducedMotion(next.preferences.reduced_motion)
+      const next = await getMyProfile(token);
+      setProfile(next);
+      setDisplayName(next.display_name);
+      setAvatarReference(next.avatar_reference ?? "");
+      setLocale(next.preferences.locale);
+      setReducedMotion(next.preferences.reduced_motion);
     } catch (cause) {
-      setError(messageFrom(cause))
+      setError(messageFrom(cause));
     } finally {
-      setIsLoading(false)
+      setIsLoading(false);
     }
-  }, [token])
+  }, [token]);
 
-  useEffect(() => { void load() }, [load])
+  useEffect(() => {
+    void load();
+  }, [load]);
 
-  if (isLoading) return <LoadingState label="正在加载个人资料" />
-  if (!profile) return <ErrorState message={error || '个人资料不可用'} onRetry={() => void load()} />
+  if (isLoading) return <LoadingState label="正在加载个人资料" />;
+  if (!profile)
+    return (
+      <ErrorState
+        message={error || "个人资料不可用"}
+        onRetry={() => void load()}
+      />
+    );
 
   return (
     <main className="mx-auto w-full max-w-3xl px-4 py-7 sm:px-6 lg:px-10 lg:py-10">
       <header className="mb-6 flex items-start gap-3">
-        <span className="grid size-11 place-items-center rounded-full bg-brand-100 text-brand-700"><UserRound aria-hidden="true" /></span>
+        <span className="grid size-11 place-items-center rounded-full bg-brand-100 text-brand-700">
+          <UserRound aria-hidden="true" />
+        </span>
         <div>
           <h1 className="m-0 text-2xl font-bold text-slate-950">个人资料</h1>
-          <p className="mb-0 mt-1 text-sm text-slate-600">更新显示名称、头像引用和非敏感界面偏好。</p>
+          <p className="mb-0 mt-1 text-sm text-slate-600">
+            更新显示名称、头像引用和非敏感界面偏好。
+          </p>
         </div>
       </header>
-      <form className="space-y-5 rounded-lg border border-slate-200 bg-white p-5 shadow-sm sm:p-6" onSubmit={(event) => {
-        event.preventDefault()
-        if (!token) return
-        setIsSaving(true); setError(''); setNotice('')
-        void updateMyProfile(token, { display_name: displayName, avatar_reference: avatarReference, preferences: { locale, reduced_motion: reducedMotion } })
-          .then(async (next) => {
-            setProfile(next)
-            setNotice('个人资料已保存。')
-            try {
-              await refreshUser()
-            } catch {
-              // Keeping the locally returned profile is sufficient when the best-effort identity refresh fails.
-            }
+      <form
+        className="space-y-5 rounded-lg border border-slate-200 bg-white p-5 shadow-sm sm:p-6"
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!token) return;
+          setIsSaving(true);
+          setError("");
+          setNotice("");
+          void updateMyProfile(token, {
+            display_name: displayName,
+            avatar_reference: avatarReference,
+            preferences: { locale, reduced_motion: reducedMotion },
           })
-          .catch((cause) => setError(messageFrom(cause)))
-          .finally(() => setIsSaving(false))
-      }}>
+            .then(async (next) => {
+              setProfile(next);
+              setNotice("个人资料已保存。");
+              try {
+                await refreshUser();
+              } catch {
+                // Keeping the locally returned profile is sufficient when the best-effort identity refresh fails.
+              }
+            })
+            .catch((cause) => setError(messageFrom(cause)))
+            .finally(() => setIsSaving(false));
+        }}
+      >
         <div className="grid gap-4 sm:grid-cols-2">
-          <ProfileField label="显示名称"><Input value={displayName} onChange={(event) => setDisplayName(event.target.value)} maxLength={120} fullWidth required /></ProfileField>
-          <ProfileField label="账号邮箱" hint="邮箱、账号类型和权限不能在此页面修改。"><Input value={profile.email} readOnly fullWidth /></ProfileField>
-          <div className="sm:col-span-2"><ProfileField label="头像引用" hint="填写已受控存储中的头像引用；留空可清除。"><Input value={avatarReference} onChange={(event) => setAvatarReference(event.target.value)} maxLength={500} fullWidth /></ProfileField></div>
-          <label className="grid gap-1 text-sm font-medium text-slate-700">界面语言
-            <select className="min-h-10 rounded-md border border-slate-300 bg-white px-3 text-sm" value={locale} onChange={(event) => setLocale(event.target.value as 'zh-CN' | 'en-US')}>
-              <option value="zh-CN">简体中文</option><option value="en-US">English (US)</option>
+          <ProfileField label="显示名称">
+            <Input
+              value={displayName}
+              onChange={(event) => setDisplayName(event.target.value)}
+              maxLength={120}
+              fullWidth
+              required
+            />
+          </ProfileField>
+          <ProfileField
+            label="账号邮箱"
+            hint="邮箱、账号类型和权限不能在此页面修改。"
+          >
+            <Input value={profile.email} readOnly fullWidth />
+          </ProfileField>
+          <div className="sm:col-span-2">
+            <ProfileField
+              label="头像引用"
+              hint="填写已受控存储中的头像引用；留空可清除。"
+            >
+              <Input
+                value={avatarReference}
+                onChange={(event) => setAvatarReference(event.target.value)}
+                maxLength={500}
+                fullWidth
+              />
+            </ProfileField>
+          </div>
+          <label className="grid gap-1 text-sm font-medium text-slate-700">
+            界面语言
+            <select
+              className="min-h-10 rounded-md border border-slate-300 bg-white px-3 text-sm"
+              value={locale}
+              onChange={(event) =>
+                setLocale(event.target.value as "zh-CN" | "en-US")
+              }
+            >
+              <option value="zh-CN">简体中文</option>
+              <option value="en-US">English (US)</option>
             </select>
           </label>
-          <label className="flex min-h-10 items-center gap-2 self-end text-sm text-slate-700"><input type="checkbox" checked={reducedMotion} onChange={(event) => setReducedMotion(event.target.checked)} /> 减少界面动画</label>
+          <label className="flex min-h-10 items-center gap-2 self-end text-sm text-slate-700">
+            <input
+              type="checkbox"
+              checked={reducedMotion}
+              onChange={(event) => setReducedMotion(event.target.checked)}
+            />{" "}
+            减少界面动画
+          </label>
         </div>
-        {error && <p className="m-0 rounded-md bg-danger-50 px-3 py-2 text-sm text-danger-700" role="alert">{error}</p>}
-        {notice && <p className="m-0 rounded-md bg-success-50 px-3 py-2 text-sm text-success-700" role="status">{notice}</p>}
-        <div className="flex justify-end"><Button type="submit" variant="primary" isDisabled={isSaving}>{isSaving ? <Spinner size="sm" /> : <Save size={16} aria-hidden="true" />}{isSaving ? '正在保存' : '保存资料'}</Button></div>
+        {error && (
+          <p
+            className="m-0 rounded-md bg-danger-50 px-3 py-2 text-sm text-danger-700"
+            role="alert"
+          >
+            {error}
+          </p>
+        )}
+        {notice && (
+          <p
+            className="m-0 rounded-md bg-success-50 px-3 py-2 text-sm text-success-700"
+            role="status"
+          >
+            {notice}
+          </p>
+        )}
+        <div className="flex justify-end">
+          <Button type="submit" variant="primary" isDisabled={isSaving}>
+            {isSaving ? (
+              <Spinner size="sm" />
+            ) : (
+              <Save size={16} aria-hidden="true" />
+            )}
+            {isSaving ? "正在保存" : "保存资料"}
+          </Button>
+        </div>
       </form>
     </main>
-  )
+  );
 }
 
-function ProfileField({ label, hint, children }: { label: string; hint?: string; children: ReactNode }) {
-  return <label className="grid gap-1 text-sm font-medium text-slate-700"><span>{label}</span>{children}{hint && <span className="text-xs font-normal text-slate-500">{hint}</span>}</label>
+function ProfileField({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: ReactNode;
+}) {
+  return (
+    <label className="grid gap-1 text-sm font-medium text-slate-700">
+      <span>{label}</span>
+      {children}
+      {hint && (
+        <span className="text-xs font-normal text-slate-500">{hint}</span>
+      )}
+    </label>
+  );
 }

--- a/frontend/src/pages/VolunteerWorkspacePage.tsx
+++ b/frontend/src/pages/VolunteerWorkspacePage.tsx
@@ -1,101 +1,862 @@
-import { Button, Chip, Input, TextArea } from '@heroui/react'
-import { AlertTriangle, Compass, LocateFixed, MapPin, RefreshCw, Search, Send, ShieldCheck, Users } from 'lucide-react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { Button, Chip, Input, TextArea } from "@heroui/react";
 import {
-  applyForTask, createClue, getCase, getCaseSummary, getTaskNavigation, getTaskSafetyBriefing,
-  listCasePois, listCases, listCaseTasks, listMyTasks, listTaskCollaborationLocations,
-  submitTaskFeedback, submitTaskLocationReport, updateTaskStatus,
-} from '../api/cases'
-import type { CaseDetail, CasePois, CaseSummary, CaseTask, TaskCollaborationLocation, TaskNavigation, TaskSafetyBriefing, TaskStatus } from '../api/cases'
-import { useAuth } from '../auth/useAuth'
-import { EmptyState, ErrorState, LoadingState } from '../components/ContentState'
+  AlertTriangle,
+  Compass,
+  LocateFixed,
+  MapPin,
+  RefreshCw,
+  Search,
+  Send,
+  ShieldCheck,
+  Users,
+} from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  applyForTask,
+  createClue,
+  getCase,
+  getCaseSummary,
+  getTaskNavigation,
+  getTaskSafetyBriefing,
+  listCasePois,
+  listCases,
+  listCaseTasks,
+  listMyTasks,
+  listTaskCollaborationLocations,
+  submitTaskFeedback,
+  submitTaskLocationReport,
+  updateTaskStatus,
+} from "../api/cases";
+import type {
+  CaseDetail,
+  CasePois,
+  CaseSummary,
+  CaseTask,
+  TaskCollaborationLocation,
+  TaskNavigation,
+  TaskSafetyBriefing,
+  TaskStatus,
+} from "../api/cases";
+import { useAuth } from "../auth/useAuth";
+import {
+  EmptyState,
+  ErrorState,
+  LoadingState,
+} from "../components/ContentState";
 
 const statusLabels: Record<TaskStatus, string> = {
-  pending_claim: 'Open for applications', assigned: 'Assigned', accepted: 'Accepted', active: 'Active', blocked: 'Paused', completed: 'Completed', cancelled: 'Cancelled',
-}
-type Failure = { message: string; retry: (() => void) | null }
-type WorkspaceCase = { detail: CaseDetail; summary: CaseSummary; tasks: CaseTask[] }
-type ClueDraft = { content: string; location: string }
+  pending_claim: "Open for applications",
+  assigned: "Assigned",
+  accepted: "Accepted",
+  active: "Active",
+  blocked: "Paused",
+  completed: "Completed",
+  cancelled: "Cancelled",
+};
+type Failure = { message: string; retry: (() => void) | null };
+type WorkspaceCase = {
+  detail: CaseDetail;
+  summary: CaseSummary;
+  tasks: CaseTask[];
+};
+type ClueDraft = { content: string; location: string };
 
-function messageFrom(cause: unknown) { return cause instanceof Error ? cause.message : 'The operation could not be completed. Please try again.' }
-function localNow() { return new Date().toISOString() }
+function messageFrom(cause: unknown) {
+  return cause instanceof Error
+    ? cause.message
+    : "The operation could not be completed. Please try again.";
+}
+function localNow() {
+  return new Date().toISOString();
+}
 
 export function VolunteerWorkspacePage() {
-  const { token } = useAuth()
-  const [cases, setCases] = useState<WorkspaceCase[]>([])
-  const [myTasks, setMyTasks] = useState<CaseTask[]>([])
-  const [navigation, setNavigation] = useState<Record<string, TaskNavigation>>({})
-  const [safety, setSafety] = useState<Record<string, TaskSafetyBriefing>>({})
-  const [locations, setLocations] = useState<Record<string, TaskCollaborationLocation[]>>({})
-  const [pois, setPois] = useState<Record<string, CasePois>>({})
-  const [poiCategory, setPoiCategory] = useState<Record<string, string>>({})
-  const [feedback, setFeedback] = useState<Record<string, string>>({})
-  const [clueDrafts, setClueDrafts] = useState<Record<string, ClueDraft>>({})
-  const [location, setLocation] = useState<Record<string, { latitude: string; longitude: string; accuracy: string }>>({})
-  const [pendingTaskIds, setPendingTaskIds] = useState<Set<string>>(new Set())
-  const pendingTaskIdsRef = useRef(new Set<string>())
-  const [loading, setLoading] = useState(true)
-  const [failure, setFailure] = useState<Failure | null>(null)
-  const [notice, setNotice] = useState('')
+  const { token } = useAuth();
+  const [cases, setCases] = useState<WorkspaceCase[]>([]);
+  const [myTasks, setMyTasks] = useState<CaseTask[]>([]);
+  const [navigation, setNavigation] = useState<Record<string, TaskNavigation>>(
+    {},
+  );
+  const [safety, setSafety] = useState<Record<string, TaskSafetyBriefing>>({});
+  const [locations, setLocations] = useState<
+    Record<string, TaskCollaborationLocation[]>
+  >({});
+  const [pois, setPois] = useState<Record<string, CasePois>>({});
+  const [poiCategory, setPoiCategory] = useState<Record<string, string>>({});
+  const [feedback, setFeedback] = useState<Record<string, string>>({});
+  const [clueDrafts, setClueDrafts] = useState<Record<string, ClueDraft>>({});
+  const [location, setLocation] = useState<
+    Record<string, { latitude: string; longitude: string; accuracy: string }>
+  >({});
+  const [pendingTaskIds, setPendingTaskIds] = useState<Set<string>>(new Set());
+  const pendingTaskIdsRef = useRef(new Set<string>());
+  const [loading, setLoading] = useState(true);
+  const [failure, setFailure] = useState<Failure | null>(null);
+  const [notice, setNotice] = useState("");
 
   const load = useCallback(async () => {
-    if (!token) return
-    setLoading(true); setFailure(null)
+    if (!token) return;
+    setLoading(true);
+    setFailure(null);
     try {
-      const [memberships, assigned] = await Promise.all([listCases(token), listMyTasks(token)])
-      const volunteerCases = memberships.filter((item) => item.access_role === 'volunteer')
-      const workspaces = await Promise.all(volunteerCases.map(async (item) => {
-        const [detail, summary, taskPage] = await Promise.all([getCase(token, item.id), getCaseSummary(token, item.id), listCaseTasks(token, item.id)])
-        return { detail, summary, tasks: taskPage.items }
-      }))
-      setCases(workspaces); setMyTasks(assigned)
-    } catch (cause) { setFailure({ message: messageFrom(cause), retry: () => void load() }) } finally { setLoading(false) }
-  }, [token])
-  useEffect(() => { void load() }, [load])
+      const [memberships, assigned] = await Promise.all([
+        listCases(token),
+        listMyTasks(token),
+      ]);
+      const volunteerCases = memberships.filter(
+        (item) => item.access_role === "volunteer",
+      );
+      const workspaces = await Promise.all(
+        volunteerCases.map(async (item) => {
+          const [detail, summary, taskPage] = await Promise.all([
+            getCase(token, item.id),
+            getCaseSummary(token, item.id),
+            listCaseTasks(token, item.id),
+          ]);
+          return { detail, summary, tasks: taskPage.items };
+        }),
+      );
+      setCases(workspaces);
+      setMyTasks(assigned);
+    } catch (cause) {
+      setFailure({ message: messageFrom(cause), retry: () => void load() });
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+  useEffect(() => {
+    void load();
+  }, [load]);
 
-  async function run(taskId: string, action: () => Promise<void>, success: string) {
-    if (pendingTaskIdsRef.current.has(taskId)) return
-    pendingTaskIdsRef.current.add(taskId); setPendingTaskIds(new Set(pendingTaskIdsRef.current)); setFailure(null); setNotice('')
-    try { await action(); setNotice(success) } catch (cause) { setFailure({ message: messageFrom(cause), retry: () => void run(taskId, action, success) }) } finally {
-      pendingTaskIdsRef.current.delete(taskId); setPendingTaskIds(new Set(pendingTaskIdsRef.current))
+  async function run(
+    taskId: string,
+    action: () => Promise<void>,
+    success: string,
+  ) {
+    if (pendingTaskIdsRef.current.has(taskId)) return;
+    pendingTaskIdsRef.current.add(taskId);
+    setPendingTaskIds(new Set(pendingTaskIdsRef.current));
+    setFailure(null);
+    setNotice("");
+    try {
+      await action();
+      setNotice(success);
+    } catch (cause) {
+      setFailure({
+        message: messageFrom(cause),
+        retry: () => void run(taskId, action, success),
+      });
+    } finally {
+      pendingTaskIdsRef.current.delete(taskId);
+      setPendingTaskIds(new Set(pendingTaskIdsRef.current));
     }
   }
   function statusActions(status: TaskStatus): TaskStatus[] {
-    if (status === 'assigned') return ['accepted']
-    if (status === 'accepted') return ['active']
-    if (status === 'active') return ['blocked', 'completed']
-    if (status === 'blocked') return ['active']
-    return []
+    if (status === "assigned") return ["accepted"];
+    if (status === "accepted") return ["active"];
+    if (status === "active") return ["blocked", "completed"];
+    if (status === "blocked") return ["active"];
+    return [];
   }
   function refreshTask(updated: CaseTask) {
-    setMyTasks((current) => current.map((item) => item.id === updated.id ? updated : item))
-    setCases((current) => current.map((workspace) => ({ ...workspace, tasks: workspace.tasks.map((item) => item.id === updated.id ? updated : item) })))
+    setMyTasks((current) =>
+      current.map((item) => (item.id === updated.id ? updated : item)),
+    );
+    setCases((current) =>
+      current.map((workspace) => ({
+        ...workspace,
+        tasks: workspace.tasks.map((item) =>
+          item.id === updated.id ? updated : item,
+        ),
+      })),
+    );
   }
   function renderTask(task: CaseTask, assigned: boolean) {
-    const busy = pendingTaskIds.has(task.id)
-    const taskLocation = location[task.id] ?? { latitude: '', longitude: '', accuracy: '50' }
-    return <article key={task.id} className="rounded-md border border-slate-200 bg-white p-4 shadow-sm">
-      <div className="flex flex-wrap items-start justify-between gap-3"><div><h3 className="m-0 text-base font-bold text-slate-950">{task.title}</h3><p className="mb-0 mt-1 text-sm text-slate-700">{task.objective}</p></div><Chip size="sm" variant="soft"><Chip.Label>{statusLabels[task.status]}</Chip.Label></Chip></div>
-      <dl className="mt-3 grid gap-2 text-sm text-slate-600 sm:grid-cols-2"><div><dt className="font-medium text-slate-800">Task area</dt><dd className="m-0">{task.area_text}</dd></div><div><dt className="font-medium text-slate-800">Due</dt><dd className="m-0">{task.due_at}</dd></div></dl>
-      {!assigned && task.status === 'pending_claim' && <div className="mt-3"><Button size="sm" variant="secondary" isDisabled={busy} onPress={() => { if (token) void run(task.id, async () => { await applyForTask(token, task.id) }, 'Task application submitted for commander review.') }}><Users size={16} />Apply to collaborate</Button></div>}
-      {!assigned && task.status !== 'pending_claim' && <p className="mb-0 mt-3 text-xs text-slate-500">This task already has collaborators; task actions become available after approval.</p>}
-      {assigned && <>
-        <div className="mt-4 flex flex-wrap gap-2">{statusActions(task.status).map((status) => <Button key={status} size="sm" variant={status === 'completed' ? 'primary' : 'secondary'} isDisabled={busy} onPress={() => { if (token) void run(task.id, async () => refreshTask(await updateTaskStatus(token, task.id, status)), `Task marked ${statusLabels[status]}.`) }}>{statusLabels[status]}</Button>)}
-          <Button size="sm" variant="ghost" isDisabled={busy} onPress={() => { if (token) void run(task.id, async () => { const result = await getTaskNavigation(token, task.id); setNavigation((value) => ({ ...value, [task.id]: result })) }, 'Navigation instructions loaded.') }}><Compass size={16} />Navigation</Button>
-          <Button size="sm" variant="ghost" isDisabled={busy} onPress={() => { if (token) void run(task.id, async () => { const result = await getTaskSafetyBriefing(token, task.id); setSafety((value) => ({ ...value, [task.id]: result })) }, 'Safety briefing loaded.') }}><ShieldCheck size={16} />Safety</Button>
-          <Button size="sm" variant="ghost" isDisabled={busy} onPress={() => { if (token) void run(task.id, async () => { const result = await listTaskCollaborationLocations(token, task.id); setLocations((value) => ({ ...value, [task.id]: result })) }, 'Current collaboration locations loaded.') }}><MapPin size={16} />Collaboration locations</Button>
+    const busy = pendingTaskIds.has(task.id);
+    const taskLocation = location[task.id] ?? {
+      latitude: "",
+      longitude: "",
+      accuracy: "50",
+    };
+    return (
+      <article
+        key={task.id}
+        className="rounded-md border border-slate-200 bg-white p-4 shadow-sm"
+      >
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h3 className="m-0 text-base font-bold text-slate-950">
+              {task.title}
+            </h3>
+            <p className="mb-0 mt-1 text-sm text-slate-700">{task.objective}</p>
+          </div>
+          <Chip size="sm" variant="soft">
+            <Chip.Label>{statusLabels[task.status]}</Chip.Label>
+          </Chip>
         </div>
-        {navigation[task.id] && <p className="mt-3 rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-slate-700">{navigation[task.id].route_summary}</p>}
-        {safety[task.id] && <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-slate-700"><div className="font-semibold text-amber-900"><AlertTriangle className="mr-1 inline" size={16} />Safety briefing</div><ul className="mb-0 mt-2 list-disc space-y-1 pl-5">{safety[task.id].notices.map((item, index) => <li key={`${task.id}-${index}`}>{item}</li>)}</ul></div>}
-        {locations[task.id] && <ul className="mt-3 rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-900">{locations[task.id].length === 0 ? <li>No current collaborator location reports.</li> : locations[task.id].map((item) => <li key={item.volunteer_user_id}>{item.volunteer_user_id}: {item.latitude.toFixed(5)}, {item.longitude.toFixed(5)} (accuracy {item.accuracy_meters}m)</li>)}</ul>}
-        {task.status === 'active' && <div className="mt-4 grid gap-4 border-t border-slate-200 pt-4 lg:grid-cols-2">
-          <form className="grid gap-2" onSubmit={(event) => { event.preventDefault(); if (!token) return; if (!taskLocation.latitude.trim() || !taskLocation.longitude.trim() || !taskLocation.accuracy.trim()) { setFailure({ message: 'Enter latitude, longitude, and accuracy.', retry: null }); return } const latitude = Number(taskLocation.latitude); const longitude = Number(taskLocation.longitude); const accuracy = Number(taskLocation.accuracy); if (!Number.isFinite(latitude) || latitude < -90 || latitude > 90 || !Number.isFinite(longitude) || longitude < -180 || longitude > 180 || !Number.isFinite(accuracy) || accuracy <= 0) { setFailure({ message: 'Enter valid coordinates and a positive accuracy.', retry: null }); return } const key = crypto.randomUUID(); const payload = { source: 'simulated' as const, latitude, longitude, accuracy_meters: accuracy, captured_at: localNow() }; void run(task.id, async () => { await submitTaskLocationReport(token, task.id, payload, key) }, 'Simulated location report submitted.') }}><h4 className="m-0 text-sm font-semibold text-slate-950"><LocateFixed className="mr-1 inline" size={16} />Simulated location report</h4><div className="grid grid-cols-3 gap-2"><Input aria-label="Latitude" type="number" value={taskLocation.latitude} onChange={(event) => setLocation((value) => ({ ...value, [task.id]: { ...taskLocation, latitude: event.target.value } }))} /><Input aria-label="Longitude" type="number" value={taskLocation.longitude} onChange={(event) => setLocation((value) => ({ ...value, [task.id]: { ...taskLocation, longitude: event.target.value } }))} /><Input aria-label="Accuracy in metres" type="number" value={taskLocation.accuracy} onChange={(event) => setLocation((value) => ({ ...value, [task.id]: { ...taskLocation, accuracy: event.target.value } }))} /></div><Button type="submit" size="sm" variant="secondary" isDisabled={busy}>Submit location</Button></form>
-          <form className="grid gap-2" onSubmit={(event) => { event.preventDefault(); if (!token || !feedback[task.id]?.trim()) return; const key = crypto.randomUUID(); const payload = { content: feedback[task.id].trim(), occurred_at: localNow(), location_text: task.area_text, location_precision: 'approximate' as const }; void run(task.id, async () => { await submitTaskFeedback(token, task.id, payload, key); setFeedback((value) => ({ ...value, [task.id]: '' })) }, 'Feedback submitted for review.') }}><h4 className="m-0 text-sm font-semibold text-slate-950">Execution feedback</h4><TextArea aria-label="Execution feedback" value={feedback[task.id] ?? ''} rows={3} maxLength={4000} onChange={(event) => setFeedback((value) => ({ ...value, [task.id]: event.target.value }))} fullWidth /><Button type="submit" size="sm" variant="secondary" isDisabled={busy || !feedback[task.id]?.trim()}>Submit feedback</Button></form>
-        </div>}
-      </>}
-    </article>
+        <dl className="mt-3 grid gap-2 text-sm text-slate-600 sm:grid-cols-2">
+          <div>
+            <dt className="font-medium text-slate-800">Task area</dt>
+            <dd className="m-0">{task.area_text}</dd>
+          </div>
+          <div>
+            <dt className="font-medium text-slate-800">Due</dt>
+            <dd className="m-0">{task.due_at}</dd>
+          </div>
+        </dl>
+        {!assigned && task.status === "pending_claim" && (
+          <div className="mt-3">
+            <Button
+              size="sm"
+              variant="secondary"
+              isDisabled={busy}
+              onPress={() => {
+                if (token)
+                  void run(
+                    task.id,
+                    async () => {
+                      await applyForTask(token, task.id);
+                    },
+                    "Task application submitted for commander review.",
+                  );
+              }}
+            >
+              <Users size={16} />
+              Apply to collaborate
+            </Button>
+          </div>
+        )}
+        {!assigned && task.status !== "pending_claim" && (
+          <p className="mb-0 mt-3 text-xs text-slate-500">
+            This task already has collaborators; task actions become available
+            after approval.
+          </p>
+        )}
+        {assigned && (
+          <>
+            <div className="mt-4 flex flex-wrap gap-2">
+              {statusActions(task.status).map((status) => (
+                <Button
+                  key={status}
+                  size="sm"
+                  variant={status === "completed" ? "primary" : "secondary"}
+                  isDisabled={busy}
+                  onPress={() => {
+                    if (token)
+                      void run(
+                        task.id,
+                        async () =>
+                          refreshTask(
+                            await updateTaskStatus(token, task.id, status),
+                          ),
+                        `Task marked ${statusLabels[status]}.`,
+                      );
+                  }}
+                >
+                  {statusLabels[status]}
+                </Button>
+              ))}
+              <Button
+                size="sm"
+                variant="ghost"
+                isDisabled={busy}
+                onPress={() => {
+                  if (token)
+                    void run(
+                      task.id,
+                      async () => {
+                        const result = await getTaskNavigation(token, task.id);
+                        setNavigation((value) => ({
+                          ...value,
+                          [task.id]: result,
+                        }));
+                      },
+                      "Navigation instructions loaded.",
+                    );
+                }}
+              >
+                <Compass size={16} />
+                Navigation
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                isDisabled={busy}
+                onPress={() => {
+                  if (token)
+                    void run(
+                      task.id,
+                      async () => {
+                        const result = await getTaskSafetyBriefing(
+                          token,
+                          task.id,
+                        );
+                        setSafety((value) => ({ ...value, [task.id]: result }));
+                      },
+                      "Safety briefing loaded.",
+                    );
+                }}
+              >
+                <ShieldCheck size={16} />
+                Safety
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                isDisabled={busy}
+                onPress={() => {
+                  if (token)
+                    void run(
+                      task.id,
+                      async () => {
+                        const result = await listTaskCollaborationLocations(
+                          token,
+                          task.id,
+                        );
+                        setLocations((value) => ({
+                          ...value,
+                          [task.id]: result,
+                        }));
+                      },
+                      "Current collaboration locations loaded.",
+                    );
+                }}
+              >
+                <MapPin size={16} />
+                Collaboration locations
+              </Button>
+            </div>
+            {navigation[task.id] && (
+              <p className="mt-3 rounded-md border border-blue-200 bg-blue-50 p-3 text-sm text-slate-700">
+                {navigation[task.id].route_summary}
+              </p>
+            )}
+            {safety[task.id] && (
+              <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-slate-700">
+                <div className="font-semibold text-amber-900">
+                  <AlertTriangle className="mr-1 inline" size={16} />
+                  Safety briefing
+                </div>
+                <ul className="mb-0 mt-2 list-disc space-y-1 pl-5">
+                  {safety[task.id].notices.map((item, index) => (
+                    <li key={`${task.id}-${index}`}>{item}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {locations[task.id] && (
+              <ul className="mt-3 rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-900">
+                {locations[task.id].length === 0 ? (
+                  <li>No current collaborator location reports.</li>
+                ) : (
+                  locations[task.id].map((item) => (
+                    <li key={item.volunteer_user_id}>
+                      {item.volunteer_user_id}: {item.latitude.toFixed(5)},{" "}
+                      {item.longitude.toFixed(5)} (accuracy{" "}
+                      {item.accuracy_meters}m)
+                    </li>
+                  ))
+                )}
+              </ul>
+            )}
+            {task.status === "active" && (
+              <div className="mt-4 grid gap-4 border-t border-slate-200 pt-4 lg:grid-cols-2">
+                <form
+                  className="grid gap-2"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    if (!token) return;
+                    if (
+                      !taskLocation.latitude.trim() ||
+                      !taskLocation.longitude.trim() ||
+                      !taskLocation.accuracy.trim()
+                    ) {
+                      setFailure({
+                        message: "Enter latitude, longitude, and accuracy.",
+                        retry: null,
+                      });
+                      return;
+                    }
+                    const latitude = Number(taskLocation.latitude);
+                    const longitude = Number(taskLocation.longitude);
+                    const accuracy = Number(taskLocation.accuracy);
+                    if (
+                      !Number.isFinite(latitude) ||
+                      latitude < -90 ||
+                      latitude > 90 ||
+                      !Number.isFinite(longitude) ||
+                      longitude < -180 ||
+                      longitude > 180 ||
+                      !Number.isFinite(accuracy) ||
+                      accuracy <= 0
+                    ) {
+                      setFailure({
+                        message:
+                          "Enter valid coordinates and a positive accuracy.",
+                        retry: null,
+                      });
+                      return;
+                    }
+                    const key = crypto.randomUUID();
+                    const payload = {
+                      source: "simulated" as const,
+                      latitude,
+                      longitude,
+                      accuracy_meters: accuracy,
+                      captured_at: localNow(),
+                    };
+                    void run(
+                      task.id,
+                      async () => {
+                        await submitTaskLocationReport(
+                          token,
+                          task.id,
+                          payload,
+                          key,
+                        );
+                      },
+                      "Simulated location report submitted.",
+                    );
+                  }}
+                >
+                  <h4 className="m-0 text-sm font-semibold text-slate-950">
+                    <LocateFixed className="mr-1 inline" size={16} />
+                    Simulated location report
+                  </h4>
+                  <div className="grid grid-cols-3 gap-2">
+                    <Input
+                      aria-label="Latitude"
+                      type="number"
+                      value={taskLocation.latitude}
+                      onChange={(event) =>
+                        setLocation((value) => ({
+                          ...value,
+                          [task.id]: {
+                            ...taskLocation,
+                            latitude: event.target.value,
+                          },
+                        }))
+                      }
+                    />
+                    <Input
+                      aria-label="Longitude"
+                      type="number"
+                      value={taskLocation.longitude}
+                      onChange={(event) =>
+                        setLocation((value) => ({
+                          ...value,
+                          [task.id]: {
+                            ...taskLocation,
+                            longitude: event.target.value,
+                          },
+                        }))
+                      }
+                    />
+                    <Input
+                      aria-label="Accuracy in metres"
+                      type="number"
+                      value={taskLocation.accuracy}
+                      onChange={(event) =>
+                        setLocation((value) => ({
+                          ...value,
+                          [task.id]: {
+                            ...taskLocation,
+                            accuracy: event.target.value,
+                          },
+                        }))
+                      }
+                    />
+                  </div>
+                  <Button
+                    type="submit"
+                    size="sm"
+                    variant="secondary"
+                    isDisabled={busy}
+                  >
+                    Submit location
+                  </Button>
+                </form>
+                <form
+                  className="grid gap-2"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    if (!token || !feedback[task.id]?.trim()) return;
+                    const key = crypto.randomUUID();
+                    const payload = {
+                      content: feedback[task.id].trim(),
+                      occurred_at: localNow(),
+                      location_text: task.area_text,
+                      location_precision: "approximate" as const,
+                    };
+                    void run(
+                      task.id,
+                      async () => {
+                        await submitTaskFeedback(token, task.id, payload, key);
+                        setFeedback((value) => ({ ...value, [task.id]: "" }));
+                      },
+                      "Feedback submitted for review.",
+                    );
+                  }}
+                >
+                  <h4 className="m-0 text-sm font-semibold text-slate-950">
+                    Execution feedback
+                  </h4>
+                  <TextArea
+                    aria-label="Execution feedback"
+                    value={feedback[task.id] ?? ""}
+                    rows={3}
+                    maxLength={4000}
+                    onChange={(event) =>
+                      setFeedback((value) => ({
+                        ...value,
+                        [task.id]: event.target.value,
+                      }))
+                    }
+                    fullWidth
+                  />
+                  <Button
+                    type="submit"
+                    size="sm"
+                    variant="secondary"
+                    isDisabled={busy || !feedback[task.id]?.trim()}
+                  >
+                    Submit feedback
+                  </Button>
+                </form>
+              </div>
+            )}
+          </>
+        )}
+      </article>
+    );
   }
 
-  const myTaskIds = new Set(myTasks.map((task) => task.id))
-  return <main className="mx-auto w-full max-w-6xl px-4 py-7 sm:px-6 lg:px-10 lg:py-10"><header className="mb-7 flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-end"><div><span className="mb-1 block text-xs font-semibold text-slate-500">Volunteer collaboration</span><h1 className="m-0 text-2xl font-bold text-slate-950 lg:text-3xl">我的任务</h1><p className="mb-0 mt-1 text-sm text-slate-600">案件信息、开放任务、待核查线索与周边资源。</p></div><Button size="sm" variant="ghost" isDisabled={loading} onPress={() => void load()}><RefreshCw size={16} />Refresh</Button></header>{notice && <p className="mb-4 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">{notice}</p>}{failure && !loading && <div className="mb-4"><ErrorState message={failure.message} onRetry={failure.retry ?? undefined} /></div>}{loading ? <LoadingState label="Loading your collaboration workspace" /> : cases.length === 0 ? <EmptyState icon={Users} title="No collaboration cases yet" description="Cases where you are added as a volunteer will appear here before a task is assigned." /> : <section className="grid gap-6">{cases.map((workspace) => { const clueDraft = clueDrafts[workspace.detail.id] ?? { content: '', location: '' }; const assignedTasks = workspace.tasks.filter((task) => myTaskIds.has(task.id)); const openTasks = workspace.tasks.filter((task) => task.status === 'pending_claim' && !myTaskIds.has(task.id)); const category = poiCategory[workspace.detail.id] ?? 'hospital'; return <article key={workspace.detail.id} className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm"><div className="flex flex-wrap items-start justify-between gap-3"><div><span className="text-xs font-semibold text-slate-500">{workspace.detail.case_code}</span><h2 className="m-0 text-xl font-bold text-slate-950">{workspace.detail.elder_profile.display_name}</h2></div><Chip size="sm" variant="soft"><Chip.Label>{workspace.detail.status}</Chip.Label></Chip></div><div className="mt-4 grid gap-4 text-sm text-slate-700 lg:grid-cols-3"><div><h3 className="m-0 text-sm font-semibold text-slate-950">Family contact</h3><p className="mb-0 mt-1">{workspace.detail.family_contact_emails?.join(', ') || 'No family contact listed.'}</p></div><div><h3 className="m-0 text-sm font-semibold text-slate-950">Health notes</h3><p className="mb-0 mt-1">{workspace.detail.elder_profile.health_notes || 'No health notes listed.'}</p></div><div><h3 className="m-0 text-sm font-semibold text-slate-950">Case summary</h3><p className="mb-0 mt-1">{workspace.summary.last_confirmed_information?.content || 'No confirmed summary item yet.'}</p></div></div><div className="mt-5 grid gap-5 lg:grid-cols-2"><section><h3 className="m-0 text-sm font-semibold text-slate-950">Confirmed clues and my submissions</h3><ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-700">{workspace.detail.clues.length === 0 ? <li>No visible clues yet.</li> : workspace.detail.clues.slice(0, 8).map((clue) => <li key={clue.id}>{clue.content}{clue.is_own_submission && <span className="ml-1 text-xs text-slate-500">(submitted by me)</span>}</li>)}</ul><form className="mt-4 grid gap-2 rounded-md border border-slate-200 bg-slate-50 p-3" onSubmit={(event) => { event.preventDefault(); if (!token || !clueDraft.content.trim()) return; void run(`case-${workspace.detail.id}-clue`, async () => { await createClue(token, workspace.detail.id, { source: 'volunteer', source_type: 'field_report', content: clueDraft.content.trim(), occurred_at: localNow(), location_text: clueDraft.location.trim() || null, location_precision: clueDraft.location.trim() ? 'approximate' : null }); setClueDrafts((value) => ({ ...value, [workspace.detail.id]: { content: '', location: '' } })); await load() }, 'Observation submitted as a pending-review clue.') }}><h4 className="m-0 text-sm font-semibold text-slate-950"><Send className="mr-1 inline" size={16} />Submit observation for review</h4><TextArea aria-label="Observation content" value={clueDraft.content} maxLength={4000} rows={3} placeholder="Only describe what you observed; it remains pending until human review." onChange={(event) => setClueDrafts((value) => ({ ...value, [workspace.detail.id]: { ...clueDraft, content: event.target.value } }))} fullWidth /><Input aria-label="Observation location" value={clueDraft.location} maxLength={500} placeholder="Optional location description" onChange={(event) => setClueDrafts((value) => ({ ...value, [workspace.detail.id]: { ...clueDraft, location: event.target.value } }))} fullWidth /><Button type="submit" size="sm" variant="secondary" isDisabled={pendingTaskIds.has(`case-${workspace.detail.id}-clue`) || !clueDraft.content.trim()}>Submit for review</Button></form></section><section><h3 className="m-0 text-sm font-semibold text-slate-950">Nearby resources</h3><p className="mb-0 mt-1 text-xs text-slate-600">The server chooses an authorized center from a task area or confirmed public place; it does not accept a browser-provided center.</p><div className="mt-2 flex flex-wrap gap-2"><select aria-label="Nearby resource category" className="min-h-9 rounded-md border border-slate-300 bg-white px-2 text-sm" value={category} onChange={(event) => setPoiCategory((value) => ({ ...value, [workspace.detail.id]: event.target.value }))}><option value="hospital">Hospital</option><option value="police">Police</option><option value="transit">Transit</option><option value="market">Market</option><option value="community_service">Community service</option></select><Button size="sm" variant="secondary" isDisabled={pendingTaskIds.has(`case-${workspace.detail.id}-pois`)} onPress={() => { if (token) void run(`case-${workspace.detail.id}-pois`, async () => { const result = await listCasePois(token, workspace.detail.id, category); setPois((value) => ({ ...value, [workspace.detail.id]: result })) }, 'Nearby resources loaded.') }}><Search size={16} />Search nearby</Button></div>{pois[workspace.detail.id] && <div className="mt-3 rounded-md border border-slate-200 p-3 text-sm text-slate-700"><p className="m-0 text-xs text-slate-500">Source: {pois[workspace.detail.id].source}{pois[workspace.detail.id].fallback_message ? ` · ${pois[workspace.detail.id].fallback_message}` : ''}</p><ul className="mb-0 mt-2 list-disc space-y-1 pl-5">{pois[workspace.detail.id].items.map((poi) => <li key={poi.id}>{poi.name}{poi.address ? ` — ${poi.address}` : ''}</li>)}</ul></div>}</section></div><section className="mt-5 border-t border-slate-200 pt-5"><h3 className="m-0 text-base font-semibold text-slate-950">My collaboration tasks</h3><div className="mt-3 grid gap-3 xl:grid-cols-2">{assignedTasks.length === 0 ? <p className="mb-0 text-sm text-slate-500">You have not joined a task yet.</p> : assignedTasks.map((task) => renderTask(task, true))}</div></section><section className="mt-5 border-t border-slate-200 pt-5"><h3 className="m-0 text-base font-semibold text-slate-950">Open tasks</h3><p className="mb-0 mt-1 text-xs text-slate-600">These standing or field tasks are awaiting volunteer applications and commander approval.</p><div className="mt-3 grid gap-3 xl:grid-cols-2">{openTasks.length === 0 ? <p className="mb-0 text-sm text-slate-500">No open tasks at the moment.</p> : openTasks.map((task) => renderTask(task, false))}</div></section></article> })}</section>}</main>
+  const myTaskIds = new Set(myTasks.map((task) => task.id));
+  return (
+    <main className="mx-auto w-full max-w-6xl px-4 py-7 sm:px-6 lg:px-10 lg:py-10">
+      <header className="mb-7 flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-end">
+        <div>
+          <span className="mb-1 block text-xs font-semibold text-slate-500">
+            Volunteer collaboration
+          </span>
+          <h1 className="m-0 text-2xl font-bold text-slate-950 lg:text-3xl">
+            我的任务
+          </h1>
+          <p className="mb-0 mt-1 text-sm text-slate-600">
+            案件信息、开放任务、待核查线索与周边资源。
+          </p>
+        </div>
+        <Button
+          size="sm"
+          variant="ghost"
+          isDisabled={loading}
+          onPress={() => void load()}
+        >
+          <RefreshCw size={16} />
+          Refresh
+        </Button>
+      </header>
+      {notice && (
+        <p className="mb-4 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">
+          {notice}
+        </p>
+      )}
+      {failure && !loading && (
+        <div className="mb-4">
+          <ErrorState
+            message={failure.message}
+            onRetry={failure.retry ?? undefined}
+          />
+        </div>
+      )}
+      {loading ? (
+        <LoadingState label="Loading your collaboration workspace" />
+      ) : cases.length === 0 ? (
+        <EmptyState
+          icon={Users}
+          title="No collaboration cases yet"
+          description="Cases where you are added as a volunteer will appear here before a task is assigned."
+        />
+      ) : (
+        <section className="grid gap-6">
+          {cases.map((workspace) => {
+            const clueDraft = clueDrafts[workspace.detail.id] ?? {
+              content: "",
+              location: "",
+            };
+            const assignedTasks = workspace.tasks.filter((task) =>
+              myTaskIds.has(task.id),
+            );
+            const openTasks = workspace.tasks.filter(
+              (task) =>
+                task.status === "pending_claim" && !myTaskIds.has(task.id),
+            );
+            const category = poiCategory[workspace.detail.id] ?? "hospital";
+            return (
+              <article
+                key={workspace.detail.id}
+                className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <span className="text-xs font-semibold text-slate-500">
+                      {workspace.detail.case_code}
+                    </span>
+                    <h2 className="m-0 text-xl font-bold text-slate-950">
+                      {workspace.detail.elder_profile.display_name}
+                    </h2>
+                  </div>
+                  <Chip size="sm" variant="soft">
+                    <Chip.Label>{workspace.detail.status}</Chip.Label>
+                  </Chip>
+                </div>
+                <div className="mt-4 grid gap-4 text-sm text-slate-700 lg:grid-cols-3">
+                  <div>
+                    <h3 className="m-0 text-sm font-semibold text-slate-950">
+                      Family contact
+                    </h3>
+                    <p className="mb-0 mt-1">
+                      {workspace.detail.family_contact_emails?.join(", ") ||
+                        "No family contact listed."}
+                    </p>
+                  </div>
+                  <div>
+                    <h3 className="m-0 text-sm font-semibold text-slate-950">
+                      Health notes
+                    </h3>
+                    <p className="mb-0 mt-1">
+                      {workspace.detail.elder_profile.health_notes ||
+                        "No health notes listed."}
+                    </p>
+                  </div>
+                  <div>
+                    <h3 className="m-0 text-sm font-semibold text-slate-950">
+                      Case summary
+                    </h3>
+                    <p className="mb-0 mt-1">
+                      {workspace.summary.last_confirmed_information?.content ||
+                        "No confirmed summary item yet."}
+                    </p>
+                  </div>
+                </div>
+                <div className="mt-5 grid gap-5 lg:grid-cols-2">
+                  <section>
+                    <h3 className="m-0 text-sm font-semibold text-slate-950">
+                      Confirmed clues and my submissions
+                    </h3>
+                    <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-slate-700">
+                      {workspace.detail.clues.length === 0 ? (
+                        <li>No visible clues yet.</li>
+                      ) : (
+                        workspace.detail.clues.slice(0, 8).map((clue) => (
+                          <li key={clue.id}>
+                            {clue.content}
+                            {clue.is_own_submission && (
+                              <span className="ml-1 text-xs text-slate-500">
+                                (submitted by me)
+                              </span>
+                            )}
+                          </li>
+                        ))
+                      )}
+                    </ul>
+                    <form
+                      className="mt-4 grid gap-2 rounded-md border border-slate-200 bg-slate-50 p-3"
+                      onSubmit={(event) => {
+                        event.preventDefault();
+                        if (!token || !clueDraft.content.trim()) return;
+                        void run(
+                          `case-${workspace.detail.id}-clue`,
+                          async () => {
+                            await createClue(token, workspace.detail.id, {
+                              source: "volunteer",
+                              source_type: "field_report",
+                              content: clueDraft.content.trim(),
+                              occurred_at: localNow(),
+                              location_text: clueDraft.location.trim() || null,
+                              location_precision: clueDraft.location.trim()
+                                ? "approximate"
+                                : null,
+                            });
+                            setClueDrafts((value) => ({
+                              ...value,
+                              [workspace.detail.id]: {
+                                content: "",
+                                location: "",
+                              },
+                            }));
+                            await load();
+                          },
+                          "Observation submitted as a pending-review clue.",
+                        );
+                      }}
+                    >
+                      <h4 className="m-0 text-sm font-semibold text-slate-950">
+                        <Send className="mr-1 inline" size={16} />
+                        Submit observation for review
+                      </h4>
+                      <TextArea
+                        aria-label="Observation content"
+                        value={clueDraft.content}
+                        maxLength={4000}
+                        rows={3}
+                        placeholder="Only describe what you observed; it remains pending until human review."
+                        onChange={(event) =>
+                          setClueDrafts((value) => ({
+                            ...value,
+                            [workspace.detail.id]: {
+                              ...clueDraft,
+                              content: event.target.value,
+                            },
+                          }))
+                        }
+                        fullWidth
+                      />
+                      <Input
+                        aria-label="Observation location"
+                        value={clueDraft.location}
+                        maxLength={500}
+                        placeholder="Optional location description"
+                        onChange={(event) =>
+                          setClueDrafts((value) => ({
+                            ...value,
+                            [workspace.detail.id]: {
+                              ...clueDraft,
+                              location: event.target.value,
+                            },
+                          }))
+                        }
+                        fullWidth
+                      />
+                      <Button
+                        type="submit"
+                        size="sm"
+                        variant="secondary"
+                        isDisabled={
+                          pendingTaskIds.has(
+                            `case-${workspace.detail.id}-clue`,
+                          ) || !clueDraft.content.trim()
+                        }
+                      >
+                        Submit for review
+                      </Button>
+                    </form>
+                  </section>
+                  <section>
+                    <h3 className="m-0 text-sm font-semibold text-slate-950">
+                      Nearby resources
+                    </h3>
+                    <p className="mb-0 mt-1 text-xs text-slate-600">
+                      The server chooses an authorized center from a task area
+                      or confirmed public place; it does not accept a
+                      browser-provided center.
+                    </p>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      <select
+                        aria-label="Nearby resource category"
+                        className="min-h-9 rounded-md border border-slate-300 bg-white px-2 text-sm"
+                        value={category}
+                        onChange={(event) =>
+                          setPoiCategory((value) => ({
+                            ...value,
+                            [workspace.detail.id]: event.target.value,
+                          }))
+                        }
+                      >
+                        <option value="hospital">Hospital</option>
+                        <option value="police">Police</option>
+                        <option value="transit">Transit</option>
+                        <option value="market">Market</option>
+                        <option value="community_service">
+                          Community service
+                        </option>
+                      </select>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        isDisabled={pendingTaskIds.has(
+                          `case-${workspace.detail.id}-pois`,
+                        )}
+                        onPress={() => {
+                          if (token)
+                            void run(
+                              `case-${workspace.detail.id}-pois`,
+                              async () => {
+                                const result = await listCasePois(
+                                  token,
+                                  workspace.detail.id,
+                                  category,
+                                );
+                                setPois((value) => ({
+                                  ...value,
+                                  [workspace.detail.id]: result,
+                                }));
+                              },
+                              "Nearby resources loaded.",
+                            );
+                        }}
+                      >
+                        <Search size={16} />
+                        Search nearby
+                      </Button>
+                    </div>
+                    {pois[workspace.detail.id] && (
+                      <div className="mt-3 rounded-md border border-slate-200 p-3 text-sm text-slate-700">
+                        <p className="m-0 text-xs text-slate-500">
+                          Source: {pois[workspace.detail.id].source}
+                          {pois[workspace.detail.id].fallback_message
+                            ? ` · ${pois[workspace.detail.id].fallback_message}`
+                            : ""}
+                        </p>
+                        <ul className="mb-0 mt-2 list-disc space-y-1 pl-5">
+                          {pois[workspace.detail.id].items.map((poi) => (
+                            <li key={poi.id}>
+                              {poi.name}
+                              {poi.address ? ` — ${poi.address}` : ""}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                  </section>
+                </div>
+                <section className="mt-5 border-t border-slate-200 pt-5">
+                  <h3 className="m-0 text-base font-semibold text-slate-950">
+                    My collaboration tasks
+                  </h3>
+                  <div className="mt-3 grid gap-3 xl:grid-cols-2">
+                    {assignedTasks.length === 0 ? (
+                      <p className="mb-0 text-sm text-slate-500">
+                        You have not joined a task yet.
+                      </p>
+                    ) : (
+                      assignedTasks.map((task) => renderTask(task, true))
+                    )}
+                  </div>
+                </section>
+                <section className="mt-5 border-t border-slate-200 pt-5">
+                  <h3 className="m-0 text-base font-semibold text-slate-950">
+                    Open tasks
+                  </h3>
+                  <p className="mb-0 mt-1 text-xs text-slate-600">
+                    These standing or field tasks are awaiting volunteer
+                    applications and commander approval.
+                  </p>
+                  <div className="mt-3 grid gap-3 xl:grid-cols-2">
+                    {openTasks.length === 0 ? (
+                      <p className="mb-0 text-sm text-slate-500">
+                        No open tasks at the moment.
+                      </p>
+                    ) : (
+                      openTasks.map((task) => renderTask(task, false))
+                    )}
+                  </div>
+                </section>
+              </article>
+            );
+          })}
+        </section>
+      )}
+    </main>
+  );
 }

--- a/frontend/src/pages/WorkspacePage.tsx
+++ b/frontend/src/pages/WorkspacePage.tsx
@@ -1,11 +1,11 @@
-import { Card, Chip } from '@heroui/react'
-import { Inbox } from 'lucide-react'
+import { Card, Chip } from "@heroui/react";
+import { Inbox } from "lucide-react";
 
 interface WorkspacePageProps {
-  context: string
-  title: string
-  emptyTitle: string
-  emptyDescription: string
+  context: string;
+  title: string;
+  emptyTitle: string;
+  emptyDescription: string;
 }
 
 export function WorkspacePage({
@@ -17,25 +17,42 @@ export function WorkspacePage({
   return (
     <div className="mx-auto w-full max-w-7xl px-4 py-7 sm:px-6 lg:px-10 lg:py-10">
       <header className="mb-7 min-h-14">
-        <span className="mb-1 block text-xs font-semibold text-slate-500">{context}</span>
-        <h1 className="m-0 text-2xl font-bold text-slate-950 lg:text-3xl">{title}</h1>
+        <span className="mb-1 block text-xs font-semibold text-slate-500">
+          {context}
+        </span>
+        <h1 className="m-0 text-2xl font-bold text-slate-950 lg:text-3xl">
+          {title}
+        </h1>
       </header>
 
-      <Card className="overflow-hidden rounded-md! border border-slate-200 shadow-none" aria-labelledby="workspace-title">
+      <Card
+        className="overflow-hidden rounded-md! border border-slate-200 shadow-none"
+        aria-labelledby="workspace-title"
+      >
         <Card.Header className="flex min-h-18 flex-row! items-center! justify-between! gap-5 border-b border-slate-200 px-5 py-4">
-          <Card.Title id="workspace-title" className="text-base font-bold text-slate-950">当前工作</Card.Title>
+          <Card.Title
+            id="workspace-title"
+            className="text-base font-bold text-slate-950"
+          >
+            当前工作
+          </Card.Title>
           <Chip size="sm" variant="soft">
             <Chip.Label>0 条记录</Chip.Label>
           </Chip>
         </Card.Header>
         <Card.Content className="flex min-h-64 flex-col items-center justify-center px-5 py-8 text-center">
-          <span className="grid size-10 place-items-center rounded-md bg-slate-100 text-slate-400" aria-hidden="true">
+          <span
+            className="grid size-10 place-items-center rounded-md bg-slate-100 text-slate-400"
+            aria-hidden="true"
+          >
             <Inbox size={22} />
           </span>
           <strong className="mt-4 text-sm text-slate-950">{emptyTitle}</strong>
-          <span className="mt-1 max-w-md text-xs text-slate-500">{emptyDescription}</span>
+          <span className="mt-1 max-w-md text-xs text-slate-500">
+            {emptyDescription}
+          </span>
         </Card.Content>
       </Card>
     </div>
-  )
+  );
 }

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,10 +1,10 @@
-import '@testing-library/jest-dom/vitest'
-import { cleanup } from '@testing-library/react'
-import { afterEach, vi } from 'vitest'
+import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach, vi } from "vitest";
 
 afterEach(() => {
-  cleanup()
-  sessionStorage.clear()
-  vi.restoreAllMocks()
-  vi.unstubAllGlobals()
-})
+  cleanup();
+  sessionStorage.clear();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});


### PR DESCRIPTION
Closes #159\n\n## 变更内容\n- 对 frontend/src 中 30 个 TypeScript、TSX、CSS 与相关测试文件应用一致的格式风格。\n- 将较长的 JSX 属性、嵌套元素、条件渲染和函数调用拆分为多行，改善阅读与评审体验。\n- 未改变业务行为、接口契约或权限逻辑。\n\n## 验收对应\n- [x] 长 JSX/TSX 结构已在不改变渲染语义的前提下清晰换行。\n- [x] 前端代码已统一为本次提交的格式风格。\n- [x] 已执行 git diff --check，无空白错误。\n- [x] 不涉及 API、文档或配置内容变更。\n\n## 测试与质量检查\n- [x] git diff --check\n- [ ] yarn --cwd frontend lint：未通过；当前环境未安装 frontend 依赖，找不到 oxlint。\n- [ ] yarn --cwd frontend test / yarn --cwd frontend build：未执行；同样受本地依赖缺失阻塞。\n- 本 PR 为格式化维护，不新增或修改行为测试。\n\n## 风险与边界\n无权限、隐私、AI、定位、第三方服务或业务行为变化。已知限制：尚未在安装前端依赖的环境中运行 lint、测试和构建。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式与重构**
  - 统一前端界面的代码格式、引号、分号、缩进及 JSX 排版，提升可读性与维护性。
  - 未改变登录、认证、案件处理、表单、任务协作及资料管理等现有功能。
- **可访问性**
  - 为仪表盘的加载、错误、指标和案件态势区域补充更明确的辅助标签。
- **测试**
  - 统一各项测试代码格式，测试场景与验证结果保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->