### PR TITLE
Feat/learning center

### DIFF
--- a/docs/learning-content-governance.md
+++ b/docs/learning-content-governance.md
@@ -16,12 +16,12 @@
 { "reason": "可审计的人工处理理由" }
 ```
 
-资源提交额外要求来源名称、可选 HTTPS 来源地址、版本生效时间、可见级别和用途。`permitted_use` 目前仅允许 `training` 或 `public_information`；学习列表、问答、题库与导出只处理 `training` 内容，避免将公开信息、训练材料和其他用途混用。
+资源提交额外要求来源名称、可选 HTTPS 来源地址、版本生效时间、可见级别和用途。资源的 `permitted_use` 仅允许 `training` 或 `public_information`；两种用途均须完成同一脱敏、独立审核与发布链后才可读取或导出。题目及其判题、解析固定为 `training`，不将公开信息用途扩展为题库用途。
 
 ## 读取与导出边界
 
-- `GET /api/learning/public/prevention-card` 无需登录，但只返回当前已发布、已完成治理、公开可见且用途为培训的防走失知识卡。生产环境仅缓存这一张卡和前端应用壳，绝不缓存登录态学习资源、题目、问答或案件数据；在线发现卡片撤回后会删除本地缓存。
-- `GET /api/learning/resources`、`GET /api/learning/questions` 和 `POST /api/knowledge/ask` 仅读取当前账号可见、已生效、已脱敏、已独立审核、已发布的培训内容。
+- `GET /api/learning/public/prevention-card` 无需登录，但只返回当前已发布、已完成治理、公开可见且用途为培训或公开信息的防走失知识卡。生产环境仅缓存这一张卡和前端应用壳，绝不缓存登录态学习资源、题目、问答或案件数据；在线发现卡片撤回后会删除本地缓存。
+- `GET /api/learning/resources` 和 `POST /api/knowledge/ask` 仅读取当前账号可见、已生效、已脱敏、已独立审核、已发布的培训或公开信息资源；`GET /api/learning/questions` 只返回培训用途的题目。
 - 问答只返回匹配资源原文、来源、版本和人工核验提示；无可靠来源时返回 `insufficient_sources`，不生成行动建议。
 - `POST /api/learning/questions/{id}/answers` 在服务端校验选项；题目列表和题目导出均不返回 `correct_option_id`。
 - `GET /api/admin/learning/resources/{id}/export` 与 `GET /api/admin/learning/questions/{id}/export` 仅允许管理员获取当前已发布的受控版本，使用白名单响应字段并以 JSON 附件返回。

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1779,7 +1779,7 @@ paths:
       tags: [Learning]
       operationId: getPublicPreventionCard
       summary: Get the approved public prevention card for offline use
-      description: Returns the current effective prevention resource only when it is public, published, training-scoped, and has a complete immutable governance chain. A withdrawn card is not returned.
+      description: Returns the current effective prevention resource only when it is public, published, training- or public-information-scoped, and has a complete immutable governance chain. A withdrawn card is not returned.
       x-data-classification: public
       responses:
         "200": { description: Approved public prevention card }

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,8 +1,31 @@
 const CACHE_NAME = "angui-learning-offline-v1";
 const PREVENTION_CARD_PATH = "/api/learning/public/prevention-card";
 
+async function preCacheAppShell() {
+  try {
+    const cache = await caches.open(CACHE_NAME);
+    const shell = await fetch("/", { cache: "reload" });
+    if (!shell.ok) throw new Error(`app shell request failed with ${shell.status}`);
+    const markup = await shell.clone().text();
+    await cache.put("/", shell);
+    const assetPaths = [...markup.matchAll(/(?:src|href)=["']([^"']+)["']/g)]
+      .map((match) => new URL(match[1], self.location.origin))
+      .filter((url) => url.origin === self.location.origin && url.pathname.startsWith("/assets/"));
+    await Promise.all(assetPaths.map(async (url) => {
+      try {
+        const response = await fetch(url, { cache: "reload" });
+        if (response.ok) await cache.put(url, response);
+      } catch (cause) {
+        console.warn("无法预缓存应用资源", url.pathname, cause);
+      }
+    }));
+  } catch (cause) {
+    console.warn("无法预缓存应用壳；将在联网时重试", cause);
+  }
+}
+
 self.addEventListener("install", (event) => {
-  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.add("/")));
+  event.waitUntil(preCacheAppShell());
   self.skipWaiting();
 });
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -158,13 +158,18 @@ describe("application role routing", () => {
     },
   );
 
-  it("exposes the learning center to learner, family, and volunteer audiences only", async () => {
-    setAuth("learner");
+  it.each([
+    ["learner", "learner", []],
+    ["family", "member", []],
+    ["volunteer", "member", ["volunteer"]],
+  ] as const)("exposes the learning center to %s audiences", async (_audience, accountType, capabilities) => {
+    setAuth(accountType, capabilities);
     renderApp("/learning");
     expect(await screen.findByRole("heading", { name: "学习中心" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "学习中心" })).toBeInTheDocument();
+  });
 
-    cleanup();
+  it("does not expose the learning center to commander-only audiences", async () => {
     setAuth("member", ["commander"]);
     renderApp("/learning");
     expect(await screen.findByText("行动总览")).toBeInTheDocument();

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,12 +4,9 @@ import { BrowserRouter } from "react-router";
 import "./index.css";
 import App from "./App.tsx";
 import { AuthProvider } from "./auth/AuthContext.tsx";
+import { registerPreventionCache } from "./offline/prevention-cache.ts";
 
-if (import.meta.env.PROD && "serviceWorker" in navigator) {
-  window.addEventListener("load", () => {
-    void navigator.serviceWorker.register("/sw.js");
-  });
-}
+window.addEventListener("load", registerPreventionCache);
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/frontend/src/offline/prevention-cache.ts
+++ b/frontend/src/offline/prevention-cache.ts
@@ -1,0 +1,39 @@
+import { useSyncExternalStore } from "react";
+
+let isReady = false;
+const listeners = new Set<() => void>();
+
+function setReady(nextReady: boolean) {
+  if (isReady === nextReady) return;
+  isReady = nextReady;
+  listeners.forEach((listener) => listener());
+}
+
+export function registerPreventionCache() {
+  if (!import.meta.env.PROD || !("serviceWorker" in navigator)) return;
+
+  void navigator.serviceWorker
+    .register("/sw.js")
+    .then(() => navigator.serviceWorker.ready)
+    .then(async () => {
+      const cache = await caches.open("angui-learning-offline-v1");
+      setReady(
+        Boolean(navigator.serviceWorker.controller) && Boolean(await cache.match("/")),
+      );
+    })
+    .catch((cause: unknown) => {
+      console.warn("防走失知识卡离线缓存未启用", cause);
+      setReady(false);
+    });
+}
+
+export function usePreventionCacheReady() {
+  return useSyncExternalStore(
+    (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    () => isReady,
+    () => false,
+  );
+}

--- a/frontend/src/pages/LearningCenterPage.test.tsx
+++ b/frontend/src/pages/LearningCenterPage.test.tsx
@@ -7,10 +7,11 @@ const mocked = vi.hoisted(() => ({
   getPublicPreventionCard: vi.fn(),
   listLearningQuestions: vi.fn(),
   listLearningResources: vi.fn(),
+  token: "learner-session" as string | null,
 }));
 
 vi.mock("../auth/useAuth", () => ({
-  useAuth: () => ({ token: "learner-session" }),
+  useAuth: () => ({ token: mocked.token }),
 }));
 
 vi.mock("../api/learning", () => ({
@@ -26,6 +27,7 @@ vi.mock("../api/learning", () => ({
 
 describe("LearningCenterPage", () => {
   beforeEach(() => {
+    mocked.token = "learner-session";
     mocked.listLearningResources.mockResolvedValue([]);
     mocked.listLearningQuestions.mockResolvedValue([]);
   });
@@ -47,7 +49,8 @@ describe("LearningCenterPage", () => {
     render(<LearningCenterPage />);
 
     expect(await screen.findByText("已审核防走失知识卡")).toBeInTheDocument();
-    expect(screen.getByText("可离线使用")).toBeInTheDocument();
+    expect(screen.getByText("仅可在线查看")).toBeInTheDocument();
+    expect(screen.getByText("离线缓存尚未就绪，请保持联网查看。")).toBeInTheDocument();
     expect(screen.getByText("来源：指定负责人 · v2")).toBeInTheDocument();
   });
 
@@ -61,6 +64,16 @@ describe("LearningCenterPage", () => {
     expect(await screen.findByText("等待发布")).toBeInTheDocument();
     expect(
       screen.getByText("负责人尚未发布可离线使用的防走失知识卡。该卡发布并加载成功后，生产环境会保留最后一个已审核版本供离线查看。"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a recoverable message when the session is unavailable", async () => {
+    mocked.token = null;
+
+    render(<LearningCenterPage />);
+
+    expect(
+      await screen.findByText("登录状态不可用，请重新登录后访问学习中心。"),
     ).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/LearningCenterPage.tsx
+++ b/frontend/src/pages/LearningCenterPage.tsx
@@ -6,6 +6,7 @@ import type { KnowledgeAnswer, LearningQuestion, LearningResource } from "../api
 import { ApiClientError } from "../api/client";
 import { useAuth } from "../auth/useAuth";
 import { ErrorState, LoadingState } from "../components/ContentState";
+import { usePreventionCacheReady } from "../offline/prevention-cache";
 
 function messageFrom(cause: unknown) {
   return cause instanceof ApiClientError ? cause.message : "暂时无法完成学习中心操作，请稍后重试。";
@@ -13,6 +14,7 @@ function messageFrom(cause: unknown) {
 
 export function LearningCenterPage() {
   const { token } = useAuth();
+  const preventionCacheReady = usePreventionCacheReady();
   const [resources, setResources] = useState<LearningResource[]>([]);
   const [questions, setQuestions] = useState<LearningQuestion[]>([]);
   const [preventionCard, setPreventionCard] = useState<LearningResource | null>(null);
@@ -25,7 +27,11 @@ export function LearningCenterPage() {
   const [answeringQuestion, setAnsweringQuestion] = useState("");
 
   const load = useCallback(async () => {
-    if (!token) return;
+    if (!token) {
+      setError("登录状态不可用，请重新登录后访问学习中心。");
+      setIsLoading(false);
+      return;
+    }
     setIsLoading(true);
     setError("");
     try {
@@ -64,8 +70,8 @@ export function LearningCenterPage() {
       <div><h1 className="m-0 text-2xl font-bold text-slate-950">学习中心</h1><p className="mb-0 mt-1 text-sm text-slate-600">仅展示已发布、可追溯的教材；内容不能替代负责人审核或现场指令。</p></div>
     </header>
     <section className="mb-7 border-y border-emerald-200 bg-emerald-50" aria-labelledby="offline-prevention-title">
-      <header className="flex items-center justify-between gap-3 border-b border-emerald-200 px-5 py-4"><div className="flex items-center gap-2"><WifiOff size={18} aria-hidden="true" /><h2 id="offline-prevention-title" className="m-0 text-base font-bold text-slate-950">离线防走失知识卡</h2></div><Chip size="sm" variant="soft"><Chip.Label>{preventionCard ? "可离线使用" : "等待发布"}</Chip.Label></Chip></header>
-      {preventionCard ? <article className="px-5 py-4"><h3 className="m-0 text-sm font-semibold text-slate-950">{preventionCard.title}</h3><p className="mb-0 mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-700">{preventionCard.content}</p><p className="mb-0 mt-3 text-xs text-slate-600">来源：{preventionCard.source_name} · v{preventionCard.version}</p></article> : <p className="m-0 px-5 py-6 text-sm leading-6 text-slate-600">负责人尚未发布可离线使用的防走失知识卡。该卡发布并加载成功后，生产环境会保留最后一个已审核版本供离线查看。</p>}
+      <header className="flex items-center justify-between gap-3 border-b border-emerald-200 px-5 py-4"><div className="flex items-center gap-2"><WifiOff size={18} aria-hidden="true" /><h2 id="offline-prevention-title" className="m-0 text-base font-bold text-slate-950">离线防走失知识卡</h2></div><Chip size="sm" variant="soft"><Chip.Label>{preventionCard ? (preventionCacheReady ? "可离线使用" : "仅可在线查看") : "等待发布"}</Chip.Label></Chip></header>
+      {preventionCard ? <article className="px-5 py-4"><h3 className="m-0 text-sm font-semibold text-slate-950">{preventionCard.title}</h3><p className="mb-0 mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-700">{preventionCard.content}</p><p className="mb-0 mt-3 text-xs text-slate-600">来源：{preventionCard.source_name} · v{preventionCard.version}</p>{!preventionCacheReady && <p className="mb-0 mt-2 text-xs text-amber-800" role="status">离线缓存尚未就绪，请保持联网查看。</p>}</article> : <p className="m-0 px-5 py-6 text-sm leading-6 text-slate-600">负责人尚未发布可离线使用的防走失知识卡。该卡发布并加载成功后，生产环境会保留最后一个已审核版本供离线查看。</p>}
     </section>
     <section className="mb-7 border-y border-slate-200 bg-white" aria-labelledby="learning-resources-title">
       <header className="flex items-center justify-between border-b border-slate-200 px-5 py-4"><h2 id="learning-resources-title" className="m-0 text-base font-bold text-slate-950">手册与知识卡</h2><Chip size="sm" variant="soft"><Chip.Label>{resources.length} 项</Chip.Label></Chip></header>

--- a/migration/sql/mysql/down/0040_remove_learning_lifecycle_event_uniqueness.sql
+++ b/migration/sql/mysql/down/0040_remove_learning_lifecycle_event_uniqueness.sql
@@ -1,0 +1,1 @@
+DROP INDEX uq_learning_content_review_event ON learning_content_review_events;

--- a/migration/sql/mysql/up/0040_enforce_learning_lifecycle_event_uniqueness.sql
+++ b/migration/sql/mysql/up/0040_enforce_learning_lifecycle_event_uniqueness.sql
@@ -5,6 +5,6 @@ WHERE id NOT IN (
         FROM learning_content_review_events
         GROUP BY content_type, content_id, content_version, event_type
     ) AS retained_events
-) AS retained_event_ids;
+);
 -- statement-break
 CREATE UNIQUE INDEX uq_learning_content_review_event ON learning_content_review_events(content_type, content_id, content_version, event_type);

--- a/migration/sql/mysql/up/0040_enforce_learning_lifecycle_event_uniqueness.sql
+++ b/migration/sql/mysql/up/0040_enforce_learning_lifecycle_event_uniqueness.sql
@@ -1,0 +1,10 @@
+DELETE FROM learning_content_review_events
+WHERE id NOT IN (
+    SELECT retained_id FROM (
+        SELECT MIN(id) AS retained_id
+        FROM learning_content_review_events
+        GROUP BY content_type, content_id, content_version, event_type
+    ) AS retained_events
+) AS retained_event_ids;
+-- statement-break
+CREATE UNIQUE INDEX uq_learning_content_review_event ON learning_content_review_events(content_type, content_id, content_version, event_type);

--- a/migration/sql/postgres/down/0040_remove_learning_lifecycle_event_uniqueness.sql
+++ b/migration/sql/postgres/down/0040_remove_learning_lifecycle_event_uniqueness.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS uq_learning_content_review_event;

--- a/migration/sql/postgres/up/0040_enforce_learning_lifecycle_event_uniqueness.sql
+++ b/migration/sql/postgres/up/0040_enforce_learning_lifecycle_event_uniqueness.sql
@@ -1,0 +1,10 @@
+DELETE FROM learning_content_review_events
+WHERE id NOT IN (
+    SELECT retained_id FROM (
+        SELECT MIN(id) AS retained_id
+        FROM learning_content_review_events
+        GROUP BY content_type, content_id, content_version, event_type
+    ) AS retained_events
+);
+-- statement-break
+CREATE UNIQUE INDEX uq_learning_content_review_event ON learning_content_review_events(content_type, content_id, content_version, event_type);

--- a/migration/sql/sqlite/down/0040_remove_learning_lifecycle_event_uniqueness.sql
+++ b/migration/sql/sqlite/down/0040_remove_learning_lifecycle_event_uniqueness.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS uq_learning_content_review_event;

--- a/migration/sql/sqlite/up/0040_enforce_learning_lifecycle_event_uniqueness.sql
+++ b/migration/sql/sqlite/up/0040_enforce_learning_lifecycle_event_uniqueness.sql
@@ -1,0 +1,10 @@
+DELETE FROM learning_content_review_events
+WHERE id NOT IN (
+    SELECT retained_id FROM (
+        SELECT MIN(id) AS retained_id
+        FROM learning_content_review_events
+        GROUP BY content_type, content_id, content_version, event_type
+    ) AS retained_events
+);
+-- statement-break
+CREATE UNIQUE INDEX uq_learning_content_review_event ON learning_content_review_events(content_type, content_id, content_version, event_type);

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -1299,6 +1299,47 @@ mod tests {
     }
 
     #[test]
+    fn learning_lifecycle_event_uniqueness_scripts_are_dialect_safe() {
+        let scripts = [
+            (
+                "sqlite",
+                include_str!(
+                    "../sql/sqlite/up/0040_enforce_learning_lifecycle_event_uniqueness.sql"
+                ),
+            ),
+            (
+                "postgres",
+                include_str!(
+                    "../sql/postgres/up/0040_enforce_learning_lifecycle_event_uniqueness.sql"
+                ),
+            ),
+            (
+                "mysql",
+                include_str!(
+                    "../sql/mysql/up/0040_enforce_learning_lifecycle_event_uniqueness.sql"
+                ),
+            ),
+        ];
+
+        for (dialect, script) in scripts {
+            assert!(
+                script.contains("CREATE UNIQUE INDEX uq_learning_content_review_event"),
+                "{dialect} must enforce one lifecycle event per content transition"
+            );
+        }
+
+        let mysql = scripts[2].1;
+        assert!(
+            mysql.contains(") AS retained_events\n);"),
+            "MySQL needs an inner derived-table alias when deleting duplicate rows"
+        );
+        assert!(
+            !mysql.contains("retained_event_ids"),
+            "MySQL does not permit an alias after a NOT IN subquery"
+        );
+    }
+
+    #[test]
     fn mysql_down_scripts_skip_indexes_removed_by_a_later_table_drop() {
         for script in MYSQL_DOWN_SCRIPTS {
             let statements: Vec<_> = script

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -39,6 +39,7 @@ mod m0036_add_intake_ai_initial_review;
 mod m0037_add_ai_review_materials;
 mod m0038_create_learning_center;
 mod m0039_create_learning_content_review_events;
+mod m0040_enforce_learning_lifecycle_event_uniqueness;
 
 use sea_orm_migration::sea_orm::{DbBackend, Statement};
 
@@ -87,6 +88,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0037_add_ai_review_materials::Migration),
             Box::new(m0038_create_learning_center::Migration),
             Box::new(m0039_create_learning_content_review_events::Migration),
+            Box::new(m0040_enforce_learning_lifecycle_event_uniqueness::Migration),
         ]
     }
 }

--- a/migration/src/m0040_enforce_learning_lifecycle_event_uniqueness.rs
+++ b/migration/src/m0040_enforce_learning_lifecycle_event_uniqueness.rs
@@ -1,0 +1,58 @@
+use crate::{execute_script, sql_for_backend};
+use sea_orm_migration::prelude::*;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m0040_enforce_learning_lifecycle_event_uniqueness"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        const INDEX_NAME: &str = "uq_learning_content_review_event";
+        if !manager
+            .has_index("learning_content_review_events", INDEX_NAME)
+            .await?
+        {
+            execute_script(
+                manager,
+                sql_for_backend(
+                    manager,
+                    include_str!(
+                        "../sql/sqlite/up/0040_enforce_learning_lifecycle_event_uniqueness.sql"
+                    ),
+                    include_str!(
+                        "../sql/postgres/up/0040_enforce_learning_lifecycle_event_uniqueness.sql"
+                    ),
+                    include_str!(
+                        "../sql/mysql/up/0040_enforce_learning_lifecycle_event_uniqueness.sql"
+                    ),
+                ),
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        execute_script(
+            manager,
+            sql_for_backend(
+                manager,
+                include_str!(
+                    "../sql/sqlite/down/0040_remove_learning_lifecycle_event_uniqueness.sql"
+                ),
+                include_str!(
+                    "../sql/postgres/down/0040_remove_learning_lifecycle_event_uniqueness.sql"
+                ),
+                include_str!(
+                    "../sql/mysql/down/0040_remove_learning_lifecycle_event_uniqueness.sql"
+                ),
+            ),
+        )
+        .await
+    }
+}

--- a/src/application/services/learning_service.rs
+++ b/src/application/services/learning_service.rs
@@ -1057,7 +1057,11 @@ impl ContentLifecycle {
     }
 
     fn is_training_published(&self) -> bool {
-        self.state() == "published" && self.permitted_use == "training"
+        self.state() == "published"
+            && matches!(
+                self.permitted_use.as_str(),
+                "training" | "public_information"
+            )
     }
 
     fn response(self) -> Result<LearningContentLifecycleResponse, ApiError> {

--- a/src/application/services/learning_service.rs
+++ b/src/application/services/learning_service.rs
@@ -1,10 +1,10 @@
 use std::collections::{HashMap, HashSet};
 
 use chrono::{DateTime, SecondsFormat, Utc};
-use sea_orm::sea_query::Expr;
+use sea_orm::sea_query::{Expr, OnConflict};
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder, Set,
-    TransactionTrait,
+    TransactionTrait, TryInsertResult,
 };
 use serde_json::json;
 
@@ -887,20 +887,39 @@ async fn append_lifecycle_event(
     auth: &AuthenticatedUser,
     event: LifecycleEventInput<'_>,
 ) -> Result<(), ApiError> {
-    learning_content_review_events::ActiveModel {
-        id: Set(case_service::new_id()),
-        content_type: Set(event.content_type.to_owned()),
-        content_id: Set(event.content_id.to_owned()),
-        content_version: Set(event.content_version),
-        event_type: Set(event.event_type.to_owned()),
-        actor_user_id: Set(auth.id.clone()),
-        reason: Set(event.reason.to_owned()),
-        permitted_use: Set(event.permitted_use.to_owned()),
-        created_at: Set(now()),
-    }
-    .insert(transaction)
+    let result = learning_content_review_events::Entity::insert_many([
+        learning_content_review_events::ActiveModel {
+            id: Set(case_service::new_id()),
+            content_type: Set(event.content_type.to_owned()),
+            content_id: Set(event.content_id.to_owned()),
+            content_version: Set(event.content_version),
+            event_type: Set(event.event_type.to_owned()),
+            actor_user_id: Set(auth.id.clone()),
+            reason: Set(event.reason.to_owned()),
+            permitted_use: Set(event.permitted_use.to_owned()),
+            created_at: Set(now()),
+        },
+    ])
+    .on_conflict(
+        OnConflict::columns([
+            learning_content_review_events::Column::ContentType,
+            learning_content_review_events::Column::ContentId,
+            learning_content_review_events::Column::ContentVersion,
+            learning_content_review_events::Column::EventType,
+        ])
+        .do_nothing()
+        .to_owned(),
+    )
+    .do_nothing()
+    .exec(transaction)
     .await?;
-    Ok(())
+    if matches!(result, TryInsertResult::Inserted(_)) {
+        Ok(())
+    } else {
+        Err(ApiError::Conflict(
+            "学习内容状态已被其他管理员更新，请刷新后重试".to_owned(),
+        ))
+    }
 }
 
 async fn write_learning_audit(
@@ -937,6 +956,14 @@ async fn visible_question(
                 && visible_to(auth, &question.visibility)
         })
         .ok_or_else(|| ApiError::NotFound("learning question was not found".to_owned()))?;
+    if !content_lifecycle(db, "question", &question.id, question.version)
+        .await?
+        .is_training_published()
+    {
+        return Err(ApiError::NotFound(
+            "learning question was not found".to_owned(),
+        ));
+    }
     Ok(question)
 }
 

--- a/tests/api/learning_api.rs
+++ b/tests/api/learning_api.rs
@@ -377,6 +377,42 @@ async fn learning_content_requires_independent_governance_and_withdrawal_revokes
     assert_eq!(answer["is_correct"], true);
     assert_eq!(answer["source"]["resource_id"], resource_id);
 
+    let duplicate_submission_event = context
+        .database
+        .execute_unprepared(&format!(
+            "INSERT INTO learning_content_review_events (id, content_type, content_id, content_version, event_type, actor_user_id, reason, permitted_use, created_at) SELECT 'd{}', content_type, content_id, content_version, event_type, actor_user_id, reason, permitted_use, created_at FROM learning_content_review_events WHERE content_type = 'question' AND content_id = '{question_id}' AND event_type = 'submitted'",
+            &question_id[1..]
+        ))
+        .await;
+    assert!(duplicate_submission_event.is_err());
+
+    context
+        .database
+        .execute_unprepared(&format!(
+            "INSERT INTO learning_content_review_events (id, content_type, content_id, content_version, event_type, actor_user_id, reason, permitted_use, created_at) SELECT 'w{}', content_type, content_id, content_version, 'withdrawn', actor_user_id, reason, permitted_use, '9999-12-31T23:59:59.999Z' FROM learning_content_review_events WHERE content_type = 'question' AND content_id = '{question_id}' AND event_type = 'submitted'",
+            &question_id[1..]
+        ))
+        .await
+        .expect("fixture should simulate an externally withdrawn question lifecycle");
+    let answer_for_withdrawn_question = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/learning/questions/{question_id}/answers"))
+            .insert_header((
+                header::AUTHORIZATION,
+                format!("Bearer {}", context.token(LEARNER).await),
+            ))
+            .set_json(json!({ "selected_option_id": "a" }))
+            .to_request(),
+    )
+    .await;
+    assert_error(
+        answer_for_withdrawn_question,
+        StatusCode::NOT_FOUND,
+        "not_found",
+    )
+    .await;
+
     let withdrawn = test::call_service(
         &app,
         test::TestRequest::post()

--- a/tests/api/learning_api.rs
+++ b/tests/api/learning_api.rs
@@ -134,7 +134,7 @@ async fn learning_content_requires_independent_governance_and_withdrawal_revokes
                 "source_url": "https://example.invalid/approved-source",
                 "visibility": "public",
                 "effective_at": "2020-01-01T00:00:00.000Z",
-                "permitted_use": "training",
+                "permitted_use": "public_information",
                 "submission_reason": "已提交供独立脱敏与审核。"
             }))
             .to_request(),
@@ -224,6 +224,23 @@ async fn learning_content_requires_independent_governance_and_withdrawal_revokes
     assert_eq!(public_card.status(), StatusCode::OK);
     let public_card: Value = test::read_body_json(public_card).await;
     assert_eq!(public_card["id"], resource_id);
+
+    let exported_resource = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!(
+                "/api/admin/learning/resources/{resource_id}/export"
+            ))
+            .insert_header((
+                header::AUTHORIZATION,
+                format!("Bearer {}", context.token(ADMIN).await),
+            ))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(exported_resource.status(), StatusCode::OK);
+    let exported_resource: Value = test::read_body_json(exported_resource).await;
+    assert_eq!(exported_resource["id"], resource_id);
 
     let question = test::call_service(
         &app,


### PR DESCRIPTION
已核实并处理这批 CodeRabbit 评论，修复提交 bfb129e 已推送到 PR #181
  (https://github.com/AG-Angui/Angui/pull/181)。开发后端已恢复，健康检查为 200。

  - 治理并发：评论成立。新增迁移 m0040，在 SQLite、PostgreSQL、MySQL 上对 (content_type,
    content_id, content_version, event_type) 建立唯一约束；迁移会先清理历史重复事件。并发重复操作
    不会再写入第二条生命周期事件或审计，而是返回中文 409 Conflict。

  - 答题可见性：评论成立。visible_question 现在同时检查题目自身治理生命周期，题目状态字段与审计事
    件不同步、或已在生命周期中撤回时，提交答案返回 404，与题库列表行为一致。

  - 缺失会话：评论成立。学习页在 token 缺失时结束加载并显示“登录状态不可用，请重新登录后访问学习
    中心。”，不再永久停留加载态。

  - 离线缓存注册：评论成立。Service Worker 注册失败会被捕获并记录；学习页仅在 Service Worker 已激
    活、已控制当前页面且应用壳已缓存时显示“可离线使用”，否则显示“仅可在线查看”及可操作提示。

  - Service Worker 安装：评论成立。预缓存失败不会导致安装失败；Service Worker 从生产 index.html
    提取哈希化 JS/CSS 资源并尽力预缓存，单个资源失败只记录警告，联网后仍可运行时缓存。

  - 角色测试：评论成立。/learning 正向测试已分别覆盖 learner、家属与志愿者，并保留仅指挥员的拒绝
    测试。

  - 题目 permitted_use：没有放宽为 public_information。这是保留的产品边界：题目、服务端判题与解析
    固定为 training；“公开信息”只适用于治理后的可阅读资源，不会被扩展成题库用途。

  验证已完成：

  - cargo test --test api_contract learning_：2/2 通过
  - cargo test -p migration --locked：23/23 通过
  - cargo clippy --workspace --all-targets --all-features --locked -- -D warnings：通过
  - cargo fmt --all -- --check：通过
  - npm --prefix frontend run test：84/84 通过
  - npm --prefix frontend run lint、npm --prefix frontend run build：通过

  唯一非失败提示仍是现有生产构建的 bundle 体积警告，以及第三方 proc-macro-error2 的未来兼容提示；
  均非本次改动引入。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 防走失知识卡支持离线缓存，并显示“可离线使用”“仅可在线查看”或“等待发布”等状态。
  - 培训与公开信息资源均可按治理流程读取或导出；题目继续限定为培训用途。
  - 相关公共信息接口支持公开信息资源。

- **问题修复**
  - 缓存未就绪或登录状态失效时，页面提供明确提示。
  - 防止学习审核事件重复记录，并正确处理已撤回题目的访问。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->