### PR TITLE
feat(command): add case detail navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -70,6 +70,14 @@ function App() {
           }
         />
         <Route
+          path="command/cases/:caseId"
+          element={
+            <CaseRoleRoute capability="commander">
+              <CaseWorkspacePage mode="commander" />
+            </CaseRoleRoute>
+          }
+        />
+        <Route
           path="volunteer"
           element={
             <CaseRoleRoute capability="volunteer">

--- a/frontend/src/pages/CaseWorkspacePage.test.tsx
+++ b/frontend/src/pages/CaseWorkspacePage.test.tsx
@@ -131,7 +131,8 @@ describe("CaseWorkspacePage", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: "补充人物资料（主操作）" }),
-    ).toHaveAttribute("href", "#case-profile");
+    ).toHaveAttribute("href", "#case-profile-editor");
+    expect(document.getElementById("case-profile-editor")).toBeInTheDocument();
     expect(screen.getByRole("navigation", { name: "案件工作区导航" })).toBeInTheDocument();
     expect(screen.getByText("补充或更正人物资料").closest("details")).not.toHaveAttribute(
       "open",
@@ -144,6 +145,95 @@ describe("CaseWorkspacePage", () => {
     );
     expect(screen.queryByRole("heading", { name: "任务看板" })).not.toBeInTheDocument();
     expect(mocked.listCaseTasks).not.toHaveBeenCalled();
+  });
+
+  it("sends a volunteer to assigned tasks from the primary action", async () => {
+    vi.clearAllMocks();
+    mocked.listCases.mockResolvedValue([
+      {
+        id: "case-volunteer-workspace",
+        case_code: "AG-VOLUNTEER-WORKSPACE",
+        status: "active",
+        access_role: "volunteer",
+        display_name: "Volunteer workspace",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
+      },
+    ]);
+    mocked.getCase.mockResolvedValue(
+      detail("case-volunteer-workspace", "Volunteer workspace", "volunteer"),
+    );
+    mocked.getCaseResourceConfiguration.mockResolvedValue({
+      attachment_max_image_bytes: 5 * 1024 * 1024,
+      attachment_max_per_case: 12,
+      case_place_types: ["frequent"],
+    });
+    mocked.getCaseMapView.mockResolvedValue({ items: [] });
+    mocked.listCaseTasks.mockResolvedValue({
+      items: [],
+      page: 1,
+      page_size: 25,
+      total: 0,
+    });
+    mocked.listCaseMembers.mockResolvedValue([]);
+    mocked.listCaseClues.mockResolvedValue({
+      items: [],
+      page: 1,
+      page_size: 25,
+      total: 0,
+    });
+
+    render(<CaseWorkspacePage mode="volunteer" />);
+
+    expect(await screen.findByRole("heading", { name: "协作提示" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "查看已分配任务（主操作）" }),
+    ).toHaveAttribute("href", "#task-board");
+  });
+
+  it("does not offer family clue submission after a case is resolved", async () => {
+    vi.clearAllMocks();
+    mocked.listCases.mockResolvedValue([
+      {
+        id: "case-family-resolved",
+        case_code: "AG-FAMILY-RESOLVED",
+        status: "resolved",
+        access_role: "family",
+        display_name: "Resolved family workspace",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
+      },
+    ]);
+    mocked.getCase.mockResolvedValue(
+      detail(
+        "case-family-resolved",
+        "Resolved family workspace",
+        "family",
+        "resolved",
+      ),
+    );
+    mocked.getCaseResourceConfiguration.mockResolvedValue({
+      attachment_max_image_bytes: 5 * 1024 * 1024,
+      attachment_max_per_case: 12,
+      case_place_types: ["frequent"],
+    });
+    mocked.getCaseMapView.mockResolvedValue({ items: [] });
+
+    render(<CaseWorkspacePage mode="family" />);
+
+    expect(
+      await screen.findByText("案件已找到，不能再提交补充信息。"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "查看案件资料（主操作）" }),
+    ).toHaveAttribute("href", "#case-profile");
+    expect(
+      screen.queryByRole("link", { name: "提交一条新线索（主操作）" }),
+    ).not.toBeInTheDocument();
   });
 
   it("puts commander task and review work ahead of case materials", async () => {

--- a/frontend/src/pages/CaseWorkspacePage.test.tsx
+++ b/frontend/src/pages/CaseWorkspacePage.test.tsx
@@ -99,6 +99,111 @@ function detail(
 }
 
 describe("CaseWorkspacePage", () => {
+  it("gives a family member one next action and keeps long forms collapsed", async () => {
+    vi.clearAllMocks();
+    mocked.listCases.mockResolvedValue([
+      {
+        id: "case-family-workspace",
+        case_code: "AG-FAMILY-WORKSPACE",
+        status: "active",
+        access_role: "family",
+        display_name: "Family workspace",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
+      },
+    ]);
+    mocked.getCase.mockResolvedValue(
+      detail("case-family-workspace", "Family workspace", "family"),
+    );
+    mocked.getCaseResourceConfiguration.mockResolvedValue({
+      attachment_max_image_bytes: 5 * 1024 * 1024,
+      attachment_max_per_case: 12,
+      case_place_types: ["frequent"],
+    });
+    mocked.getCaseMapView.mockResolvedValue({ items: [] });
+
+    render(<CaseWorkspacePage mode="family" />);
+
+    expect(
+      await screen.findByRole("heading", { name: "当前可以做什么" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "补充人物资料（主操作）" }),
+    ).toHaveAttribute("href", "#case-profile");
+    expect(screen.getByRole("navigation", { name: "案件工作区导航" })).toBeInTheDocument();
+    expect(screen.getByText("补充或更正人物资料").closest("details")).not.toHaveAttribute(
+      "open",
+    );
+    expect(screen.getByText("案件状态与成员管理").closest("details")).not.toHaveAttribute(
+      "open",
+    );
+    expect(screen.getByText("提交一条新线索").closest("details")).not.toHaveAttribute(
+      "open",
+    );
+    expect(screen.queryByRole("heading", { name: "任务看板" })).not.toBeInTheDocument();
+    expect(mocked.listCaseTasks).not.toHaveBeenCalled();
+  });
+
+  it("puts commander task and review work ahead of case materials", async () => {
+    vi.clearAllMocks();
+    mocked.listCommandIntake.mockResolvedValue([]);
+    mocked.listCases.mockResolvedValue([
+      {
+        id: "case-commander-workspace",
+        case_code: "AG-COMMANDER-WORKSPACE",
+        status: "active",
+        access_role: "commander",
+        display_name: "Commander workspace",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-07-24T00:00:00Z",
+        updated_at: "2026-07-24T00:00:00Z",
+      },
+    ]);
+    mocked.getCase.mockResolvedValue(
+      detail("case-commander-workspace", "Commander workspace", "commander"),
+    );
+    mocked.getCaseResourceConfiguration.mockResolvedValue({
+      attachment_max_image_bytes: 5 * 1024 * 1024,
+      attachment_max_per_case: 12,
+      case_place_types: ["frequent"],
+    });
+    mocked.getCaseMapView.mockResolvedValue({ items: [] });
+    mocked.listCaseTasks.mockResolvedValue({
+      items: [],
+      page: 1,
+      page_size: 25,
+      total: 0,
+    });
+    mocked.listCaseMembers.mockResolvedValue([]);
+    mocked.listCaseClues.mockResolvedValue({
+      items: [],
+      page: 1,
+      page_size: 25,
+      total: 0,
+    });
+
+    render(<CaseWorkspacePage mode="commander" />);
+
+    expect(
+      await screen.findByRole("heading", { name: "指挥工作台" }),
+    ).toBeInTheDocument();
+    const taskHeading = screen.getByRole("heading", { name: "任务看板" });
+    const clueHeading = screen.getByRole("heading", { name: "线索" });
+    expect(taskHeading.compareDocumentPosition(clueHeading)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(screen.getByRole("link", { name: "前往任务和审核区（主操作）" })).toHaveAttribute(
+      "href",
+      "#task-board",
+    );
+    expect(screen.getByText("案件状态与成员管理").closest("details")).not.toHaveAttribute(
+      "open",
+    );
+  });
+
   it("lets a commander accept a minimal pending case before viewing it", async () => {
     mocked.listCases.mockResolvedValue([]);
     mocked.listCommandIntake.mockResolvedValue([

--- a/frontend/src/pages/CaseWorkspacePage.test.tsx
+++ b/frontend/src/pages/CaseWorkspacePage.test.tsx
@@ -1,13 +1,28 @@
 import {
   act,
   fireEvent,
-  render,
+  render as renderUi,
   screen,
   waitFor,
 } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import type { ReactElement } from "react";
+import { MemoryRouter, Route, Routes } from "react-router";
 import type { CaseDetail, CaseRole, CaseStatus, Clue } from "../api/cases";
 import { CaseWorkspacePage } from "./CaseWorkspacePage";
+
+function render(ui: ReactElement) {
+  const wrapped = (nextUi: ReactElement) => (
+    <MemoryRouter initialEntries={["/command/cases/case-command"]}>
+      <Routes>
+        <Route path="/command/cases/:caseId" element={nextUi} />
+        <Route path="*" element={nextUi} />
+      </Routes>
+    </MemoryRouter>
+  );
+  const result = renderUi(wrapped(ui));
+  return { ...result, rerender: (nextUi: ReactElement) => result.rerender(wrapped(nextUi)) };
+}
 
 const mocked = vi.hoisted(() => ({
   auth: { token: "test-session" as string | null },
@@ -310,7 +325,13 @@ describe("CaseWorkspacePage", () => {
       detail("pending-case", "Accepted case", "commander"),
     );
 
-    render(<CaseWorkspacePage mode="commander" />);
+    renderUi(
+      <MemoryRouter initialEntries={["/command"]}>
+        <Routes>
+          <Route path="/command" element={<CaseWorkspacePage mode="commander" />} />
+        </Routes>
+      </MemoryRouter>,
+    );
 
     expect(await screen.findByText("AG-PENDING")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "受理案件" }));
@@ -372,6 +393,19 @@ describe("CaseWorkspacePage", () => {
 
     render(<CaseWorkspacePage mode="commander" />);
 
+    expect(await screen.findByRole("navigation", { name: "案件详情导航" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "返回案件列表" })).toHaveAttribute(
+      "href",
+      "/command",
+    );
+    expect(screen.getByRole("link", { name: "任务与审核" })).toHaveAttribute(
+      "href",
+      "#case-tasks",
+    );
+    expect(screen.getByRole("link", { name: "态势与线索" })).toHaveAttribute(
+      "href",
+      "#case-clues",
+    );
     expect(await screen.findByText("Fictional market")).toBeInTheDocument();
     expect(screen.getByText("North gate, fictional park")).toBeInTheDocument();
     expect(screen.getByText("仅文字地点")).toBeInTheDocument();

--- a/frontend/src/pages/CaseWorkspacePage.tsx
+++ b/frontend/src/pages/CaseWorkspacePage.tsx
@@ -10,6 +10,7 @@ import {
   UserPlus,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router";
 import {
   addCaseMember,
   acceptCommandCase,
@@ -126,6 +127,8 @@ const placeTypeLabels: Record<string, string> = {
 
 export function CaseWorkspacePage({ mode }: { mode: WorkspaceMode }) {
   const { token, user } = useAuth();
+  const navigate = useNavigate();
+  const { caseId: routeCaseId } = useParams();
   const [cases, setCases] = useState<CaseListItem[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [detail, setDetail] = useState<CaseDetail | null>(null);
@@ -148,7 +151,9 @@ export function CaseWorkspacePage({ mode }: { mode: WorkspaceMode }) {
         const items = await listCases(token);
         setCases(items);
         setSelectedId((currentId) => {
-          const nextId = preferredId ?? currentId ?? items[0]?.id ?? null;
+          const nextId =
+            preferredId ??
+            (mode === "commander" ? routeCaseId ?? null : currentId ?? items[0]?.id ?? null);
           if (!nextId) setDetail(null);
           return nextId;
         });
@@ -158,7 +163,7 @@ export function CaseWorkspacePage({ mode }: { mode: WorkspaceMode }) {
         setIsLoading(false);
       }
     },
-    [token],
+    [mode, routeCaseId, token],
   );
 
   const loadDetail = useCallback(
@@ -194,6 +199,10 @@ export function CaseWorkspacePage({ mode }: { mode: WorkspaceMode }) {
   }, [loadCases]);
 
   useEffect(() => {
+    if (mode === "commander") setSelectedId(routeCaseId ?? null);
+  }, [mode, routeCaseId]);
+
+  useEffect(() => {
     if (selectedId) {
       void loadDetail(selectedId);
       return;
@@ -213,6 +222,61 @@ export function CaseWorkspacePage({ mode }: { mode: WorkspaceMode }) {
   );
   const copy = workspaceCopy[mode];
   const canCreateCase = user?.account_type === "member";
+  const isCommandCaseDetail = mode === "commander" && Boolean(routeCaseId);
+
+  if (isCommandCaseDetail) {
+    return (
+      <div className="mx-auto w-full max-w-[1440px] px-4 py-6 sm:px-6 lg:px-8">
+        <div className="grid gap-6 lg:grid-cols-[248px_minmax(0,1fr)]">
+          <aside className="lg:sticky lg:top-6 lg:self-start">
+            <nav className="border border-slate-200 bg-white p-4" aria-label="案件详情导航">
+              <Link className="text-sm font-medium text-brand-700 hover:underline" to="/command">
+                返回案件列表
+              </Link>
+              <div className="mt-5 border-y border-slate-200 py-4">
+                <span className="block text-xs text-slate-500">当前位置</span>
+                <strong className="mt-1 block text-sm text-slate-950">
+                  {detail?.elder_profile.display_name ?? "正在加载案件"}
+                </strong>
+                <span className="mt-1 block text-xs text-slate-500">
+                  {detail?.case_code ?? routeCaseId}
+                </span>
+                {detail && (
+                  <span className="mt-2 inline-block text-xs font-medium text-slate-700">
+                    {statusLabels[detail.status]}
+                  </span>
+                )}
+              </div>
+              <div className="mt-4 grid gap-1 text-sm">
+                <a className="rounded-md px-3 py-2 text-slate-700 hover:bg-brand-50 hover:text-brand-700" href="#case-tasks">任务与审核</a>
+                <a className="rounded-md px-3 py-2 text-slate-700 hover:bg-brand-50 hover:text-brand-700" href="#case-clues">态势与线索</a>
+                <a className="rounded-md px-3 py-2 text-slate-700 hover:bg-brand-50 hover:text-brand-700" href="#case-profile">案件资料</a>
+                <a className="rounded-md px-3 py-2 text-slate-700 hover:bg-brand-50 hover:text-brand-700" href="#case-members">协作与成员</a>
+              </div>
+            </nav>
+          </aside>
+          <main id="case-detail-content" className="min-w-0 border border-slate-200 bg-white">
+            {isDetailLoading ? (
+              <LoadingState label="正在加载案件详情" />
+            ) : detailError ? (
+              <ErrorState message={detailError} onRetry={() => selectedId && void loadDetail(selectedId)} />
+            ) : detail && resourceConfiguration ? (
+              <CaseDetailView
+                detail={detail}
+                resourceConfiguration={resourceConfiguration}
+                pendingCount={pendingCount}
+                onChanged={async (message) => {
+                  setNotice(message);
+                  await loadDetail(detail.id);
+                  await loadCases(detail.id);
+                }}
+              />
+            ) : null}
+          </main>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="mx-auto w-full max-w-7xl px-4 py-7 sm:px-6 lg:px-10 lg:py-10">
@@ -268,7 +332,7 @@ export function CaseWorkspacePage({ mode }: { mode: WorkspaceMode }) {
         />
       )}
 
-      <div className="mt-5 grid min-h-[560px] overflow-hidden border-y border-slate-200 bg-white lg:grid-cols-[310px_minmax(0,1fr)]">
+      <div className={`mt-5 min-h-[560px] overflow-hidden border-y border-slate-200 bg-white ${mode === "commander" ? "" : "grid lg:grid-cols-[310px_minmax(0,1fr)]"}`}>
         <section
           className="border-b border-slate-200 lg:border-r lg:border-b-0"
           aria-label="案件列表"
@@ -294,7 +358,13 @@ export function CaseWorkspacePage({ mode }: { mode: WorkspaceMode }) {
                 <button
                   type="button"
                   key={item.id}
-                  onClick={() => setSelectedId(item.id)}
+                  onClick={() => {
+                    if (mode === "commander") {
+                      navigate(`/command/cases/${item.id}`);
+                      return;
+                    }
+                    setSelectedId(item.id);
+                  }}
                   aria-pressed={selectedId === item.id}
                   className={`flex min-h-20 w-full items-center gap-3 px-4 py-3 text-left transition-colors ${
                     selectedId === item.id ? "bg-brand-50" : "hover:bg-slate-50"
@@ -323,7 +393,7 @@ export function CaseWorkspacePage({ mode }: { mode: WorkspaceMode }) {
           )}
         </section>
 
-        <section className="min-w-0">
+        {mode !== "commander" && <section className="min-w-0">
           {isDetailLoading ? (
             <LoadingState label="正在加载案件详情" />
           ) : detailError ? (
@@ -347,7 +417,7 @@ export function CaseWorkspacePage({ mode }: { mode: WorkspaceMode }) {
               <EmptyState icon={FileSearch} title="选择一个案件查看详情" />
             </div>
           )}
-        </section>
+        </section>}
       </div>
     </div>
   );
@@ -623,7 +693,7 @@ function CaseDetailView({
       )}
 
       {(isCommander || detail.access_role === "family") && (
-        <details className="border-b border-slate-200 bg-slate-50">
+        <details id="case-members" className="border-b border-slate-200 bg-slate-50">
           <summary className="cursor-pointer px-5 py-4 text-sm font-semibold text-slate-900 sm:px-6">
             案件状态与成员管理
           </summary>
@@ -1764,6 +1834,7 @@ function TaskBoard({
       className="border-b border-slate-200 px-5 py-5 sm:px-6"
       aria-label="任务看板"
     >
+      <span id="case-tasks" aria-hidden="true" />
       <div className="flex items-start justify-between gap-3">
         <div>
           <h3 className="m-0 text-base font-bold text-slate-950">任务看板</h3>

--- a/frontend/src/pages/CaseWorkspacePage.tsx
+++ b/frontend/src/pages/CaseWorkspacePage.tsx
@@ -603,7 +603,7 @@ function CaseDetailView({
       </section>
 
       {canEditElderProfile && (
-        <details className="border-b border-slate-200 bg-brand-50/30">
+        <details id="case-profile-editor" className="border-b border-slate-200 bg-brand-50/30">
           <summary className="cursor-pointer px-5 py-4 text-sm font-semibold text-slate-900 sm:px-6">
             补充或更正人物资料
           </summary>
@@ -1571,6 +1571,7 @@ function RoleActionPanel({
 }) {
   const isCommander = accessRole === "commander";
   const isFamily = accessRole === "family";
+  const isActive = caseStatus === "active";
   const heading = isCommander
     ? "指挥工作台"
     : isFamily
@@ -1581,22 +1582,32 @@ function RoleActionPanel({
       ? `有 ${pendingCount} 条线索等待人工审核，请先完成审核并记录理由。`
       : "当前没有待审核线索；可在任务看板查看或创建受控任务。"
     : isFamily
-      ? hasProfileGaps
+      ? !isActive
+        ? caseStatus === "resolved"
+          ? "案件已找到，不能再提交补充信息。"
+          : "案件已关闭，不能再提交补充信息。"
+        : hasProfileGaps
         ? "请先补充关键人物资料，再提交新的线索、地点或图片。"
         : "可补充线索、地点或图片；提交的信息会先进入人工审核。"
       : "请查看已分配任务与经服务端裁剪后的案件信息。";
   const action = isCommander
     ? "前往任务和审核区"
     : isFamily
-      ? hasProfileGaps
+      ? isActive && hasProfileGaps
         ? "补充人物资料"
-        : "提交一条新线索"
-      : "查看案件资料";
+        : isActive
+          ? "提交一条新线索"
+          : "查看案件资料"
+      : "查看已分配任务";
   const target = isCommander
     ? "#task-board"
-    : isFamily && hasProfileGaps
-      ? "#case-profile"
-      : "#case-clues";
+    : isFamily
+      ? isActive && hasProfileGaps
+        ? "#case-profile-editor"
+        : isActive
+          ? "#case-clues"
+          : "#case-profile"
+      : "#task-board";
 
   return (
     <section
@@ -1613,7 +1624,7 @@ function RoleActionPanel({
             {heading}
           </h3>
           <p className="mb-0 mt-1 text-sm leading-6 text-slate-700">
-            {caseStatus === "closed" ? "案件已关闭，不能再提交补充信息。" : description}
+            {description}
           </p>
         </div>
         <a

--- a/frontend/src/pages/CaseWorkspacePage.tsx
+++ b/frontend/src/pages/CaseWorkspacePage.tsx
@@ -539,11 +539,42 @@ function CaseDetailView({
         </div>
       </header>
 
-      <TaskBoard detail={detail} token={token} />
-      <CaseSituationPanel detail={detail} token={token} />
+      <RoleActionPanel
+        accessRole={detail.access_role}
+        caseStatus={detail.status}
+        pendingCount={pendingCount}
+        hasProfileGaps={
+          !detail.elder_profile.last_seen_location ||
+          !detail.elder_profile.last_seen_at ||
+          !detail.elder_profile.physical_description
+        }
+      />
+      <nav
+        className="flex flex-wrap gap-x-4 gap-y-2 border-b border-slate-200 bg-white px-5 py-3 text-sm font-medium sm:px-6"
+        aria-label="案件工作区导航"
+      >
+        <a
+          className="text-brand-700 underline-offset-4 hover:underline"
+          href={detail.access_role === "family" ? "#case-actions" : "#task-board"}
+        >
+          当前行动
+        </a>
+        <a className="text-brand-700 underline-offset-4 hover:underline" href="#case-clues">
+          线索与地点
+        </a>
+        <a className="text-brand-700 underline-offset-4 hover:underline" href="#case-profile">
+          案件资料
+        </a>
+      </nav>
+
+      {detail.access_role !== "family" && (
+        <TaskBoard detail={detail} token={token} />
+      )}
       <CaseCollaborationPanel detail={detail} token={token} />
+      <CaseSituationPanel detail={detail} token={token} />
 
       <section
+        id="case-profile"
         className="grid gap-x-8 gap-y-4 border-b border-slate-200 px-5 py-5 sm:grid-cols-2 sm:px-6 lg:grid-cols-3"
         aria-label="老人资料"
       >
@@ -572,87 +603,96 @@ function CaseDetailView({
       </section>
 
       {canEditElderProfile && (
-        <ElderProfileEditor
-          detail={detail}
-          token={token}
-          busy={busy}
-          onSave={(payload) =>
-            run(
-              "elder-profile",
-              () => updateElderProfile(token!, detail.id, payload),
-              "人物摘要已更新",
-            )
-          }
-        />
+        <details className="border-b border-slate-200 bg-brand-50/30">
+          <summary className="cursor-pointer px-5 py-4 text-sm font-semibold text-slate-900 sm:px-6">
+            补充或更正人物资料
+          </summary>
+          <ElderProfileEditor
+            detail={detail}
+            token={token}
+            busy={busy}
+            onSave={(payload) =>
+              run(
+                "elder-profile",
+                () => updateElderProfile(token!, detail.id, payload),
+                "人物摘要已更新",
+              )
+            }
+          />
+        </details>
       )}
 
       {(isCommander || detail.access_role === "family") && (
-        <section className="grid gap-5 border-b border-slate-200 bg-slate-50 px-5 py-5 sm:px-6 lg:grid-cols-2">
-          {isCommander && (
+        <details className="border-b border-slate-200 bg-slate-50">
+          <summary className="cursor-pointer px-5 py-4 text-sm font-semibold text-slate-900 sm:px-6">
+            案件状态与成员管理
+          </summary>
+          <section className="grid gap-5 px-5 pb-5 sm:px-6 lg:grid-cols-2">
+            {isCommander && (
+              <form
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  if (!token) return;
+                  void run(
+                    "status",
+                    () => updateCaseStatus(token, detail.id, nextStatus),
+                    "案件状态已更新",
+                  );
+                }}
+              >
+                <h3
+                  id="case-status-title"
+                  className="m-0 text-sm font-bold text-slate-950"
+                >
+                  案件状态
+                </h3>
+                <div className="mt-3 flex gap-2">
+                  <select
+                    aria-labelledby="case-status-title"
+                    className="min-h-10 flex-1 rounded-md border border-slate-300 bg-white px-3 text-sm"
+                    value={nextStatus}
+                    onChange={(event) =>
+                      setNextStatus(event.target.value as CaseStatus)
+                    }
+                    disabled={detail.status === "closed"}
+                  >
+                    {statusOptions.map((status) => (
+                      <option key={status} value={status}>
+                        {statusLabels[status]}
+                      </option>
+                    ))}
+                  </select>
+                  <Button
+                    type="submit"
+                    size="sm"
+                    variant="secondary"
+                    isDisabled={busy === "status" || nextStatus === detail.status}
+                  >
+                    保存
+                  </Button>
+                </div>
+              </form>
+            )}
+
             <form
               onSubmit={(event) => {
                 event.preventDefault();
                 if (!token) return;
                 void run(
-                  "status",
-                  () => updateCaseStatus(token, detail.id, nextStatus),
-                  "案件状态已更新",
-                );
+                  "member",
+                  () =>
+                    addCaseMember(
+                      token,
+                      detail.id,
+                      memberEmail.trim(),
+                      selectedMemberRole,
+                    ),
+                  "案件成员已添加",
+                ).then((succeeded) => {
+                  if (succeeded) setMemberEmail("");
+                });
               }}
             >
-              <h3
-                id="case-status-title"
-                className="m-0 text-sm font-bold text-slate-950"
-              >
-                案件状态
-              </h3>
-              <div className="mt-3 flex gap-2">
-                <select
-                  aria-labelledby="case-status-title"
-                  className="min-h-10 flex-1 rounded-md border border-slate-300 bg-white px-3 text-sm"
-                  value={nextStatus}
-                  onChange={(event) =>
-                    setNextStatus(event.target.value as CaseStatus)
-                  }
-                  disabled={detail.status === "closed"}
-                >
-                  {statusOptions.map((status) => (
-                    <option key={status} value={status}>
-                      {statusLabels[status]}
-                    </option>
-                  ))}
-                </select>
-                <Button
-                  type="submit"
-                  size="sm"
-                  variant="secondary"
-                  isDisabled={busy === "status" || nextStatus === detail.status}
-                >
-                  保存
-                </Button>
-              </div>
-            </form>
-          )}
-
-          <form
-            onSubmit={(event) => {
-              event.preventDefault();
-              if (!token) return;
-              void run(
-                "member",
-                () =>
-                  addCaseMember(
-                    token,
-                    detail.id,
-                    memberEmail.trim(),
-                    selectedMemberRole,
-                  ),
-                "案件成员已添加",
-              ).then((succeeded) => {
-                if (succeeded) setMemberEmail("");
-              });
-            }}
-          >
             <h3 className="m-0 text-sm font-bold text-slate-950">添加成员</h3>
             <div className="mt-3 grid gap-2 sm:grid-cols-[minmax(0,1fr)_120px_auto]">
               <Input
@@ -687,8 +727,9 @@ function CaseDetailView({
                 <UserPlus size={17} />
               </Button>
             </div>
-          </form>
-        </section>
+            </form>
+          </section>
+        </details>
       )}
 
       {error && (
@@ -697,7 +738,7 @@ function CaseDetailView({
         </div>
       )}
 
-      <section className="px-5 py-5 sm:px-6" aria-labelledby="clues-title">
+      <section id="case-clues" className="px-5 py-5 sm:px-6" aria-labelledby="clues-title">
         <div className="flex items-center justify-between gap-3">
           <h3
             id="clues-title"
@@ -1085,8 +1126,12 @@ function CaseDetailView({
         )}
 
         {detail.status === "active" && (
-          <form
-            className="mt-5 grid gap-3 sm:grid-cols-[minmax(0,1fr)_220px]"
+          <details className="mt-5 rounded-md border border-slate-200 bg-slate-50">
+            <summary className="cursor-pointer px-3 py-3 text-sm font-semibold text-slate-900">
+              {isCommander ? "提交补充线索" : "提交一条新线索"}
+            </summary>
+            <form
+              className="grid gap-3 border-t border-slate-200 p-3 sm:grid-cols-[minmax(0,1fr)_220px] sm:p-4"
             onSubmit={(event) => {
               event.preventDefault();
               if (!token) return;
@@ -1238,7 +1283,8 @@ function CaseDetailView({
                 提交线索
               </Button>
             </div>
-          </form>
+            </form>
+          </details>
         )}
       </section>
 
@@ -1512,6 +1558,76 @@ function CaseDetailView({
   );
 }
 
+function RoleActionPanel({
+  accessRole,
+  caseStatus,
+  pendingCount,
+  hasProfileGaps,
+}: {
+  accessRole: CaseRole;
+  caseStatus: CaseStatus;
+  pendingCount: number;
+  hasProfileGaps: boolean;
+}) {
+  const isCommander = accessRole === "commander";
+  const isFamily = accessRole === "family";
+  const heading = isCommander
+    ? "指挥工作台"
+    : isFamily
+      ? "当前可以做什么"
+      : "协作提示";
+  const description = isCommander
+    ? pendingCount > 0
+      ? `有 ${pendingCount} 条线索等待人工审核，请先完成审核并记录理由。`
+      : "当前没有待审核线索；可在任务看板查看或创建受控任务。"
+    : isFamily
+      ? hasProfileGaps
+        ? "请先补充关键人物资料，再提交新的线索、地点或图片。"
+        : "可补充线索、地点或图片；提交的信息会先进入人工审核。"
+      : "请查看已分配任务与经服务端裁剪后的案件信息。";
+  const action = isCommander
+    ? "前往任务和审核区"
+    : isFamily
+      ? hasProfileGaps
+        ? "补充人物资料"
+        : "提交一条新线索"
+      : "查看案件资料";
+  const target = isCommander
+    ? "#task-board"
+    : isFamily && hasProfileGaps
+      ? "#case-profile"
+      : "#case-clues";
+
+  return (
+    <section
+      id="case-actions"
+      className="border-b border-emerald-200 bg-emerald-50/70 px-5 py-5 sm:px-6"
+      aria-labelledby="role-actions-title"
+    >
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+        <div className="max-w-2xl">
+          <p className="m-0 text-xs font-semibold text-emerald-800">
+            {isCommander ? "先处理待办，再查看资料" : "根据当前案件状态继续"}
+          </p>
+          <h3 id="role-actions-title" className="mb-0 mt-1 text-lg font-bold text-slate-950">
+            {heading}
+          </h3>
+          <p className="mb-0 mt-1 text-sm leading-6 text-slate-700">
+            {caseStatus === "closed" ? "案件已关闭，不能再提交补充信息。" : description}
+          </p>
+        </div>
+        <a
+          className="inline-flex min-h-10 items-center justify-center rounded-md bg-brand-700 px-4 text-sm font-semibold text-white no-underline transition-colors hover:bg-brand-800 focus:outline-none focus:ring-2 focus:ring-brand-700 focus:ring-offset-2"
+          href={target}
+          aria-label={`${action}（主操作）`}
+        >
+          {action}
+        </a>
+      </div>
+    </section>
+  );
+}
+
 const taskStatusLabels: Record<string, string> = {
   pending_claim: "待志愿者申请",
   assigned: "待领取",
@@ -1633,6 +1749,7 @@ function TaskBoard({
   }
   return (
     <section
+      id="task-board"
       className="border-b border-slate-200 px-5 py-5 sm:px-6"
       aria-label="任务看板"
     >
@@ -2512,7 +2629,8 @@ function CaseCollaborationPanel({
         </div>
       )}
 
-      <div className="min-w-0">
+      {isCommander && (
+        <div className="min-w-0">
         <h3 className="m-0 text-base font-bold text-slate-950">
           文本整理为待审核线索
         </h3>
@@ -2563,7 +2681,8 @@ function CaseCollaborationPanel({
             </p>
           </div>
         ))}
-      </div>
+        </div>
+      )}
 
       {isCommander && (
         <div className="min-w-0">


### PR DESCRIPTION
Closes #165

## 变更内容
- 指挥端 `/command` 现在只呈现案件工作队列，不再在列表页并排加载右侧案件详情。
- 新增 `/command/cases/:caseId` 详情路由；从列表点击案件后进入可刷新、可分享、可使用浏览器前进/后退恢复的 URL。
- 详情页左侧新增固定案件上下文：返回案件列表、当前案件名称/编号/状态和案件内导航。
- 案件内导航提供任务与审核、态势与线索、案件资料、协作与成员的锚点入口；右侧继续复用既有详情、任务、审核、地图和资料功能。
- 更新工作台测试装配为参数化路由，并覆盖详情侧栏、返回列表链接和关键分区锚点。

## 验收对应
- [x] 列表点击可进入 `/command/cases/:caseId`。
- [x] 详情侧栏显示当前案件上下文、当前位置和返回列表入口。
- [x] 案件内导航可跳转任务、线索、资料与成员分区。
- [x] 保留原有任务、人工审核、资料编辑、地图文字降级、服务端字段裁剪和 RBAC 行为。
- [x] 窄屏保持单列布局；桌面端侧栏使用 sticky 定位且不会遮挡内容。

## 测试与质量检查
- [x] `frontend/node_modules/.bin/vitest.cmd run src/pages/CaseWorkspacePage.test.tsx`（14 passed）
- [x] `frontend/node_modules/.bin/oxlint.cmd`
- [x] `frontend/node_modules/.bin/tsc.cmd -b`
- [x] `frontend/node_modules/.bin/vite.cmd build`
- [x] `git diff --check`
- Vite 构建成功，保留项目既有的单个 bundle 大于 500 kB 提示；本 PR 未增加依赖或资源。

## 风险与边界
无服务端权限、字段裁剪、API 契约、位置精度、人工审核或公开进展规则变更。案件内导航仅为前端信息架构，不替代授权检查。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 指挥端新增独立案件详情路由，可直接打开指定案件并返回列表。
  - 新增案件概况、资料、成员、线索和任务等区域的快捷导航。
  - 优化案件工作区布局，支持角色行动面板及可折叠内容区域。
  - 指挥端提供任务看板、线索审核、文本整理和案件摘要等功能。
  - 改进案件详情中的任务、线索链接及按需加载体验。

- **测试**
  - 补充案件详情路由、导航、返回列表及内容展示测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->