### PR TITLE
feat(frontend): prioritize role-based case workspaces

### DIFF
--- a/frontend/src/pages/CaseWorkspacePage.test.tsx
+++ b/frontend/src/pages/CaseWorkspacePage.test.tsx
@@ -131,7 +131,8 @@ describe("CaseWorkspacePage", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: "补充人物资料（主操作）" }),
-    ).toHaveAttribute("href", "#case-profile");
+    ).toHaveAttribute("href", "#case-profile-editor");
+    expect(document.getElementById("case-profile-editor")).toBeInTheDocument();
     expect(screen.getByRole("navigation", { name: "案件工作区导航" })).toBeInTheDocument();
     expect(screen.getByText("补充或更正人物资料").closest("details")).not.toHaveAttribute(
       "open",
@@ -144,6 +145,95 @@ describe("CaseWorkspacePage", () => {
     );
     expect(screen.queryByRole("heading", { name: "任务看板" })).not.toBeInTheDocument();
     expect(mocked.listCaseTasks).not.toHaveBeenCalled();
+  });
+
+  it("sends a volunteer to assigned tasks from the primary action", async () => {
+    vi.clearAllMocks();
+    mocked.listCases.mockResolvedValue([
+      {
+        id: "case-volunteer-workspace",
+        case_code: "AG-VOLUNTEER-WORKSPACE",
+        status: "active",
+        access_role: "volunteer",
+        display_name: "Volunteer workspace",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
+      },
+    ]);
+    mocked.getCase.mockResolvedValue(
+      detail("case-volunteer-workspace", "Volunteer workspace", "volunteer"),
+    );
+    mocked.getCaseResourceConfiguration.mockResolvedValue({
+      attachment_max_image_bytes: 5 * 1024 * 1024,
+      attachment_max_per_case: 12,
+      case_place_types: ["frequent"],
+    });
+    mocked.getCaseMapView.mockResolvedValue({ items: [] });
+    mocked.listCaseTasks.mockResolvedValue({
+      items: [],
+      page: 1,
+      page_size: 25,
+      total: 0,
+    });
+    mocked.listCaseMembers.mockResolvedValue([]);
+    mocked.listCaseClues.mockResolvedValue({
+      items: [],
+      page: 1,
+      page_size: 25,
+      total: 0,
+    });
+
+    render(<CaseWorkspacePage mode="volunteer" />);
+
+    expect(await screen.findByRole("heading", { name: "协作提示" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "查看已分配任务（主操作）" }),
+    ).toHaveAttribute("href", "#task-board");
+  });
+
+  it("does not offer family clue submission after a case is resolved", async () => {
+    vi.clearAllMocks();
+    mocked.listCases.mockResolvedValue([
+      {
+        id: "case-family-resolved",
+        case_code: "AG-FAMILY-RESOLVED",
+        status: "resolved",
+        access_role: "family",
+        display_name: "Resolved family workspace",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
+      },
+    ]);
+    mocked.getCase.mockResolvedValue(
+      detail(
+        "case-family-resolved",
+        "Resolved family workspace",
+        "family",
+        "resolved",
+      ),
+    );
+    mocked.getCaseResourceConfiguration.mockResolvedValue({
+      attachment_max_image_bytes: 5 * 1024 * 1024,
+      attachment_max_per_case: 12,
+      case_place_types: ["frequent"],
+    });
+    mocked.getCaseMapView.mockResolvedValue({ items: [] });
+
+    render(<CaseWorkspacePage mode="family" />);
+
+    expect(
+      await screen.findByText("案件已找到，不能再提交补充信息。"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "查看案件资料（主操作）" }),
+    ).toHaveAttribute("href", "#case-profile");
+    expect(
+      screen.queryByRole("link", { name: "提交一条新线索（主操作）" }),
+    ).not.toBeInTheDocument();
   });
 
   it("puts commander task and review work ahead of case materials", async () => {

--- a/frontend/src/pages/CaseWorkspacePage.test.tsx
+++ b/frontend/src/pages/CaseWorkspacePage.test.tsx
@@ -191,6 +191,7 @@ describe("CaseWorkspacePage", () => {
     expect(
       screen.getByRole("link", { name: "查看已分配任务（主操作）" }),
     ).toHaveAttribute("href", "#task-board");
+    expect(document.getElementById("task-board")).toBeInTheDocument();
   });
 
   it("does not offer family clue submission after a case is resolved", async () => {
@@ -231,9 +232,12 @@ describe("CaseWorkspacePage", () => {
     expect(
       screen.getByRole("link", { name: "查看案件资料（主操作）" }),
     ).toHaveAttribute("href", "#case-profile");
+    expect(document.getElementById("case-profile")).toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: "提交一条新线索（主操作）" }),
     ).not.toBeInTheDocument();
+    expect(screen.queryByText("提交一条新线索")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "提交线索" })).not.toBeInTheDocument();
   });
 
   it("puts commander task and review work ahead of case materials", async () => {
@@ -289,6 +293,7 @@ describe("CaseWorkspacePage", () => {
       "href",
       "#task-board",
     );
+    expect(document.getElementById("task-board")).toBeInTheDocument();
     expect(screen.getByText("案件状态与成员管理").closest("details")).not.toHaveAttribute(
       "open",
     );

--- a/frontend/src/pages/CaseWorkspacePage.test.tsx
+++ b/frontend/src/pages/CaseWorkspacePage.test.tsx
@@ -99,6 +99,111 @@ function detail(
 }
 
 describe("CaseWorkspacePage", () => {
+  it("gives a family member one next action and keeps long forms collapsed", async () => {
+    vi.clearAllMocks();
+    mocked.listCases.mockResolvedValue([
+      {
+        id: "case-family-workspace",
+        case_code: "AG-FAMILY-WORKSPACE",
+        status: "active",
+        access_role: "family",
+        display_name: "Family workspace",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
+      },
+    ]);
+    mocked.getCase.mockResolvedValue(
+      detail("case-family-workspace", "Family workspace", "family"),
+    );
+    mocked.getCaseResourceConfiguration.mockResolvedValue({
+      attachment_max_image_bytes: 5 * 1024 * 1024,
+      attachment_max_per_case: 12,
+      case_place_types: ["frequent"],
+    });
+    mocked.getCaseMapView.mockResolvedValue({ items: [] });
+
+    render(<CaseWorkspacePage mode="family" />);
+
+    expect(
+      await screen.findByRole("heading", { name: "当前可以做什么" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "补充人物资料（主操作）" }),
+    ).toHaveAttribute("href", "#case-profile");
+    expect(screen.getByRole("navigation", { name: "案件工作区导航" })).toBeInTheDocument();
+    expect(screen.getByText("补充或更正人物资料").closest("details")).not.toHaveAttribute(
+      "open",
+    );
+    expect(screen.getByText("案件状态与成员管理").closest("details")).not.toHaveAttribute(
+      "open",
+    );
+    expect(screen.getByText("提交一条新线索").closest("details")).not.toHaveAttribute(
+      "open",
+    );
+    expect(screen.queryByRole("heading", { name: "任务看板" })).not.toBeInTheDocument();
+    expect(mocked.listCaseTasks).not.toHaveBeenCalled();
+  });
+
+  it("puts commander task and review work ahead of case materials", async () => {
+    vi.clearAllMocks();
+    mocked.listCommandIntake.mockResolvedValue([]);
+    mocked.listCases.mockResolvedValue([
+      {
+        id: "case-commander-workspace",
+        case_code: "AG-COMMANDER-WORKSPACE",
+        status: "active",
+        access_role: "commander",
+        display_name: "Commander workspace",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
+      },
+    ]);
+    mocked.getCase.mockResolvedValue(
+      detail("case-commander-workspace", "Commander workspace", "commander"),
+    );
+    mocked.getCaseResourceConfiguration.mockResolvedValue({
+      attachment_max_image_bytes: 5 * 1024 * 1024,
+      attachment_max_per_case: 12,
+      case_place_types: ["frequent"],
+    });
+    mocked.getCaseMapView.mockResolvedValue({ items: [] });
+    mocked.listCaseTasks.mockResolvedValue({
+      items: [],
+      page: 1,
+      page_size: 25,
+      total: 0,
+    });
+    mocked.listCaseMembers.mockResolvedValue([]);
+    mocked.listCaseClues.mockResolvedValue({
+      items: [],
+      page: 1,
+      page_size: 25,
+      total: 0,
+    });
+
+    render(<CaseWorkspacePage mode="commander" />);
+
+    expect(
+      await screen.findByRole("heading", { name: "指挥工作台" }),
+    ).toBeInTheDocument();
+    const taskHeading = screen.getByRole("heading", { name: "任务看板" });
+    const clueHeading = screen.getByRole("heading", { name: "线索" });
+    expect(taskHeading.compareDocumentPosition(clueHeading)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(screen.getByRole("link", { name: "前往任务和审核区（主操作）" })).toHaveAttribute(
+      "href",
+      "#task-board",
+    );
+    expect(screen.getByText("案件状态与成员管理").closest("details")).not.toHaveAttribute(
+      "open",
+    );
+  });
+
   it("lets a commander accept a minimal pending case before viewing it", async () => {
     mocked.listCases.mockResolvedValue([]);
     mocked.listCommandIntake.mockResolvedValue([

--- a/frontend/src/pages/CaseWorkspacePage.tsx
+++ b/frontend/src/pages/CaseWorkspacePage.tsx
@@ -603,7 +603,7 @@ function CaseDetailView({
       </section>
 
       {canEditElderProfile && (
-        <details className="border-b border-slate-200 bg-brand-50/30">
+        <details id="case-profile-editor" className="border-b border-slate-200 bg-brand-50/30">
           <summary className="cursor-pointer px-5 py-4 text-sm font-semibold text-slate-900 sm:px-6">
             补充或更正人物资料
           </summary>
@@ -1571,6 +1571,7 @@ function RoleActionPanel({
 }) {
   const isCommander = accessRole === "commander";
   const isFamily = accessRole === "family";
+  const isActive = caseStatus === "active";
   const heading = isCommander
     ? "指挥工作台"
     : isFamily
@@ -1581,22 +1582,32 @@ function RoleActionPanel({
       ? `有 ${pendingCount} 条线索等待人工审核，请先完成审核并记录理由。`
       : "当前没有待审核线索；可在任务看板查看或创建受控任务。"
     : isFamily
-      ? hasProfileGaps
+      ? !isActive
+        ? caseStatus === "resolved"
+          ? "案件已找到，不能再提交补充信息。"
+          : "案件已关闭，不能再提交补充信息。"
+        : hasProfileGaps
         ? "请先补充关键人物资料，再提交新的线索、地点或图片。"
         : "可补充线索、地点或图片；提交的信息会先进入人工审核。"
       : "请查看已分配任务与经服务端裁剪后的案件信息。";
   const action = isCommander
     ? "前往任务和审核区"
     : isFamily
-      ? hasProfileGaps
+      ? isActive && hasProfileGaps
         ? "补充人物资料"
-        : "提交一条新线索"
-      : "查看案件资料";
+        : isActive
+          ? "提交一条新线索"
+          : "查看案件资料"
+      : "查看已分配任务";
   const target = isCommander
     ? "#task-board"
-    : isFamily && hasProfileGaps
-      ? "#case-profile"
-      : "#case-clues";
+    : isFamily
+      ? isActive && hasProfileGaps
+        ? "#case-profile-editor"
+        : isActive
+          ? "#case-clues"
+          : "#case-profile"
+      : "#task-board";
 
   return (
     <section
@@ -1613,7 +1624,7 @@ function RoleActionPanel({
             {heading}
           </h3>
           <p className="mb-0 mt-1 text-sm leading-6 text-slate-700">
-            {caseStatus === "closed" ? "案件已关闭，不能再提交补充信息。" : description}
+            {description}
           </p>
         </div>
         <a

--- a/frontend/src/pages/CaseWorkspacePage.tsx
+++ b/frontend/src/pages/CaseWorkspacePage.tsx
@@ -539,11 +539,42 @@ function CaseDetailView({
         </div>
       </header>
 
-      <TaskBoard detail={detail} token={token} />
-      <CaseSituationPanel detail={detail} token={token} />
+      <RoleActionPanel
+        accessRole={detail.access_role}
+        caseStatus={detail.status}
+        pendingCount={pendingCount}
+        hasProfileGaps={
+          !detail.elder_profile.last_seen_location ||
+          !detail.elder_profile.last_seen_at ||
+          !detail.elder_profile.physical_description
+        }
+      />
+      <nav
+        className="flex flex-wrap gap-x-4 gap-y-2 border-b border-slate-200 bg-white px-5 py-3 text-sm font-medium sm:px-6"
+        aria-label="案件工作区导航"
+      >
+        <a
+          className="text-brand-700 underline-offset-4 hover:underline"
+          href={detail.access_role === "family" ? "#case-actions" : "#task-board"}
+        >
+          当前行动
+        </a>
+        <a className="text-brand-700 underline-offset-4 hover:underline" href="#case-clues">
+          线索与地点
+        </a>
+        <a className="text-brand-700 underline-offset-4 hover:underline" href="#case-profile">
+          案件资料
+        </a>
+      </nav>
+
+      {detail.access_role !== "family" && (
+        <TaskBoard detail={detail} token={token} />
+      )}
       <CaseCollaborationPanel detail={detail} token={token} />
+      <CaseSituationPanel detail={detail} token={token} />
 
       <section
+        id="case-profile"
         className="grid gap-x-8 gap-y-4 border-b border-slate-200 px-5 py-5 sm:grid-cols-2 sm:px-6 lg:grid-cols-3"
         aria-label="老人资料"
       >
@@ -572,87 +603,96 @@ function CaseDetailView({
       </section>
 
       {canEditElderProfile && (
-        <ElderProfileEditor
-          detail={detail}
-          token={token}
-          busy={busy}
-          onSave={(payload) =>
-            run(
-              "elder-profile",
-              () => updateElderProfile(token!, detail.id, payload),
-              "人物摘要已更新",
-            )
-          }
-        />
+        <details className="border-b border-slate-200 bg-brand-50/30">
+          <summary className="cursor-pointer px-5 py-4 text-sm font-semibold text-slate-900 sm:px-6">
+            补充或更正人物资料
+          </summary>
+          <ElderProfileEditor
+            detail={detail}
+            token={token}
+            busy={busy}
+            onSave={(payload) =>
+              run(
+                "elder-profile",
+                () => updateElderProfile(token!, detail.id, payload),
+                "人物摘要已更新",
+              )
+            }
+          />
+        </details>
       )}
 
       {(isCommander || detail.access_role === "family") && (
-        <section className="grid gap-5 border-b border-slate-200 bg-slate-50 px-5 py-5 sm:px-6 lg:grid-cols-2">
-          {isCommander && (
+        <details className="border-b border-slate-200 bg-slate-50">
+          <summary className="cursor-pointer px-5 py-4 text-sm font-semibold text-slate-900 sm:px-6">
+            案件状态与成员管理
+          </summary>
+          <section className="grid gap-5 px-5 pb-5 sm:px-6 lg:grid-cols-2">
+            {isCommander && (
+              <form
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  if (!token) return;
+                  void run(
+                    "status",
+                    () => updateCaseStatus(token, detail.id, nextStatus),
+                    "案件状态已更新",
+                  );
+                }}
+              >
+                <h3
+                  id="case-status-title"
+                  className="m-0 text-sm font-bold text-slate-950"
+                >
+                  案件状态
+                </h3>
+                <div className="mt-3 flex gap-2">
+                  <select
+                    aria-labelledby="case-status-title"
+                    className="min-h-10 flex-1 rounded-md border border-slate-300 bg-white px-3 text-sm"
+                    value={nextStatus}
+                    onChange={(event) =>
+                      setNextStatus(event.target.value as CaseStatus)
+                    }
+                    disabled={detail.status === "closed"}
+                  >
+                    {statusOptions.map((status) => (
+                      <option key={status} value={status}>
+                        {statusLabels[status]}
+                      </option>
+                    ))}
+                  </select>
+                  <Button
+                    type="submit"
+                    size="sm"
+                    variant="secondary"
+                    isDisabled={busy === "status" || nextStatus === detail.status}
+                  >
+                    保存
+                  </Button>
+                </div>
+              </form>
+            )}
+
             <form
               onSubmit={(event) => {
                 event.preventDefault();
                 if (!token) return;
                 void run(
-                  "status",
-                  () => updateCaseStatus(token, detail.id, nextStatus),
-                  "案件状态已更新",
-                );
+                  "member",
+                  () =>
+                    addCaseMember(
+                      token,
+                      detail.id,
+                      memberEmail.trim(),
+                      selectedMemberRole,
+                    ),
+                  "案件成员已添加",
+                ).then((succeeded) => {
+                  if (succeeded) setMemberEmail("");
+                });
               }}
             >
-              <h3
-                id="case-status-title"
-                className="m-0 text-sm font-bold text-slate-950"
-              >
-                案件状态
-              </h3>
-              <div className="mt-3 flex gap-2">
-                <select
-                  aria-labelledby="case-status-title"
-                  className="min-h-10 flex-1 rounded-md border border-slate-300 bg-white px-3 text-sm"
-                  value={nextStatus}
-                  onChange={(event) =>
-                    setNextStatus(event.target.value as CaseStatus)
-                  }
-                  disabled={detail.status === "closed"}
-                >
-                  {statusOptions.map((status) => (
-                    <option key={status} value={status}>
-                      {statusLabels[status]}
-                    </option>
-                  ))}
-                </select>
-                <Button
-                  type="submit"
-                  size="sm"
-                  variant="secondary"
-                  isDisabled={busy === "status" || nextStatus === detail.status}
-                >
-                  保存
-                </Button>
-              </div>
-            </form>
-          )}
-
-          <form
-            onSubmit={(event) => {
-              event.preventDefault();
-              if (!token) return;
-              void run(
-                "member",
-                () =>
-                  addCaseMember(
-                    token,
-                    detail.id,
-                    memberEmail.trim(),
-                    selectedMemberRole,
-                  ),
-                "案件成员已添加",
-              ).then((succeeded) => {
-                if (succeeded) setMemberEmail("");
-              });
-            }}
-          >
             <h3 className="m-0 text-sm font-bold text-slate-950">添加成员</h3>
             <div className="mt-3 grid gap-2 sm:grid-cols-[minmax(0,1fr)_120px_auto]">
               <Input
@@ -687,8 +727,9 @@ function CaseDetailView({
                 <UserPlus size={17} />
               </Button>
             </div>
-          </form>
-        </section>
+            </form>
+          </section>
+        </details>
       )}
 
       {error && (
@@ -697,7 +738,7 @@ function CaseDetailView({
         </div>
       )}
 
-      <section className="px-5 py-5 sm:px-6" aria-labelledby="clues-title">
+      <section id="case-clues" className="px-5 py-5 sm:px-6" aria-labelledby="clues-title">
         <div className="flex items-center justify-between gap-3">
           <h3
             id="clues-title"
@@ -1085,8 +1126,12 @@ function CaseDetailView({
         )}
 
         {detail.status === "active" && (
-          <form
-            className="mt-5 grid gap-3 sm:grid-cols-[minmax(0,1fr)_220px]"
+          <details className="mt-5 rounded-md border border-slate-200 bg-slate-50">
+            <summary className="cursor-pointer px-3 py-3 text-sm font-semibold text-slate-900">
+              {isCommander ? "提交补充线索" : "提交一条新线索"}
+            </summary>
+            <form
+              className="grid gap-3 border-t border-slate-200 p-3 sm:grid-cols-[minmax(0,1fr)_220px] sm:p-4"
             onSubmit={(event) => {
               event.preventDefault();
               if (!token) return;
@@ -1238,7 +1283,8 @@ function CaseDetailView({
                 提交线索
               </Button>
             </div>
-          </form>
+            </form>
+          </details>
         )}
       </section>
 
@@ -1512,6 +1558,76 @@ function CaseDetailView({
   );
 }
 
+function RoleActionPanel({
+  accessRole,
+  caseStatus,
+  pendingCount,
+  hasProfileGaps,
+}: {
+  accessRole: CaseRole;
+  caseStatus: CaseStatus;
+  pendingCount: number;
+  hasProfileGaps: boolean;
+}) {
+  const isCommander = accessRole === "commander";
+  const isFamily = accessRole === "family";
+  const heading = isCommander
+    ? "指挥工作台"
+    : isFamily
+      ? "当前可以做什么"
+      : "协作提示";
+  const description = isCommander
+    ? pendingCount > 0
+      ? `有 ${pendingCount} 条线索等待人工审核，请先完成审核并记录理由。`
+      : "当前没有待审核线索；可在任务看板查看或创建受控任务。"
+    : isFamily
+      ? hasProfileGaps
+        ? "请先补充关键人物资料，再提交新的线索、地点或图片。"
+        : "可补充线索、地点或图片；提交的信息会先进入人工审核。"
+      : "请查看已分配任务与经服务端裁剪后的案件信息。";
+  const action = isCommander
+    ? "前往任务和审核区"
+    : isFamily
+      ? hasProfileGaps
+        ? "补充人物资料"
+        : "提交一条新线索"
+      : "查看案件资料";
+  const target = isCommander
+    ? "#task-board"
+    : isFamily && hasProfileGaps
+      ? "#case-profile"
+      : "#case-clues";
+
+  return (
+    <section
+      id="case-actions"
+      className="border-b border-emerald-200 bg-emerald-50/70 px-5 py-5 sm:px-6"
+      aria-labelledby="role-actions-title"
+    >
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+        <div className="max-w-2xl">
+          <p className="m-0 text-xs font-semibold text-emerald-800">
+            {isCommander ? "先处理待办，再查看资料" : "根据当前案件状态继续"}
+          </p>
+          <h3 id="role-actions-title" className="mb-0 mt-1 text-lg font-bold text-slate-950">
+            {heading}
+          </h3>
+          <p className="mb-0 mt-1 text-sm leading-6 text-slate-700">
+            {caseStatus === "closed" ? "案件已关闭，不能再提交补充信息。" : description}
+          </p>
+        </div>
+        <a
+          className="inline-flex min-h-10 items-center justify-center rounded-md bg-brand-700 px-4 text-sm font-semibold text-white no-underline transition-colors hover:bg-brand-800 focus:outline-none focus:ring-2 focus:ring-brand-700 focus:ring-offset-2"
+          href={target}
+          aria-label={`${action}（主操作）`}
+        >
+          {action}
+        </a>
+      </div>
+    </section>
+  );
+}
+
 const taskStatusLabels: Record<string, string> = {
   pending_claim: "待志愿者申请",
   assigned: "待领取",
@@ -1633,6 +1749,7 @@ function TaskBoard({
   }
   return (
     <section
+      id="task-board"
       className="border-b border-slate-200 px-5 py-5 sm:px-6"
       aria-label="任务看板"
     >
@@ -2512,7 +2629,8 @@ function CaseCollaborationPanel({
         </div>
       )}
 
-      <div className="min-w-0">
+      {isCommander && (
+        <div className="min-w-0">
         <h3 className="m-0 text-base font-bold text-slate-950">
           文本整理为待审核线索
         </h3>
@@ -2563,7 +2681,8 @@ function CaseCollaborationPanel({
             </p>
           </div>
         ))}
-      </div>
+        </div>
+      )}
 
       {isCommander && (
         <div className="min-w-0">


### PR DESCRIPTION
Closes #161

## 变更内容
- 新增按角色显示的案件工作台行动摘要和页内导航，将“当前行动、线索与地点、案件资料”分层组织。
- 家属端首屏突出一个根据资料完整度决定的下一步操作；人物资料、成员管理和线索提交表单默认折叠，避免连续长表单。
- 指挥端将任务看板与线索审核保留在案件资料之前，主操作跳转至任务区；任务、审核和人工确认逻辑保持不变。
- 家属端不再加载或展示任务看板、内部文本整理草稿；服务端字段裁剪与 RBAC 仍是唯一的权限控制。
- 新增角色化工作区测试，覆盖家属的主行动/折叠状态与指挥端的任务、审核优先级。

## 验收对应
- [x] 家属端可识别案件状态、下一步和已核实公开进展，低频表单不再同时展开。
- [x] 指挥端将任务与线索审核排在资料之前，并使用独立主操作入口。
- [x] 保留可见标签、语义链接、键盘可访问的原生折叠控件、错误提示和现有人工审核流程。
- [x] 未改动服务端 RBAC、字段裁剪、API 契约、位置精度规则或公开进展规则。
- [x] 已补充前端自动化测试覆盖新的角色层级。

## 测试与质量检查
- [x] `frontend/node_modules/.bin/vitest.cmd run src/pages/CaseWorkspacePage.test.tsx`（16 passed）
- [x] `frontend/node_modules/.bin/oxlint.cmd`
- [x] `frontend/node_modules/.bin/tsc.cmd -b`
- [x] `frontend/node_modules/.bin/vite.cmd build`
- [x] `git diff --check`
- Vite 构建成功，并保留项目现有的单个 bundle 大于 500 kB 提示；本 PR 未引入新的资源或依赖。

## 风险与边界
无权限、隐私、AI、定位、第三方服务或对外发布行为变化。前端的折叠和隐藏仅用于降低认知负荷，不替代服务端授权检查。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 案件详情页新增按角色显示的行动提示面板和工作区导航。
  * 非家属角色可查看任务看板及相关跳转入口。
  * 人物资料、案件状态、成员管理和线索提交区域支持折叠。
  * 志愿者可直接进入已分配任务；已解决案件不再显示家属线索提交入口。
  * 指挥工作区优先展示任务与审核入口，线索草稿整理功能仅对指挥角色显示。

* **测试**
  * 新增家属、志愿者及指挥工作区场景测试，覆盖操作入口、默认折叠状态和空任务列表加载。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->