### PR TITLE
feat(ai): persist safe review execution progress

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -20,6 +20,8 @@
 | `POST` | `/api/intake-sessions/{session_id}/answers` | `201` | 追加一个未确认答案并获取下一问 |
 | `GET` | `/api/intake-sessions/{session_id}/profile-draft` | `200` | 获取家属专属、待确认的标准化画像草稿 |
 | `POST` | `/api/intake-sessions/{session_id}/confirm` | `201` | 家属确认画像并创建正式案件 |
+| `GET` | `/api/ai/executions/{execution_id}` | `200` | 查询当前用户的受控 AI 执行阶段与安全终态 |
+| `GET` | `/api/ai/executions/{execution_id}/events` | `200` | 按事件 ID 恢复读取有序、可去重的安全 SSE 生命周期事件 |
 | `GET` | `/api/cases` | `200` | 按创建时间倒序列出案件 |
 | `GET` | `/api/cases/command-intake` | `200` | 指挥查看仅含最小接案信息的待受理队列 |
 | `POST` | `/api/cases` | `201` | 创建案件和老人画像 |
@@ -333,7 +335,9 @@ The following authenticated endpoints produce only drafts; none confirms a clue,
 
 Family intake now has a separate first-confirmation path: `POST /api/intake-sessions/{session_id}/ai-initial-review` stores a family-only initial-review draft and never creates a case. `GET /api/intake-sessions/{session_id}/ai-initial-review` returns the current result. The family must acknowledge every displayed issue through `POST /api/intake-sessions/{session_id}/ai-initial-review/acknowledge` before the existing `/confirm` endpoint performs the second confirmation and creates the case. Model failures, policy mismatches, and invalid JSON use the deterministic rule-check fallback; no fallback result confirms a fact or location.
 
-The intake profile-generation and initial-review POST endpoints respond as SSE. Before the final `completed` JSON event, they may emit `progress` events with the safe stage values `queued`, `preparing`, `generating`, `validating`, or `fallback`. Progress events carry only the stage name and never model reasoning, raw prompts, profile content, unvalidated candidate fields, provider credentials, or upstream SSE payloads. Clients must treat only `completed` as a final draft/review result and must discard a partial stream on interruption.
+The intake profile-generation and initial-review POST endpoints respond as SSE. Their first `started` event includes a stable `execution_id`; progress events include a monotonic `event_id` and the safe stage values `queued`, `preparing`, `generating`, `validating`, or `fallback`. Progress events carry lifecycle metadata only and never model reasoning, raw prompts, profile content, unvalidated candidate fields, provider credentials, or upstream SSE payloads. Clients must treat only `completed` as a final draft/review result and must discard a partial stream on interruption.
+
+`GET /api/ai/executions/{execution_id}` lets the owning authenticated user recover the current execution state after refresh or an interrupted stream. `GET /api/ai/executions/{execution_id}/events?after={last_event_id}` returns ordered, de-duplicable lifecycle metadata only. After completion, clients re-read the existing draft or review resource rather than treating a cached or partial event as a result. Execution audits contain only the execution ID, stage, safe failure kind, result status, and fallback flag; they do not store prompt text, sensitive inputs, model output, or preview content.
 
 - `GET /api/intake-sessions/{session_id}/ai-follow-up` returns one optional, skippable AI follow-up question or the static-question fallback. `GET /api/intake-sessions/{session_id}/answer-revisions` lists immutable answers for the session creator; `POST /api/intake-sessions/{session_id}/answers/{field}/restore` restores a selected answer by creating a new revision.
 - `PATCH /api/cases/{case_id}/clue-drafts/{draft_id}/review` accepts `field_decisions` for `content_summary`, `occurred_at`, `location_text`, `source_text`, and `action_candidates`. Decisions are `accept`, `edit`, or `clear`; only an accepted draft is promoted to a normal pending-review clue.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -110,6 +110,7 @@ paths:
       x-data-classification: sensitive
       responses:
         "200": { description: Ordered safe SSE events, content: { text/event-stream: { schema: { type: string } } } }
+        "400": { $ref: "#/components/responses/ValidationError" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/InternalError" }
@@ -2416,7 +2417,7 @@ components:
     AiExecution:
       type: object
       additionalProperties: false
-      required: [execution_id, workflow, stage, status, fallback_used, last_event_id, created_at, updated_at]
+      required: [execution_id, workflow, stage, status, failure_kind, result_status, fallback_used, last_event_id, created_at, updated_at]
       properties:
         execution_id: { type: string }
         workflow: { type: string }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -70,6 +70,50 @@ paths:
                 service: angui-api
                 version: 0.1.0
 
+  /api/ai/executions/{execution_id}:
+    parameters:
+      - name: execution_id
+        in: path
+        required: true
+        schema: { type: string }
+    get:
+      tags: [Intake sessions]
+      operationId: getAiExecution
+      summary: Read a caller-owned controlled AI execution status
+      description: Returns safe lifecycle metadata only, never prompts, provider streams, candidate text, or sensitive inputs.
+      security: [{ bearerAuth: [] }]
+      x-account-types: [member]
+      x-data-classification: sensitive
+      responses:
+        "200": { description: Safe execution state, content: { application/json: { schema: { $ref: "#/components/schemas/AiExecution" } } } }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
+  /api/ai/executions/{execution_id}/events:
+    parameters:
+      - name: execution_id
+        in: path
+        required: true
+        schema: { type: string }
+      - name: after
+        in: query
+        required: false
+        schema: { type: integer, minimum: 0 }
+    get:
+      tags: [Intake sessions]
+      operationId: listAiExecutionEvents
+      summary: Read ordered safe execution events after an event id
+      description: Reconnect with `after` to obtain only newer, de-duplicable lifecycle events, then fetch the existing draft resource after completion.
+      security: [{ bearerAuth: [] }]
+      x-account-types: [member]
+      x-data-classification: sensitive
+      responses:
+        "200": { description: Ordered safe SSE events, content: { text/event-stream: { schema: { type: string } } } }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
   /api/auth/login:
     post:
       tags: [Authentication]
@@ -2368,6 +2412,22 @@ components:
           type: string
           description: 当前 Cargo package 版本。
           example: 0.1.0
+
+    AiExecution:
+      type: object
+      additionalProperties: false
+      required: [execution_id, workflow, stage, status, fallback_used, last_event_id, created_at, updated_at]
+      properties:
+        execution_id: { type: string }
+        workflow: { type: string }
+        stage: { type: string, enum: [queued, preparing, generating, validating, fallback, ready_for_review, failed] }
+        status: { type: string, enum: [running, completed, failed] }
+        failure_kind: { type: [string, "null"] }
+        result_status: { type: [string, "null"] }
+        fallback_used: { type: boolean }
+        last_event_id: { type: integer }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
 
     LoginRequest:
       type: object

--- a/frontend/src/api/aiExecutions.ts
+++ b/frontend/src/api/aiExecutions.ts
@@ -1,0 +1,31 @@
+import { apiRequest } from "./client";
+
+export type AiExecutionStage =
+  | "queued"
+  | "preparing"
+  | "generating"
+  | "validating"
+  | "fallback"
+  | "ready_for_review"
+  | "failed";
+
+export interface AiExecution {
+  execution_id: string;
+  workflow: "intake_profile_draft" | "intake_initial_review" | string;
+  stage: AiExecutionStage;
+  status: "running" | "completed" | "failed";
+  failure_kind: string | null;
+  result_status: string | null;
+  fallback_used: boolean;
+  last_event_id: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export function getAiExecution(token: string, executionId: string) {
+  return apiRequest<AiExecution>(
+    `/ai/executions/${encodeURIComponent(executionId)}`,
+    {},
+    token,
+  );
+}

--- a/frontend/src/api/cases.test.ts
+++ b/frontend/src/api/cases.test.ts
@@ -19,6 +19,13 @@ function jsonResponse(status: number, body: unknown): Response {
   });
 }
 
+function sseCompletedResponse(body: unknown): Response {
+  return new Response(`event: completed\ndata: ${JSON.stringify(body)}\n\n`, {
+    status: 201,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
 function requestOptions(call: unknown[]) {
   return call[1] as RequestInit;
 }
@@ -162,7 +169,7 @@ describe("case API contract", () => {
   it("preserves an explicit empty summary draft content so the server can reject it", async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(jsonResponse(201, { id: "summary-1" }))
+      .mockResolvedValueOnce(sseCompletedResponse({ id: "summary-1" }))
       .mockResolvedValueOnce(
         jsonResponse(400, {
           error: { code: "validation_error", message: "content is required" },

--- a/frontend/src/api/cases.ts
+++ b/frontend/src/api/cases.ts
@@ -1,4 +1,9 @@
-import { ApiClientError, apiRequest } from "./client";
+import {
+  ApiClientError,
+  apiRequest,
+  apiSseRequest,
+  type SseEventListener,
+} from "./client";
 import type { AccountType, GlobalCapability } from "./auth";
 
 export type CaseRole = "family" | "commander" | "volunteer";
@@ -752,11 +757,13 @@ export function createClueDraft(
   token: string,
   caseId: string,
   payload: { source_record_id: string },
+  onEvent?: SseEventListener,
 ): Promise<ClueDraft[]> {
-  return apiRequest<ClueDraft[]>(
+  return apiSseRequest<ClueDraft[]>(
     `/cases/${caseId}/clue-drafts`,
     { method: "POST", body: JSON.stringify(payload) },
     token,
+    onEvent,
   );
 }
 
@@ -830,14 +837,24 @@ export function createSummaryDraft(
   token: string,
   caseId: string,
   content?: string,
+  onEvent?: SseEventListener,
 ): Promise<SummaryDraft> {
-  return apiRequest<SummaryDraft>(
+  const options = {
+    method: "POST",
+    body: JSON.stringify(content === undefined ? {} : { content }),
+  };
+  if (content !== undefined) {
+    return apiRequest<SummaryDraft>(
+      `/cases/${caseId}/summary-drafts`,
+      options,
+      token,
+    );
+  }
+  return apiSseRequest<SummaryDraft>(
     `/cases/${caseId}/summary-drafts`,
-    {
-      method: "POST",
-      body: JSON.stringify(content === undefined ? {} : { content }),
-    },
+    options,
     token,
+    onEvent,
   );
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -9,6 +9,7 @@ interface ApiErrorPayload {
 }
 
 export interface SseEvent {
+  id?: string;
   event: string;
   payload: unknown;
 }
@@ -185,8 +186,10 @@ export async function apiSseRequest<T>(
       buffered = frames.pop() ?? "";
       for (const frame of frames) {
         let event = "message";
+        let id: string | undefined;
         const data: string[] = [];
         for (const line of frame.split(/\r?\n/)) {
+          if (line.startsWith("id:")) id = line.slice(3).trim();
           if (line.startsWith("event:")) event = line.slice(6).trim();
           if (line.startsWith("data:")) data.push(line.slice(5).trimStart());
         }
@@ -202,7 +205,7 @@ export async function apiSseRequest<T>(
             userMessageFor(0, "invalid_stream"),
           );
         }
-        onEvent?.({ event, payload });
+        onEvent?.({ id, event, payload });
         if (event === "completed") return payload as T;
         if (event === "error") {
           const message =

--- a/frontend/src/components/AiReviewProgress.tsx
+++ b/frontend/src/components/AiReviewProgress.tsx
@@ -48,14 +48,18 @@ const stageDetails: Record<
   },
 };
 
+const terminalStages: AiReviewStage[] = ["ready_for_review", "failed"];
+
 export function AiReviewProgress({
   stage,
-  title = "AI 审核进行中",
+  title,
 }: {
   stage: AiReviewStage;
   title?: string;
 }) {
   const detail = stageDetails[stage];
+  const isTerminal = terminalStages.includes(stage);
+  const heading = isTerminal ? "AI 审核已结束" : (title ?? "AI 审核进行中");
 
   return (
     <section
@@ -63,15 +67,19 @@ export function AiReviewProgress({
       role="status"
       aria-live="polite"
       aria-atomic="true"
-      aria-label={`${title}：${detail.label}`}
+      aria-label={`${heading}：${detail.label}`}
     >
       <div className="flex items-start gap-3">
         <span
-          className="mt-1 flex h-3 w-3 shrink-0 rounded-full bg-brand-600 motion-safe:animate-pulse motion-reduce:animate-none"
+          className={`mt-1 flex h-3 w-3 shrink-0 rounded-full bg-brand-600 ${
+            isTerminal
+              ? ""
+              : "motion-safe:animate-pulse motion-reduce:animate-none"
+          }`}
           aria-hidden="true"
         />
         <div className="min-w-0 flex-1">
-          <h3 className="m-0 text-sm font-bold text-slate-950">{title}</h3>
+          <h3 className="m-0 text-sm font-bold text-slate-950">{heading}</h3>
           <p className="mb-0 mt-1 leading-6">{detail.label}</p>
           <p className="mb-0 mt-1 text-xs leading-5 text-slate-600">
             {detail.description}
@@ -88,7 +96,7 @@ export function AiReviewProgress({
                 className={`block h-1.5 rounded-full ${
                   isComplete ? "bg-brand-600" : "bg-brand-100"
                 } ${
-                  isCurrent
+                  isCurrent && !isTerminal
                     ? "motion-safe:animate-pulse motion-reduce:animate-none"
                     : ""
                 }`}

--- a/frontend/src/components/AiReviewProgress.tsx
+++ b/frontend/src/components/AiReviewProgress.tsx
@@ -3,7 +3,9 @@ export type AiReviewStage =
   | "preparing"
   | "generating"
   | "validating"
-  | "fallback";
+  | "fallback"
+  | "ready_for_review"
+  | "failed";
 
 const stageDetails: Record<
   AiReviewStage,
@@ -33,6 +35,16 @@ const stageDetails: Record<
     label: "正在切换规则结果",
     description: "AI 结果不可用或未通过校验，系统会提供可人工核对的规则结果。",
     completed: 4,
+  },
+  ready_for_review: {
+    label: "候选已准备好，等待人工审核",
+    description: "结果仍是草稿或候选，必须由当前角色人工核对后才能继续。",
+    completed: 4,
+  },
+  failed: {
+    label: "审核未能完成",
+    description: "没有生成可用草稿。请重试，或按现有人工流程继续。",
+    completed: 0,
   },
 };
 

--- a/frontend/src/pages/CaseWorkspacePage.tsx
+++ b/frontend/src/pages/CaseWorkspacePage.tsx
@@ -74,9 +74,13 @@ import type {
   PlaceType,
   PlaceVisibility,
 } from "../api/cases";
-import { ApiClientError } from "../api/client";
+import { ApiClientError, type SseEvent } from "../api/client";
+import { getAiExecution } from "../api/aiExecutions";
 import { useAuth } from "../auth/useAuth";
-import { AiReviewProgress } from "../components/AiReviewProgress";
+import {
+  AiReviewProgress,
+  type AiReviewStage,
+} from "../components/AiReviewProgress";
 import {
   EmptyState,
   ErrorState,
@@ -2629,11 +2633,43 @@ function CaseCollaborationPanel({
   const [reviewReason, setReviewReason] = useState("");
   const [error, setError] = useState("");
   const [busy, setBusy] = useState("");
+  const [aiReviewStage, setAiReviewStage] = useState<AiReviewStage | null>(
+    null,
+  );
+  const [activeAiExecution, setActiveAiExecution] = useState<{
+    id: string;
+    workflow: string;
+  } | null>(null);
   const progressRequestVersion = useRef(0);
   const isFamily = detail.access_role === "family";
   const canFindPois =
     detail.access_role === "commander" || detail.access_role === "volunteer";
   const isCommander = detail.access_role === "commander";
+
+  const updateAiReviewStage = useCallback(({ event, payload }: SseEvent) => {
+    if (!payload || typeof payload !== "object") return;
+    if (
+      event === "started" &&
+      "execution_id" in payload &&
+      typeof payload.execution_id === "string" &&
+      "workflow" in payload &&
+      typeof payload.workflow === "string"
+    ) {
+      setActiveAiExecution({ id: payload.execution_id, workflow: payload.workflow });
+      setAiReviewStage("queued");
+    }
+    if (event !== "progress" || !("stage" in payload)) return;
+    const stage = payload.stage;
+    if (
+      stage === "queued" ||
+      stage === "preparing" ||
+      stage === "generating" ||
+      stage === "validating" ||
+      stage === "fallback"
+    ) {
+      setAiReviewStage(stage);
+    }
+  }, []);
 
   const loadPublicProgress = useCallback(async () => {
     const requestVersion = progressRequestVersion.current + 1;
@@ -2709,6 +2745,85 @@ function CaseCollaborationPanel({
     void loadSummary();
     void loadClueDrafts();
   }, [detail.id, loadClueDrafts, loadPublicProgress, loadSummary]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const raw = window.sessionStorage.getItem(`angui:case-ai-execution:${detail.id}`);
+    if (!raw) return;
+    try {
+      const value = JSON.parse(raw) as { id?: unknown; workflow?: unknown };
+      if (typeof value.id === "string" && typeof value.workflow === "string")
+        setActiveAiExecution({ id: value.id, workflow: value.workflow });
+    } catch {
+      window.sessionStorage.removeItem(`angui:case-ai-execution:${detail.id}`);
+    }
+  }, [detail.id]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const key = `angui:case-ai-execution:${detail.id}`;
+    if (activeAiExecution) window.sessionStorage.setItem(key, JSON.stringify(activeAiExecution));
+    else window.sessionStorage.removeItem(key);
+  }, [activeAiExecution, detail.id]);
+
+  useEffect(() => {
+    if (!token || !activeAiExecution) return;
+    const executionId = activeAiExecution.id;
+    const workflow = activeAiExecution.workflow;
+    let cancelled = false;
+    let retry: number | undefined;
+    let attempts = 0;
+    let networkFailures = 0;
+    const maxAttempts = 60;
+    const maxNetworkFailures = 3;
+    const recover = async () => {
+      attempts += 1;
+      if (attempts > maxAttempts) {
+        if (!cancelled) {
+          setAiReviewStage("failed");
+          setError("AI 草稿恢复超时，请重试或改用人工流程。");
+          setBusy("");
+        }
+        return;
+      }
+      try {
+        const execution = await getAiExecution(token, executionId);
+        networkFailures = 0;
+        if (cancelled) return;
+        if (execution.status === "running") {
+          setAiReviewStage(execution.stage);
+          retry = window.setTimeout(() => void recover(), 2_000);
+          return;
+        }
+        if (execution.status === "failed") {
+          setAiReviewStage("failed");
+          setError("AI 草稿未能完成，请重试或改用人工流程。");
+        } else if (workflow === "clue_draft") await loadClueDrafts();
+        else if (workflow === "summary_draft") await loadSummary();
+        if (!cancelled) {
+          setActiveAiExecution(null);
+          setAiReviewStage(null);
+          setBusy("");
+        }
+      } catch (cause) {
+        if (!cancelled) {
+          networkFailures += 1;
+          if (networkFailures <= maxNetworkFailures && attempts < maxAttempts) {
+            retry = window.setTimeout(() => void recover(), 2_000);
+          } else {
+            setAiReviewStage("failed");
+            setError(messageFrom(cause));
+            setBusy("");
+          }
+        }
+      }
+    };
+    void recover();
+    return () => {
+      cancelled = true;
+      if (retry !== undefined) window.clearTimeout(retry);
+    };
+  }, [activeAiExecution, loadClueDrafts, loadSummary, token]);
 
   async function run(key: string, action: () => Promise<void>) {
     setBusy(key);
@@ -2889,13 +3004,15 @@ function CaseCollaborationPanel({
 
       {isCommander && (
         <div className="min-w-0">
-          {(busy === "clue-draft" || busy === "summary-edit") && (
+          {(busy === "clue-draft" || activeAiExecution) && (
             <AiReviewProgress
-              stage="generating"
+              stage={aiReviewStage ?? "generating"}
               title={
                 busy === "clue-draft"
                   ? "AI 线索草稿生成中"
-                  : "AI 案情摘要生成中"
+                  : activeAiExecution?.workflow === "summary_draft"
+                    ? "AI 案情摘要生成中"
+                    : "AI 线索草稿生成中"
               }
             />
           )}
@@ -2950,9 +3067,11 @@ function CaseCollaborationPanel({
                   );
                   const created = await createClueDraft(token, detail.id, {
                     source_record_id: record.id,
-                  });
+                  }, updateAiReviewStage);
                   setClueDrafts((current) => [...created, ...current]);
                   setClueDraftText("");
+                  setActiveAiExecution(null);
+                  setAiReviewStage(null);
                 })
               }
             >

--- a/frontend/src/pages/CaseWorkspacePage.tsx
+++ b/frontend/src/pages/CaseWorkspacePage.tsx
@@ -2849,7 +2849,11 @@ function CaseCollaborationPanel({
               onPress={() =>
                 void run("pois", async () => {
                   if (!token) return;
-                  setPois(await listCasePois(token, detail.id, poiCategory));
+                  try {
+                    setPois(await listCasePois(token, detail.id, poiCategory));
+                  } catch (cause) {
+                    throw new Error(poiErrorMessage(cause));
+                  }
                 })
               }
             >
@@ -3965,6 +3969,12 @@ function toIsoOrNull(value: string): string | null {
 function messageFrom(cause: unknown): string {
   if (cause instanceof ApiClientError) return cause.message;
   return cause instanceof Error ? cause.message : "操作失败";
+}
+
+function poiErrorMessage(cause: unknown): string {
+  if (cause instanceof ApiClientError && cause.status === 409)
+    return "当前案件没有可用的任务或已确认地点坐标，无法检索周边资源。请使用任务区域文字并联系指挥确认。";
+  return messageFrom(cause);
 }
 
 function formatDate(value: string | null): string | null {

--- a/frontend/src/pages/FamilyIntakeForm.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.tsx
@@ -210,6 +210,16 @@ export function FamilyIntakeForm({
   const [error, setError] = useState("");
   const [hasHydrated, setHasHydrated] = useState(false);
   const confirmDialogRef = useRef<HTMLDivElement>(null);
+  const basicInformationRef = useRef(basicInformation);
+  const activeAiExecutionRef = useRef(activeAiExecution);
+
+  useEffect(() => {
+    basicInformationRef.current = basicInformation;
+  }, [basicInformation]);
+
+  useEffect(() => {
+    activeAiExecutionRef.current = activeAiExecution;
+  }, [activeAiExecution]);
 
   const updateAiReviewStage = useCallback(({ event, payload }: SseEvent) => {
     if (!payload || typeof payload !== "object") return;
@@ -220,10 +230,13 @@ export function FamilyIntakeForm({
       "workflow" in payload &&
       typeof payload.workflow === "string"
     ) {
-      setActiveAiExecution({
+      const execution = {
         id: payload.execution_id,
         workflow: payload.workflow,
-      });
+      };
+      activeAiExecutionRef.current = execution;
+      setActiveAiExecution(execution);
+      setAiReviewStage("queued");
     }
     if (event !== "progress") return;
     const stage = "stage" in payload ? payload.stage : null;
@@ -232,7 +245,9 @@ export function FamilyIntakeForm({
       stage === "preparing" ||
       stage === "generating" ||
       stage === "validating" ||
-      stage === "fallback"
+      stage === "fallback" ||
+      stage === "ready_for_review" ||
+      stage === "failed"
     ) {
       setAiReviewStage(stage);
     }
@@ -362,10 +377,24 @@ export function FamilyIntakeForm({
     const sessionId = session.id;
     let cancelled = false;
     let retry: number | undefined;
+    let attempts = 0;
+    let networkFailures = 0;
+    const maxAttempts = 60;
+    const maxNetworkFailures = 3;
 
     async function recover() {
+      attempts += 1;
+      if (attempts > maxAttempts) {
+        if (!cancelled) {
+          setAiReviewStage("failed");
+          setError("AI 审核恢复超时，请重试或按现有人工流程继续。");
+          setBusyAction(null);
+        }
+        return;
+      }
       try {
         const execution = await getAiExecution(sessionToken, executionId);
+        networkFailures = 0;
         if (cancelled) return;
         if (execution.status === "running") {
           setAiReviewStage(execution.stage);
@@ -375,13 +404,11 @@ export function FamilyIntakeForm({
         if (execution.status === "failed") {
           setAiReviewStage("failed");
           setError("AI 审核未能完成，请重试或按现有人工流程继续。");
-          setActiveAiExecution(null);
           setBusyAction(null);
           return;
         }
         if (workflow === "intake_profile_draft") {
-          const next = await loadDraft(sessionId, true, basicInformation);
-          if (next && !cancelled) setProfile(profileFromDraft(next, basicInformation));
+          await loadDraft(sessionId, true, basicInformationRef.current);
         } else if (workflow === "intake_initial_review") {
           const review = await getIntakeAiInitialReview(sessionToken, sessionId);
           if (!cancelled) {
@@ -399,9 +426,14 @@ export function FamilyIntakeForm({
         }
       } catch (cause) {
         if (!cancelled) {
-          setError(messageFrom(cause));
-          setActiveAiExecution(null);
-          setBusyAction(null);
+          networkFailures += 1;
+          if (networkFailures <= maxNetworkFailures && attempts < maxAttempts) {
+            retry = window.setTimeout(recover, 2_000);
+          } else {
+            setAiReviewStage("failed");
+            setError(messageFrom(cause));
+            setBusyAction(null);
+          }
         }
       }
     }
@@ -411,7 +443,7 @@ export function FamilyIntakeForm({
       cancelled = true;
       if (retry !== undefined) window.clearTimeout(retry);
     };
-  }, [activeAiExecution, basicInformation, loadDraft, session, token]);
+  }, [activeAiExecution, loadDraft, session, token]);
 
   useEffect(() => {
     if (!answer.trim() || typeof window === "undefined") return;
@@ -622,6 +654,8 @@ export function FamilyIntakeForm({
     setBusyAction("initial_review");
     setError("");
     setAiReviewStage("queued");
+    activeAiExecutionRef.current = null;
+    setActiveAiExecution(null);
     try {
       const review = await startIntakeAiInitialReview(
         token,
@@ -637,7 +671,7 @@ export function FamilyIntakeForm({
     } catch (cause) {
       setError(messageFrom(cause));
     } finally {
-      if (!activeAiExecution) setAiReviewStage(null);
+      if (!activeAiExecutionRef.current) setAiReviewStage(null);
       setBusyAction(null);
     }
   }
@@ -647,6 +681,8 @@ export function FamilyIntakeForm({
     setBusyAction("generate");
     setError("");
     setAiReviewStage("queued");
+    activeAiExecutionRef.current = null;
+    setActiveAiExecution(null);
     try {
       const next = await generateIntakeDraft(
         token,
@@ -659,7 +695,7 @@ export function FamilyIntakeForm({
     } catch (cause) {
       setError(messageFrom(cause));
     } finally {
-      if (!activeAiExecution) setAiReviewStage(null);
+      if (!activeAiExecutionRef.current) setAiReviewStage(null);
       setBusyAction(null);
     }
   }
@@ -828,7 +864,9 @@ export function FamilyIntakeForm({
                 {busyAction === "generate" ? "正在生成新版本" : "生成新版本"}
               </Button>
             </div>
-            {busyAction === "generate" && (
+            {(busyAction === "generate" ||
+              (activeAiExecution?.workflow === "intake_profile_draft" &&
+                aiReviewStage === "failed")) && (
               <AiReviewProgress
                 stage={aiReviewStage ?? "queued"}
                 title="AI 画像草稿生成中"
@@ -1219,7 +1257,11 @@ export function FamilyIntakeForm({
             />
             <InitialReviewPanel
               review={initialReview}
-              isReviewing={busyAction === "initial_review"}
+              isReviewing={
+                busyAction === "initial_review" ||
+                (activeAiExecution?.workflow === "intake_initial_review" &&
+                  aiReviewStage === "failed")
+              }
               stage={aiReviewStage}
               confirmedIssueIds={confirmedInitialReviewIssues}
               onToggleIssue={toggleInitialReviewIssue}
@@ -2199,10 +2241,22 @@ function readStoredState(storageKey: string): StoredIntakeState | null {
       session: session as StoredIntakeSession,
       answer: typeof parsed.answer === "string" ? parsed.answer : "",
       basicInformation: readBasicInformation(parsed.basicInformation),
+      aiExecution: readAiExecution(parsed.aiExecution),
     };
   } catch {
     return discardStoredState(storageKey);
   }
+}
+
+function readAiExecution(
+  value: unknown,
+): { id: string; workflow: string } | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const execution = value as Partial<{ id: string; workflow: string }>;
+  if (typeof execution.id !== "string" || !execution.id) return undefined;
+  if (typeof execution.workflow !== "string" || !execution.workflow)
+    return undefined;
+  return { id: execution.id, workflow: execution.workflow };
 }
 
 function readBasicInformation(value: unknown): BasicInformationDraft {

--- a/frontend/src/pages/FamilyIntakeForm.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ApiClientError, type SseEvent } from "../api/client";
+import { getAiExecution } from "../api/aiExecutions";
 import {
   acknowledgeIntakeAiInitialReview,
   confirmIntakeSession,
@@ -134,6 +135,7 @@ interface StoredIntakeState {
   session: StoredIntakeSession;
   answer: string;
   basicInformation: BasicInformationDraft;
+  aiExecution?: { id: string; workflow: string };
 }
 
 interface BasicInformationDraft {
@@ -177,6 +179,10 @@ export function FamilyIntakeForm({
   const [aiReviewStage, setAiReviewStage] = useState<AiReviewStage | null>(
     null,
   );
+  const [activeAiExecution, setActiveAiExecution] = useState<{
+    id: string;
+    workflow: string;
+  } | null>(null);
   const [confirmedInitialReviewIssues, setConfirmedInitialReviewIssues] =
     useState<string[]>([]);
   const [answerRevisions, setAnswerRevisions] = useState<
@@ -206,7 +212,20 @@ export function FamilyIntakeForm({
   const confirmDialogRef = useRef<HTMLDivElement>(null);
 
   const updateAiReviewStage = useCallback(({ event, payload }: SseEvent) => {
-    if (event !== "progress" || !payload || typeof payload !== "object") return;
+    if (!payload || typeof payload !== "object") return;
+    if (
+      event === "started" &&
+      "execution_id" in payload &&
+      typeof payload.execution_id === "string" &&
+      "workflow" in payload &&
+      typeof payload.workflow === "string"
+    ) {
+      setActiveAiExecution({
+        id: payload.execution_id,
+        workflow: payload.workflow,
+      });
+    }
+    if (event !== "progress") return;
     const stage = "stage" in payload ? payload.stage : null;
     if (
       stage === "queued" ||
@@ -283,6 +302,7 @@ export function FamilyIntakeForm({
       setSession(stored.session);
       setAnswer(stored.answer);
       setBasicInformation(stored.basicInformation);
+      if (stored.aiExecution) setActiveAiExecution(stored.aiExecution);
       if (
         [
           "ready_for_confirmation",
@@ -322,9 +342,76 @@ export function FamilyIntakeForm({
       session: toStoredSession(session),
       answer,
       basicInformation,
+      aiExecution: activeAiExecution ?? undefined,
     };
     window.sessionStorage.setItem(storageKey, JSON.stringify(stored));
-  }, [answer, basicInformation, hasHydrated, session, storageKey]);
+  }, [
+    activeAiExecution,
+    answer,
+    basicInformation,
+    hasHydrated,
+    session,
+    storageKey,
+  ]);
+
+  useEffect(() => {
+    if (!token || !session || !activeAiExecution) return;
+    const sessionToken = token;
+    const executionId = activeAiExecution.id;
+    const workflow = activeAiExecution.workflow;
+    const sessionId = session.id;
+    let cancelled = false;
+    let retry: number | undefined;
+
+    async function recover() {
+      try {
+        const execution = await getAiExecution(sessionToken, executionId);
+        if (cancelled) return;
+        if (execution.status === "running") {
+          setAiReviewStage(execution.stage);
+          retry = window.setTimeout(recover, 2_000);
+          return;
+        }
+        if (execution.status === "failed") {
+          setAiReviewStage("failed");
+          setError("AI 审核未能完成，请重试或按现有人工流程继续。");
+          setActiveAiExecution(null);
+          setBusyAction(null);
+          return;
+        }
+        if (workflow === "intake_profile_draft") {
+          const next = await loadDraft(sessionId, true, basicInformation);
+          if (next && !cancelled) setProfile(profileFromDraft(next, basicInformation));
+        } else if (workflow === "intake_initial_review") {
+          const review = await getIntakeAiInitialReview(sessionToken, sessionId);
+          if (!cancelled) {
+            setInitialReview(review);
+            setConfirmedInitialReviewIssues([]);
+            setSession((current) =>
+              current ? { ...current, status: review.status } : current,
+            );
+          }
+        }
+        if (!cancelled) {
+          setAiReviewStage(null);
+          setActiveAiExecution(null);
+          setBusyAction(null);
+        }
+      } catch (cause) {
+        if (!cancelled) {
+          setError(messageFrom(cause));
+          setActiveAiExecution(null);
+          setBusyAction(null);
+        }
+      }
+    }
+
+    void recover();
+    return () => {
+      cancelled = true;
+      if (retry !== undefined) window.clearTimeout(retry);
+    };
+  }, [activeAiExecution, basicInformation, loadDraft, session, token]);
 
   useEffect(() => {
     if (!answer.trim() || typeof window === "undefined") return;
@@ -346,6 +433,7 @@ export function FamilyIntakeForm({
       setDraft(null);
       setInitialReview(null);
       setAiReviewStage(null);
+      setActiveAiExecution(null);
       setConfirmedInitialReviewIssues([]);
       setAssessments([]);
       setAnswer("");
@@ -549,7 +637,7 @@ export function FamilyIntakeForm({
     } catch (cause) {
       setError(messageFrom(cause));
     } finally {
-      setAiReviewStage(null);
+      if (!activeAiExecution) setAiReviewStage(null);
       setBusyAction(null);
     }
   }
@@ -571,7 +659,7 @@ export function FamilyIntakeForm({
     } catch (cause) {
       setError(messageFrom(cause));
     } finally {
-      setAiReviewStage(null);
+      if (!activeAiExecution) setAiReviewStage(null);
       setBusyAction(null);
     }
   }

--- a/frontend/src/pages/VolunteerWorkspacePage.tsx
+++ b/frontend/src/pages/VolunteerWorkspacePage.tsx
@@ -74,9 +74,13 @@ type ClueDraft = {
 };
 
 function messageFrom(cause: unknown) {
+  return cause instanceof Error ? cause.message : "操作未能完成，请稍后重试。";
+}
+
+function poiErrorMessage(cause: unknown) {
   if (cause instanceof ApiClientError && cause.status === 409)
     return "当前案件没有可用的任务或已确认公开地点坐标，无法检索周边资源。请使用任务区域文字并联系指挥确认。";
-  return cause instanceof Error ? cause.message : "操作未能完成，请稍后重试。";
+  return messageFrom(cause);
 }
 function localNow() {
   return new Date().toISOString();
@@ -828,7 +832,9 @@ export function VolunteerWorkspacePage() {
                                   token,
                                   workspace.detail.id,
                                   category,
-                                );
+                                ).catch((cause) => {
+                                  throw new Error(poiErrorMessage(cause));
+                                });
                                 setPois((value) => ({
                                   ...value,
                                   [workspace.detail.id]: result,

--- a/frontend/src/pages/VolunteerWorkspacePage.tsx
+++ b/frontend/src/pages/VolunteerWorkspacePage.tsx
@@ -44,6 +44,7 @@ import {
   LoadingState,
 } from "../components/ContentState";
 import { LocationConfirmationPicker } from "../components/LocationConfirmationPicker";
+import { ApiClientError } from "../api/client";
 
 const statusLabels: Record<TaskStatus, string> = {
   pending_claim: "待申请",
@@ -73,6 +74,8 @@ type ClueDraft = {
 };
 
 function messageFrom(cause: unknown) {
+  if (cause instanceof ApiClientError && cause.status === 409)
+    return "当前案件没有可用的任务或已确认公开地点坐标，无法检索周边资源。请使用任务区域文字并联系指挥确认。";
   return cause instanceof Error ? cause.message : "操作未能完成，请稍后重试。";
 }
 function localNow() {

--- a/migration/sql/mysql/down/0042_drop_ai_executions.sql
+++ b/migration/sql/mysql/down/0042_drop_ai_executions.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS ai_execution_events;
+-- statement-break
+DROP TABLE IF EXISTS ai_executions;

--- a/migration/sql/mysql/up/0042_create_ai_executions.sql
+++ b/migration/sql/mysql/up/0042_create_ai_executions.sql
@@ -27,5 +27,3 @@ CREATE TABLE ai_execution_events (
     CONSTRAINT fk_ai_execution_events_execution FOREIGN KEY (execution_id) REFERENCES ai_executions(id) ON UPDATE CASCADE ON DELETE CASCADE,
     UNIQUE KEY uq_ai_execution_events_sequence (execution_id, event_id)
 );
--- statement-break
-CREATE INDEX idx_ai_execution_events_execution ON ai_execution_events(execution_id, event_id);

--- a/migration/sql/mysql/up/0042_create_ai_executions.sql
+++ b/migration/sql/mysql/up/0042_create_ai_executions.sql
@@ -1,0 +1,31 @@
+CREATE TABLE ai_executions (
+    id VARCHAR(36) PRIMARY KEY,
+    owner_user_id VARCHAR(36) NOT NULL,
+    intake_session_id VARCHAR(36) NULL,
+    workflow VARCHAR(80) NOT NULL,
+    stage VARCHAR(40) NOT NULL,
+    status VARCHAR(30) NOT NULL,
+    failure_kind VARCHAR(80) NULL,
+    result_status VARCHAR(80) NULL,
+    fallback_used BOOLEAN NOT NULL DEFAULT FALSE,
+    last_event_id BIGINT NOT NULL DEFAULT 0,
+    created_at VARCHAR(40) NOT NULL,
+    updated_at VARCHAR(40) NOT NULL,
+    CONSTRAINT fk_ai_executions_owner FOREIGN KEY (owner_user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_ai_executions_session FOREIGN KEY (intake_session_id) REFERENCES intake_sessions(id) ON UPDATE CASCADE ON DELETE SET NULL
+);
+-- statement-break
+CREATE INDEX idx_ai_executions_owner ON ai_executions(owner_user_id, updated_at);
+-- statement-break
+CREATE TABLE ai_execution_events (
+    id VARCHAR(36) PRIMARY KEY,
+    execution_id VARCHAR(36) NOT NULL,
+    event_id BIGINT NOT NULL,
+    event_type VARCHAR(80) NOT NULL,
+    stage VARCHAR(40) NULL,
+    created_at VARCHAR(40) NOT NULL,
+    CONSTRAINT fk_ai_execution_events_execution FOREIGN KEY (execution_id) REFERENCES ai_executions(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    UNIQUE KEY uq_ai_execution_events_sequence (execution_id, event_id)
+);
+-- statement-break
+CREATE INDEX idx_ai_execution_events_execution ON ai_execution_events(execution_id, event_id);

--- a/migration/sql/postgres/down/0042_drop_ai_executions.sql
+++ b/migration/sql/postgres/down/0042_drop_ai_executions.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS ai_execution_events;
+-- statement-break
+DROP TABLE IF EXISTS ai_executions;

--- a/migration/sql/postgres/up/0042_create_ai_executions.sql
+++ b/migration/sql/postgres/up/0042_create_ai_executions.sql
@@ -24,5 +24,3 @@ CREATE TABLE ai_execution_events (
     created_at VARCHAR(40) NOT NULL,
     UNIQUE (execution_id, event_id)
 );
--- statement-break
-CREATE INDEX idx_ai_execution_events_execution ON ai_execution_events(execution_id, event_id);

--- a/migration/sql/postgres/up/0042_create_ai_executions.sql
+++ b/migration/sql/postgres/up/0042_create_ai_executions.sql
@@ -1,0 +1,28 @@
+CREATE TABLE ai_executions (
+    id VARCHAR(36) PRIMARY KEY,
+    owner_user_id VARCHAR(36) NOT NULL REFERENCES users(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+    intake_session_id VARCHAR(36) REFERENCES intake_sessions(id) ON UPDATE CASCADE ON DELETE SET NULL,
+    workflow VARCHAR(80) NOT NULL,
+    stage VARCHAR(40) NOT NULL,
+    status VARCHAR(30) NOT NULL,
+    failure_kind VARCHAR(80),
+    result_status VARCHAR(80),
+    fallback_used BOOLEAN NOT NULL DEFAULT FALSE,
+    last_event_id BIGINT NOT NULL DEFAULT 0,
+    created_at VARCHAR(40) NOT NULL,
+    updated_at VARCHAR(40) NOT NULL
+);
+-- statement-break
+CREATE INDEX idx_ai_executions_owner ON ai_executions(owner_user_id, updated_at DESC);
+-- statement-break
+CREATE TABLE ai_execution_events (
+    id VARCHAR(36) PRIMARY KEY,
+    execution_id VARCHAR(36) NOT NULL REFERENCES ai_executions(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    event_id BIGINT NOT NULL,
+    event_type VARCHAR(80) NOT NULL,
+    stage VARCHAR(40),
+    created_at VARCHAR(40) NOT NULL,
+    UNIQUE (execution_id, event_id)
+);
+-- statement-break
+CREATE INDEX idx_ai_execution_events_execution ON ai_execution_events(execution_id, event_id);

--- a/migration/sql/sqlite/down/0042_drop_ai_executions.sql
+++ b/migration/sql/sqlite/down/0042_drop_ai_executions.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS ai_execution_events;
+-- statement-break
+DROP TABLE IF EXISTS ai_executions;

--- a/migration/sql/sqlite/up/0042_create_ai_executions.sql
+++ b/migration/sql/sqlite/up/0042_create_ai_executions.sql
@@ -27,5 +27,3 @@ CREATE TABLE ai_execution_events (
     FOREIGN KEY (execution_id) REFERENCES ai_executions(id) ON UPDATE CASCADE ON DELETE CASCADE,
     UNIQUE (execution_id, event_id)
 );
--- statement-break
-CREATE INDEX idx_ai_execution_events_execution ON ai_execution_events(execution_id, event_id);

--- a/migration/sql/sqlite/up/0042_create_ai_executions.sql
+++ b/migration/sql/sqlite/up/0042_create_ai_executions.sql
@@ -1,0 +1,31 @@
+CREATE TABLE ai_executions (
+    id TEXT PRIMARY KEY NOT NULL,
+    owner_user_id TEXT NOT NULL,
+    intake_session_id TEXT,
+    workflow TEXT NOT NULL,
+    stage TEXT NOT NULL,
+    status TEXT NOT NULL,
+    failure_kind TEXT,
+    result_status TEXT,
+    fallback_used INTEGER NOT NULL DEFAULT 0,
+    last_event_id INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (owner_user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+    FOREIGN KEY (intake_session_id) REFERENCES intake_sessions(id) ON UPDATE CASCADE ON DELETE SET NULL
+);
+-- statement-break
+CREATE INDEX idx_ai_executions_owner ON ai_executions(owner_user_id, updated_at DESC);
+-- statement-break
+CREATE TABLE ai_execution_events (
+    id TEXT PRIMARY KEY NOT NULL,
+    execution_id TEXT NOT NULL,
+    event_id INTEGER NOT NULL,
+    event_type TEXT NOT NULL,
+    stage TEXT,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (execution_id) REFERENCES ai_executions(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    UNIQUE (execution_id, event_id)
+);
+-- statement-break
+CREATE INDEX idx_ai_execution_events_execution ON ai_execution_events(execution_id, event_id);

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -41,6 +41,7 @@ mod m0038_create_learning_center;
 mod m0039_create_learning_content_review_events;
 mod m0040_enforce_learning_lifecycle_event_uniqueness;
 mod m0041_add_learning_content_version_lineage;
+mod m0042_create_ai_executions;
 
 use sea_orm_migration::sea_orm::{DbBackend, Statement};
 
@@ -91,6 +92,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0039_create_learning_content_review_events::Migration),
             Box::new(m0040_enforce_learning_lifecycle_event_uniqueness::Migration),
             Box::new(m0041_add_learning_content_version_lineage::Migration),
+            Box::new(m0042_create_ai_executions::Migration),
         ]
     }
 }

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -398,9 +398,9 @@ mod tests {
         let database = Database::connect("sqlite::memory:")
             .await
             .expect("in-memory sqlite connection should succeed");
-        Migrator::up(&database, None)
+        Migrator::up(&database, Some(41))
             .await
-            .expect("all migrations should succeed");
+            .expect("migrations through learning lineage should succeed");
         database
             .execute_unprepared(
                 "INSERT INTO learning_resources (id, title, summary, content, resource_type, tags_json, source_name, source_url, previous_version_id, version, visibility, status, effective_at, withdrawn_at, created_at, updated_at) VALUES ('lineage-v1', 'First version', 'First version summary', 'First version content', 'manual', '[]', 'Test source', NULL, NULL, 1, 'learner', 'published', '2026-08-01T00:00:00.000Z', NULL, '2026-08-01T00:00:00.000Z', '2026-08-01T00:00:00.000Z'), ('lineage-v2', 'Corrected version', 'Corrected version summary', 'Corrected version content', 'manual', '[]', 'Test source', NULL, 'lineage-v1', 2, 'learner', 'withdrawn', '2026-08-01T00:00:00.000Z', NULL, '2026-08-01T00:00:00.000Z', '2026-08-01T00:00:00.000Z')",

--- a/migration/src/m0042_create_ai_executions.rs
+++ b/migration/src/m0042_create_ai_executions.rs
@@ -1,0 +1,47 @@
+use crate::{ensure_rollback_is_safe, execute_script, sql_for_backend};
+use sea_orm_migration::prelude::*;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m0042_create_ai_executions"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        execute_script(
+            manager,
+            sql_for_backend(
+                manager,
+                include_str!("../sql/sqlite/up/0042_create_ai_executions.sql"),
+                include_str!("../sql/postgres/up/0042_create_ai_executions.sql"),
+                include_str!("../sql/mysql/up/0042_create_ai_executions.sql"),
+            ),
+        )
+        .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        ensure_rollback_is_safe(
+            manager,
+            &[(
+                "AI execution records exist",
+                "SELECT 1 FROM ai_executions LIMIT 1",
+            )],
+        )
+        .await?;
+        execute_script(
+            manager,
+            sql_for_backend(
+                manager,
+                include_str!("../sql/sqlite/down/0042_drop_ai_executions.sql"),
+                include_str!("../sql/postgres/down/0042_drop_ai_executions.sql"),
+                include_str!("../sql/mysql/down/0042_drop_ai_executions.sql"),
+            ),
+        )
+        .await
+    }
+}

--- a/src/api/routes/ai_executions.rs
+++ b/src/api/routes/ai_executions.rs
@@ -1,0 +1,62 @@
+use actix_web::{HttpResponse, http::header, web};
+use serde::Deserialize;
+
+use crate::{
+    app_state::AppState, error::ApiError, models::AuthenticatedUser, services::ai_execution_service,
+};
+
+#[derive(Debug, Deserialize)]
+struct EventQuery {
+    after: Option<i64>,
+}
+
+pub fn configure(config: &mut web::ServiceConfig) {
+    config.service(
+        web::scope("/ai/executions")
+            .route("/{execution_id}", web::get().to(get_execution))
+            .route(
+                "/{execution_id}/events",
+                web::get().to(list_execution_events),
+            ),
+    );
+}
+
+async fn get_execution(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    execution_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    Ok(HttpResponse::Ok()
+        .json(ai_execution_service::get_execution(&state.db, &auth, &execution_id).await?))
+}
+
+async fn list_execution_events(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    execution_id: web::Path<String>,
+    query: web::Query<EventQuery>,
+) -> Result<HttpResponse, ApiError> {
+    let events = ai_execution_service::list_events(
+        &state.db,
+        &auth,
+        &execution_id,
+        query.after.unwrap_or(0),
+    )
+    .await?;
+    let body = events
+        .into_iter()
+        .map(|event| {
+            let payload = serde_json::to_string(&event)
+                .unwrap_or_else(|_| "{\"message\":\"internal service error\"}".to_owned());
+            format!(
+                "id: {}\nevent: {}\ndata: {}\n\n",
+                event.event_id, event.event_type, payload
+            )
+        })
+        .collect::<String>();
+    Ok(HttpResponse::Ok()
+        .insert_header((header::CONTENT_TYPE, "text/event-stream"))
+        .insert_header((header::CACHE_CONTROL, "no-cache"))
+        .insert_header(("X-Accel-Buffering", "no"))
+        .body(body))
+}

--- a/src/api/routes/ai_executions.rs
+++ b/src/api/routes/ai_executions.rs
@@ -43,17 +43,14 @@ async fn list_execution_events(
         query.after.unwrap_or(0),
     )
     .await?;
-    let body = events
-        .into_iter()
-        .map(|event| {
-            let payload = serde_json::to_string(&event)
-                .unwrap_or_else(|_| "{\"message\":\"internal service error\"}".to_owned());
-            format!(
-                "id: {}\nevent: {}\ndata: {}\n\n",
-                event.event_id, event.event_type, payload
-            )
-        })
-        .collect::<String>();
+    let mut body = String::new();
+    for event in events {
+        let payload = serde_json::to_string(&event).map_err(|_| ApiError::Internal)?;
+        body.push_str(&format!(
+            "id: {}\nevent: {}\ndata: {}\n\n",
+            event.event_id, event.event_type, payload
+        ));
+    }
     Ok(HttpResponse::Ok()
         .insert_header((header::CONTENT_TYPE, "text/event-stream"))
         .insert_header((header::CACHE_CONTROL, "no-cache"))

--- a/src/api/routes/cases.rs
+++ b/src/api/routes/cases.rs
@@ -1,4 +1,9 @@
-use actix_web::{HttpResponse, http::header, web};
+use std::time::Duration;
+
+use actix_web::{Error, HttpResponse, http::header, web};
+use futures_util::stream;
+use serde_json::json;
+use tokio::sync::mpsc;
 
 use crate::{
     app_state::AppState,
@@ -427,16 +432,92 @@ async fn create_clue_drafts(
     case_id: web::Path<String>,
     request: web::Json<CreateClueDraftRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    Ok(HttpResponse::Created().json(
-        crate::services::case_collaboration_service::create_clue_drafts(
+    let case_id = case_id.into_inner();
+    case_service::require_case_role(
+        &state.db,
+        &auth.id,
+        &case_id,
+        &[CaseRole::Family, CaseRole::Commander, CaseRole::Volunteer],
+    )
+    .await?;
+    let (execution, started) =
+        crate::services::ai_execution_service::start_case_execution(&state.db, &auth, "clue_draft")
+            .await?;
+    let request = request.into_inner();
+    let execution_id = execution.execution_id.clone();
+    let (sender, receiver) = mpsc::channel(8);
+    let _ = sender.try_send(sse_event(
+        "started",
+        json!({ "execution_id": execution_id, "event_id": started.event_id, "workflow": execution.workflow, "stage": "queued" }),
+    ));
+    tokio::spawn(async move {
+        for stage in ["preparing", "generating"] {
+            if let Ok(event) = crate::services::ai_execution_service::advance_execution(
+                &state.db,
+                &auth,
+                &execution.execution_id,
+                stage,
+            )
+            .await
+            {
+                let _ = sender.send(sse_event("progress", json!(event))).await;
+            }
+        }
+        let event = match crate::services::case_collaboration_service::create_clue_drafts(
             &state.db,
             &auth,
             &case_id,
-            request.into_inner(),
+            request,
             &state.ai_gateway,
         )
-        .await?,
-    ))
+        .await
+        {
+            Ok(drafts) => {
+                let fallback_used = drafts
+                    .iter()
+                    .any(|draft| draft.degradation_status.contains("fallback"));
+                let stage = if fallback_used {
+                    "fallback"
+                } else {
+                    "validating"
+                };
+                if let Ok(event) = crate::services::ai_execution_service::advance_execution(
+                    &state.db,
+                    &auth,
+                    &execution.execution_id,
+                    stage,
+                )
+                .await
+                {
+                    let _ = sender.send(sse_event("progress", json!(event))).await;
+                }
+                let _ = crate::services::ai_execution_service::complete_execution(
+                    &state.db,
+                    &auth,
+                    &execution.execution_id,
+                    "draft_ready",
+                    fallback_used,
+                )
+                .await;
+                sse_event("completed", json!(drafts))
+            }
+            Err(_) => {
+                let _ = crate::services::ai_execution_service::fail_execution(
+                    &state.db,
+                    &auth,
+                    &execution.execution_id,
+                    "processing_failed",
+                )
+                .await;
+                sse_event(
+                    "error",
+                    json!({ "message": "AI 草稿未能完成，请重试或改用人工流程。" }),
+                )
+            }
+        };
+        let _ = sender.send(event).await;
+    });
+    Ok(sse_response(receiver))
 }
 
 async fn list_clue_drafts(
@@ -493,16 +574,122 @@ async fn create_summary_draft(
     case_id: web::Path<String>,
     request: web::Json<CreateSummaryDraftRequest>,
 ) -> Result<HttpResponse, ApiError> {
-    Ok(HttpResponse::Created().json(
-        crate::services::case_collaboration_service::create_summary_draft(
+    let case_id = case_id.into_inner();
+    let request = request.into_inner();
+    if request.content.is_some() {
+        return Ok(HttpResponse::Created().json(
+            crate::services::case_collaboration_service::create_summary_draft(
+                &state.db,
+                &auth,
+                &case_id,
+                request,
+                &state.ai_gateway,
+            )
+            .await?,
+        ));
+    }
+    case_service::require_case_role(&state.db, &auth.id, &case_id, &[CaseRole::Commander]).await?;
+    let (execution, started) = crate::services::ai_execution_service::start_case_execution(
+        &state.db,
+        &auth,
+        "summary_draft",
+    )
+    .await?;
+    let execution_id = execution.execution_id.clone();
+    let (sender, receiver) = mpsc::channel(8);
+    let _ = sender.try_send(sse_event(
+        "started",
+        json!({ "execution_id": execution_id, "event_id": started.event_id, "workflow": execution.workflow, "stage": "queued" }),
+    ));
+    tokio::spawn(async move {
+        for stage in ["preparing", "generating"] {
+            if let Ok(event) = crate::services::ai_execution_service::advance_execution(
+                &state.db,
+                &auth,
+                &execution.execution_id,
+                stage,
+            )
+            .await
+            {
+                let _ = sender.send(sse_event("progress", json!(event))).await;
+            }
+        }
+        let event = match crate::services::case_collaboration_service::create_summary_draft(
             &state.db,
             &auth,
             &case_id,
-            request.into_inner(),
+            request,
             &state.ai_gateway,
         )
-        .await?,
-    ))
+        .await
+        {
+            Ok(draft) => {
+                let fallback_used = draft.provider_model.is_none();
+                let stage = if fallback_used {
+                    "fallback"
+                } else {
+                    "validating"
+                };
+                if let Ok(event) = crate::services::ai_execution_service::advance_execution(
+                    &state.db,
+                    &auth,
+                    &execution.execution_id,
+                    stage,
+                )
+                .await
+                {
+                    let _ = sender.send(sse_event("progress", json!(event))).await;
+                }
+                let _ = crate::services::ai_execution_service::complete_execution(
+                    &state.db,
+                    &auth,
+                    &execution.execution_id,
+                    "draft_ready",
+                    fallback_used,
+                )
+                .await;
+                sse_event("completed", json!(draft))
+            }
+            Err(_) => {
+                let _ = crate::services::ai_execution_service::fail_execution(
+                    &state.db,
+                    &auth,
+                    &execution.execution_id,
+                    "processing_failed",
+                )
+                .await;
+                sse_event(
+                    "error",
+                    json!({ "message": "AI 摘要未能完成，请重试或改用人工流程。" }),
+                )
+            }
+        };
+        let _ = sender.send(event).await;
+    });
+    Ok(sse_response(receiver))
+}
+
+fn sse_response(receiver: mpsc::Receiver<web::Bytes>) -> HttpResponse {
+    let events = stream::unfold(
+        (receiver, tokio::time::interval(Duration::from_secs(10))),
+        |(mut receiver, mut heartbeat)| async move {
+            tokio::select! {
+                event = receiver.recv() => event.map(|event| (Ok::<_, Error>(event), (receiver, heartbeat))),
+                _ = heartbeat.tick() => Some((Ok(web::Bytes::from_static(b": keep-alive\n\n")), (receiver, heartbeat))),
+            }
+        },
+    );
+    HttpResponse::Created()
+        .insert_header((header::CONTENT_TYPE, "text/event-stream"))
+        .insert_header((header::CACHE_CONTROL, "no-cache"))
+        .insert_header(("X-Accel-Buffering", "no"))
+        .streaming(events)
+}
+
+fn sse_event(event: &str, payload: serde_json::Value) -> web::Bytes {
+    let payload = serde_json::to_string(&payload)
+        .unwrap_or_else(|_| "{\"message\":\"internal service error\"}".to_owned());
+    web::Bytes::from(format!("event: {event}\ndata: {payload}\n\n"))
 }
 
 async fn get_latest_summary_draft(

--- a/src/api/routes/intake_sessions.rs
+++ b/src/api/routes/intake_sessions.rs
@@ -113,17 +113,9 @@ async fn generate_intake_profile_draft(
             "execution_id": execution_id.clone(),
             "event_id": started.event_id,
             "workflow": execution.workflow,
-        }),
-    ));
-    let _ = sender.try_send(sse_event(
-        "progress",
-        json!({
-            "execution_id": execution_id.clone(),
-            "event_id": started.event_id,
             "stage": "queued",
         }),
     ));
-
     tokio::spawn(async move {
         if let Ok(event) =
             ai_execution_service::advance_execution(&state.db, &auth, &execution_id, "preparing")
@@ -168,13 +160,16 @@ async fn generate_intake_profile_draft(
                 sse_event("completed", json!(draft))
             }
             Err(_) => {
-                let _ = ai_execution_service::fail_execution(
+                if let Err(error) = ai_execution_service::fail_execution(
                     &state.db,
                     &auth,
                     &execution_id,
                     "processing_failed",
                 )
-                .await;
+                .await
+                {
+                    log::error!("failed to persist failed AI execution {execution_id}: {error}");
+                }
                 sse_event(
                     "error",
                     json!({ "message": "AI 审核未能完成，请重试或改用人工流程。" }),
@@ -322,17 +317,9 @@ async fn start_ai_initial_review(
             "execution_id": execution_id.clone(),
             "event_id": started.event_id,
             "workflow": execution.workflow,
-        }),
-    ));
-    let _ = sender.try_send(sse_event(
-        "progress",
-        json!({
-            "execution_id": execution_id.clone(),
-            "event_id": started.event_id,
             "stage": "queued",
         }),
     ));
-
     tokio::spawn(async move {
         if let Ok(event) =
             ai_execution_service::advance_execution(&state.db, &auth, &execution_id, "preparing")
@@ -378,13 +365,16 @@ async fn start_ai_initial_review(
                 sse_event("completed", json!(review))
             }
             Err(_) => {
-                let _ = ai_execution_service::fail_execution(
+                if let Err(error) = ai_execution_service::fail_execution(
                     &state.db,
                     &auth,
                     &execution_id,
                     "processing_failed",
                 )
-                .await;
+                .await
+                {
+                    log::error!("failed to persist failed AI execution {execution_id}: {error}");
+                }
                 sse_event(
                     "error",
                     json!({ "message": "AI 审核未能完成，请重试或改用人工流程。" }),

--- a/src/api/routes/intake_sessions.rs
+++ b/src/api/routes/intake_sessions.rs
@@ -14,6 +14,7 @@ use crate::{
         ReviewIntakeProfileDraftRequest, StartIntakeAiInitialReviewRequest,
         SubmitIntakeAnswerRequest,
     },
+    services::ai_execution_service,
     services::intake_session_service,
 };
 
@@ -96,20 +97,46 @@ async fn generate_intake_profile_draft(
     session_id: web::Path<String>,
 ) -> Result<HttpResponse, ApiError> {
     let session_id = session_id.into_inner();
+    let (execution, started) = ai_execution_service::start_intake_execution(
+        &state.db,
+        &auth,
+        &session_id,
+        "intake_profile_draft",
+    )
+    .await?;
+    let execution_id = execution.execution_id.clone();
     let (sender, receiver) = mpsc::channel(8);
     let _ = sender.try_send(sse_event(
         "started",
-        json!({ "session_id": session_id.clone() }),
+        json!({
+            "session_id": session_id.clone(),
+            "execution_id": execution_id.clone(),
+            "event_id": started.event_id,
+            "workflow": execution.workflow,
+        }),
     ));
-    let _ = sender.try_send(sse_event("progress", json!({ "stage": "queued" })));
+    let _ = sender.try_send(sse_event(
+        "progress",
+        json!({
+            "execution_id": execution_id.clone(),
+            "event_id": started.event_id,
+            "stage": "queued",
+        }),
+    ));
 
     tokio::spawn(async move {
-        let _ = sender
-            .send(sse_event("progress", json!({ "stage": "preparing" })))
-            .await;
-        let _ = sender
-            .send(sse_event("progress", json!({ "stage": "generating" })))
-            .await;
+        if let Ok(event) =
+            ai_execution_service::advance_execution(&state.db, &auth, &execution_id, "preparing")
+                .await
+        {
+            let _ = sender.send(sse_event("progress", json!(event))).await;
+        }
+        if let Ok(event) =
+            ai_execution_service::advance_execution(&state.db, &auth, &execution_id, "generating")
+                .await
+        {
+            let _ = sender.send(sse_event("progress", json!(event))).await;
+        }
         let event = match intake_session_service::generate_intake_profile_draft(
             &state.db,
             &auth,
@@ -124,12 +151,35 @@ async fn generate_intake_profile_draft(
                 } else {
                     "validating"
                 };
-                let _ = sender
-                    .send(sse_event("progress", json!({ "stage": stage })))
-                    .await;
+                if let Ok(event) =
+                    ai_execution_service::advance_execution(&state.db, &auth, &execution_id, stage)
+                        .await
+                {
+                    let _ = sender.send(sse_event("progress", json!(event))).await;
+                }
+                let _ = ai_execution_service::complete_execution(
+                    &state.db,
+                    &auth,
+                    &execution_id,
+                    "draft_ready",
+                    stage == "fallback",
+                )
+                .await;
                 sse_event("completed", json!(draft))
             }
-            Err(error) => sse_event("error", json!({ "message": error.to_string() })),
+            Err(_) => {
+                let _ = ai_execution_service::fail_execution(
+                    &state.db,
+                    &auth,
+                    &execution_id,
+                    "processing_failed",
+                )
+                .await;
+                sse_event(
+                    "error",
+                    json!({ "message": "AI 审核未能完成，请重试或改用人工流程。" }),
+                )
+            }
         };
         let _ = sender.send(event).await;
     });
@@ -256,20 +306,46 @@ async fn start_ai_initial_review(
 ) -> Result<HttpResponse, ApiError> {
     let session_id = session_id.into_inner();
     let request = request.into_inner();
+    let (execution, started) = ai_execution_service::start_intake_execution(
+        &state.db,
+        &auth,
+        &session_id,
+        "intake_initial_review",
+    )
+    .await?;
+    let execution_id = execution.execution_id.clone();
     let (sender, receiver) = mpsc::channel(8);
     let _ = sender.try_send(sse_event(
         "started",
-        json!({ "session_id": session_id.clone() }),
+        json!({
+            "session_id": session_id.clone(),
+            "execution_id": execution_id.clone(),
+            "event_id": started.event_id,
+            "workflow": execution.workflow,
+        }),
     ));
-    let _ = sender.try_send(sse_event("progress", json!({ "stage": "queued" })));
+    let _ = sender.try_send(sse_event(
+        "progress",
+        json!({
+            "execution_id": execution_id.clone(),
+            "event_id": started.event_id,
+            "stage": "queued",
+        }),
+    ));
 
     tokio::spawn(async move {
-        let _ = sender
-            .send(sse_event("progress", json!({ "stage": "preparing" })))
-            .await;
-        let _ = sender
-            .send(sse_event("progress", json!({ "stage": "generating" })))
-            .await;
+        if let Ok(event) =
+            ai_execution_service::advance_execution(&state.db, &auth, &execution_id, "preparing")
+                .await
+        {
+            let _ = sender.send(sse_event("progress", json!(event))).await;
+        }
+        if let Ok(event) =
+            ai_execution_service::advance_execution(&state.db, &auth, &execution_id, "generating")
+                .await
+        {
+            let _ = sender.send(sse_event("progress", json!(event))).await;
+        }
         let event = match intake_session_service::start_ai_initial_review(
             &state.db,
             &auth,
@@ -285,12 +361,35 @@ async fn start_ai_initial_review(
                 } else {
                     "validating"
                 };
-                let _ = sender
-                    .send(sse_event("progress", json!({ "stage": stage })))
-                    .await;
+                if let Ok(event) =
+                    ai_execution_service::advance_execution(&state.db, &auth, &execution_id, stage)
+                        .await
+                {
+                    let _ = sender.send(sse_event("progress", json!(event))).await;
+                }
+                let _ = ai_execution_service::complete_execution(
+                    &state.db,
+                    &auth,
+                    &execution_id,
+                    "review_ready",
+                    stage == "fallback",
+                )
+                .await;
                 sse_event("completed", json!(review))
             }
-            Err(error) => sse_event("error", json!({ "message": error.to_string() })),
+            Err(_) => {
+                let _ = ai_execution_service::fail_execution(
+                    &state.db,
+                    &auth,
+                    &execution_id,
+                    "processing_failed",
+                )
+                .await;
+                sse_event(
+                    "error",
+                    json!({ "message": "AI 审核未能完成，请重试或改用人工流程。" }),
+                )
+            }
         };
         let _ = sender.send(event).await;
     });

--- a/src/api/routes/mod.rs
+++ b/src/api/routes/mod.rs
@@ -1,4 +1,5 @@
 mod admin;
+mod ai_executions;
 mod auth;
 mod cases;
 mod clues;
@@ -46,6 +47,7 @@ pub fn configure(config: &mut web::ServiceConfig) {
             .wrap(ApiSessionAuthentication)
             .service(health::get_health)
             .configure(auth::configure)
+            .configure(ai_executions::configure)
             .configure(learning::configure)
             .configure(admin::configure)
             .configure(user_profiles::configure)

--- a/src/application/services/ai_execution_service.rs
+++ b/src/application/services/ai_execution_service.rs
@@ -1,0 +1,330 @@
+use chrono::{SecondsFormat, Utc};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, IntoActiveModel, QueryFilter,
+    QueryOrder, Set, TransactionTrait,
+};
+use serde::Serialize;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::{
+    entities::{ai_execution_events, ai_executions, intake_sessions},
+    error::ApiError,
+    models::AuthenticatedUser,
+    services::case_service,
+};
+
+#[derive(Clone, Debug, Serialize)]
+pub struct AiExecutionResponse {
+    pub execution_id: String,
+    pub workflow: String,
+    pub stage: String,
+    pub status: String,
+    pub failure_kind: Option<String>,
+    pub result_status: Option<String>,
+    pub fallback_used: bool,
+    pub last_event_id: i64,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct AiExecutionEventResponse {
+    pub execution_id: String,
+    pub event_id: i64,
+    pub event_type: String,
+    pub stage: Option<String>,
+    pub created_at: String,
+}
+
+pub async fn start_intake_execution(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    intake_session_id: &str,
+    workflow: &str,
+) -> Result<(AiExecutionResponse, AiExecutionEventResponse), ApiError> {
+    let transaction = db.begin().await?;
+    let session = intake_sessions::Entity::find_by_id(intake_session_id)
+        .one(&transaction)
+        .await?
+        .ok_or_else(|| ApiError::NotFound("intake session was not found".to_owned()))?;
+    if session.created_by_user_id != auth.id {
+        return Err(ApiError::NotFound(
+            "intake session was not found".to_owned(),
+        ));
+    }
+
+    let timestamp = now();
+    let execution_id = Uuid::new_v4().to_string();
+    let model = ai_executions::ActiveModel {
+        id: Set(execution_id.clone()),
+        owner_user_id: Set(auth.id.clone()),
+        intake_session_id: Set(Some(intake_session_id.to_owned())),
+        workflow: Set(workflow.to_owned()),
+        stage: Set("queued".to_owned()),
+        status: Set("running".to_owned()),
+        failure_kind: Set(None),
+        result_status: Set(None),
+        fallback_used: Set(false),
+        last_event_id: Set(1),
+        created_at: Set(timestamp.clone()),
+        updated_at: Set(timestamp.clone()),
+    }
+    .insert(&transaction)
+    .await?;
+    let event = insert_event(
+        &transaction,
+        &execution_id,
+        1,
+        "ai_review.started",
+        Some("queued"),
+        &timestamp,
+    )
+    .await?;
+    write_execution_audit(
+        &transaction,
+        auth,
+        "ai_execution.started",
+        &execution_id,
+        "queued",
+        "running",
+        None,
+        false,
+    )
+    .await?;
+    transaction.commit().await?;
+    Ok((response(model), event_response(event)))
+}
+
+pub async fn get_execution(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    execution_id: &str,
+) -> Result<AiExecutionResponse, ApiError> {
+    let model = owned_execution(db, auth, execution_id).await?;
+    Ok(response(model))
+}
+
+pub async fn list_events(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    execution_id: &str,
+    after: i64,
+) -> Result<Vec<AiExecutionEventResponse>, ApiError> {
+    owned_execution(db, auth, execution_id).await?;
+    let events = ai_execution_events::Entity::find()
+        .filter(ai_execution_events::Column::ExecutionId.eq(execution_id))
+        .filter(ai_execution_events::Column::EventId.gt(after.max(0)))
+        .order_by_asc(ai_execution_events::Column::EventId)
+        .all(db)
+        .await?;
+    Ok(events.into_iter().map(event_response).collect())
+}
+
+pub async fn advance_execution(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    execution_id: &str,
+    stage: &str,
+) -> Result<AiExecutionEventResponse, ApiError> {
+    update_execution(
+        db,
+        auth,
+        execution_id,
+        stage,
+        "running",
+        None,
+        None,
+        false,
+        "ai_review.stage",
+        "ai_execution.stage",
+    )
+    .await
+}
+
+pub async fn complete_execution(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    execution_id: &str,
+    result_status: &str,
+    fallback_used: bool,
+) -> Result<AiExecutionEventResponse, ApiError> {
+    update_execution(
+        db,
+        auth,
+        execution_id,
+        "ready_for_review",
+        "completed",
+        None,
+        Some(result_status),
+        fallback_used,
+        "ai_review.completed",
+        "ai_execution.completed",
+    )
+    .await
+}
+
+pub async fn fail_execution(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    execution_id: &str,
+    failure_kind: &str,
+) -> Result<AiExecutionEventResponse, ApiError> {
+    update_execution(
+        db,
+        auth,
+        execution_id,
+        "failed",
+        "failed",
+        Some(failure_kind),
+        None,
+        false,
+        "ai_review.failed",
+        "ai_execution.failed",
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn update_execution(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    execution_id: &str,
+    stage: &str,
+    status: &str,
+    failure_kind: Option<&str>,
+    result_status: Option<&str>,
+    fallback_used: bool,
+    event_type: &str,
+    audit_action: &str,
+) -> Result<AiExecutionEventResponse, ApiError> {
+    let transaction = db.begin().await?;
+    let existing = owned_execution(&transaction, auth, execution_id).await?;
+    if existing.status != "running" {
+        return Err(ApiError::Conflict(
+            "AI execution has already reached a terminal state".to_owned(),
+        ));
+    }
+    let timestamp = now();
+    let event_id = existing.last_event_id + 1;
+    let mut active = existing.into_active_model();
+    active.stage = Set(stage.to_owned());
+    active.status = Set(status.to_owned());
+    active.failure_kind = Set(failure_kind.map(str::to_owned));
+    active.result_status = Set(result_status.map(str::to_owned));
+    active.fallback_used = Set(fallback_used);
+    active.last_event_id = Set(event_id);
+    active.updated_at = Set(timestamp.clone());
+    active.update(&transaction).await?;
+    let event = insert_event(
+        &transaction,
+        execution_id,
+        event_id,
+        event_type,
+        Some(stage),
+        &timestamp,
+    )
+    .await?;
+    write_execution_audit(
+        &transaction,
+        auth,
+        audit_action,
+        execution_id,
+        stage,
+        status,
+        failure_kind,
+        fallback_used,
+    )
+    .await?;
+    transaction.commit().await?;
+    Ok(event_response(event))
+}
+
+async fn owned_execution<C: sea_orm::ConnectionTrait>(
+    db: &C,
+    auth: &AuthenticatedUser,
+    execution_id: &str,
+) -> Result<ai_executions::Model, ApiError> {
+    ai_executions::Entity::find_by_id(execution_id)
+        .filter(ai_executions::Column::OwnerUserId.eq(&auth.id))
+        .one(db)
+        .await?
+        .ok_or_else(|| ApiError::NotFound("AI execution was not found".to_owned()))
+}
+
+async fn insert_event<C: sea_orm::ConnectionTrait>(
+    db: &C,
+    execution_id: &str,
+    event_id: i64,
+    event_type: &str,
+    stage: Option<&str>,
+    created_at: &str,
+) -> Result<ai_execution_events::Model, ApiError> {
+    Ok(ai_execution_events::ActiveModel {
+        id: Set(Uuid::new_v4().to_string()),
+        execution_id: Set(execution_id.to_owned()),
+        event_id: Set(event_id),
+        event_type: Set(event_type.to_owned()),
+        stage: Set(stage.map(str::to_owned)),
+        created_at: Set(created_at.to_owned()),
+    }
+    .insert(db)
+    .await?)
+}
+
+async fn write_execution_audit<C: sea_orm::ConnectionTrait>(
+    db: &C,
+    auth: &AuthenticatedUser,
+    action: &str,
+    execution_id: &str,
+    stage: &str,
+    result_status: &str,
+    failure_kind: Option<&str>,
+    fallback_used: bool,
+) -> Result<(), ApiError> {
+    case_service::write_audit(
+        db,
+        None,
+        auth,
+        action,
+        "ai_execution",
+        execution_id.to_owned(),
+        Some(json!({
+            "execution_id": execution_id,
+            "stage": stage,
+            "result_status": result_status,
+            "failure_kind": failure_kind,
+            "fallback_used": fallback_used,
+        })),
+    )
+    .await
+}
+
+fn response(model: ai_executions::Model) -> AiExecutionResponse {
+    AiExecutionResponse {
+        execution_id: model.id,
+        workflow: model.workflow,
+        stage: model.stage,
+        status: model.status,
+        failure_kind: model.failure_kind,
+        result_status: model.result_status,
+        fallback_used: model.fallback_used,
+        last_event_id: model.last_event_id,
+        created_at: model.created_at,
+        updated_at: model.updated_at,
+    }
+}
+
+fn event_response(model: ai_execution_events::Model) -> AiExecutionEventResponse {
+    AiExecutionEventResponse {
+        execution_id: model.execution_id,
+        event_id: model.event_id,
+        event_type: model.event_type,
+        stage: model.stage,
+        created_at: model.created_at,
+    }
+}
+
+fn now() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}

--- a/src/application/services/ai_execution_service.rs
+++ b/src/application/services/ai_execution_service.rs
@@ -37,6 +37,14 @@ pub struct AiExecutionEventResponse {
     pub created_at: String,
 }
 
+struct ExecutionTransition<'a> {
+    stage: &'a str,
+    status: &'a str,
+    failure_kind: Option<&'a str>,
+    result_status: Option<&'a str>,
+    fallback_used: bool,
+}
+
 pub async fn start_intake_execution(
     db: &DatabaseConnection,
     auth: &AuthenticatedUser,
@@ -86,10 +94,76 @@ pub async fn start_intake_execution(
         auth,
         "ai_execution.started",
         &execution_id,
-        "queued",
-        "running",
-        None,
-        false,
+        &ExecutionTransition {
+            stage: "queued",
+            status: "running",
+            failure_kind: None,
+            result_status: None,
+            fallback_used: false,
+        },
+    )
+    .await?;
+    transaction.commit().await?;
+    Ok((response(model), event_response(event)))
+}
+
+/// Starts a case-scoped controlled execution. Case-role authorization remains
+/// workflow-specific in the caller; this function deliberately records no
+/// case content, source material, prompt, or candidate data.
+pub async fn start_case_execution(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    workflow: &str,
+) -> Result<(AiExecutionResponse, AiExecutionEventResponse), ApiError> {
+    start_execution(db, auth, None, workflow).await
+}
+
+async fn start_execution(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    intake_session_id: Option<&str>,
+    workflow: &str,
+) -> Result<(AiExecutionResponse, AiExecutionEventResponse), ApiError> {
+    let transaction = db.begin().await?;
+    let timestamp = now();
+    let execution_id = Uuid::new_v4().to_string();
+    let model = ai_executions::ActiveModel {
+        id: Set(execution_id.clone()),
+        owner_user_id: Set(auth.id.clone()),
+        intake_session_id: Set(intake_session_id.map(str::to_owned)),
+        workflow: Set(workflow.to_owned()),
+        stage: Set("queued".to_owned()),
+        status: Set("running".to_owned()),
+        failure_kind: Set(None),
+        result_status: Set(None),
+        fallback_used: Set(false),
+        last_event_id: Set(1),
+        created_at: Set(timestamp.clone()),
+        updated_at: Set(timestamp.clone()),
+    }
+    .insert(&transaction)
+    .await?;
+    let event = insert_event(
+        &transaction,
+        &execution_id,
+        1,
+        "ai_review.started",
+        Some("queued"),
+        &timestamp,
+    )
+    .await?;
+    write_execution_audit(
+        &transaction,
+        auth,
+        "ai_execution.started",
+        &execution_id,
+        &ExecutionTransition {
+            stage: "queued",
+            status: "running",
+            failure_kind: None,
+            result_status: None,
+            fallback_used: false,
+        },
     )
     .await?;
     transaction.commit().await?;
@@ -131,11 +205,13 @@ pub async fn advance_execution(
         db,
         auth,
         execution_id,
-        stage,
-        "running",
-        None,
-        None,
-        false,
+        &ExecutionTransition {
+            stage,
+            status: "running",
+            failure_kind: None,
+            result_status: None,
+            fallback_used: false,
+        },
         "ai_review.stage",
         "ai_execution.stage",
     )
@@ -153,11 +229,13 @@ pub async fn complete_execution(
         db,
         auth,
         execution_id,
-        "ready_for_review",
-        "completed",
-        None,
-        Some(result_status),
-        fallback_used,
+        &ExecutionTransition {
+            stage: "ready_for_review",
+            status: "completed",
+            failure_kind: None,
+            result_status: Some(result_status),
+            fallback_used,
+        },
         "ai_review.completed",
         "ai_execution.completed",
     )
@@ -174,27 +252,24 @@ pub async fn fail_execution(
         db,
         auth,
         execution_id,
-        "failed",
-        "failed",
-        Some(failure_kind),
-        None,
-        false,
+        &ExecutionTransition {
+            stage: "failed",
+            status: "failed",
+            failure_kind: Some(failure_kind),
+            result_status: None,
+            fallback_used: false,
+        },
         "ai_review.failed",
         "ai_execution.failed",
     )
     .await
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn update_execution(
     db: &DatabaseConnection,
     auth: &AuthenticatedUser,
     execution_id: &str,
-    stage: &str,
-    status: &str,
-    failure_kind: Option<&str>,
-    result_status: Option<&str>,
-    fallback_used: bool,
+    transition: &ExecutionTransition<'_>,
     event_type: &str,
     audit_action: &str,
 ) -> Result<AiExecutionEventResponse, ApiError> {
@@ -208,11 +283,11 @@ async fn update_execution(
     let timestamp = now();
     let event_id = existing.last_event_id + 1;
     let mut active = existing.into_active_model();
-    active.stage = Set(stage.to_owned());
-    active.status = Set(status.to_owned());
-    active.failure_kind = Set(failure_kind.map(str::to_owned));
-    active.result_status = Set(result_status.map(str::to_owned));
-    active.fallback_used = Set(fallback_used);
+    active.stage = Set(transition.stage.to_owned());
+    active.status = Set(transition.status.to_owned());
+    active.failure_kind = Set(transition.failure_kind.map(str::to_owned));
+    active.result_status = Set(transition.result_status.map(str::to_owned));
+    active.fallback_used = Set(transition.fallback_used);
     active.last_event_id = Set(event_id);
     active.updated_at = Set(timestamp.clone());
     active.update(&transaction).await?;
@@ -221,21 +296,11 @@ async fn update_execution(
         execution_id,
         event_id,
         event_type,
-        Some(stage),
+        Some(transition.stage),
         &timestamp,
     )
     .await?;
-    write_execution_audit(
-        &transaction,
-        auth,
-        audit_action,
-        execution_id,
-        stage,
-        status,
-        failure_kind,
-        fallback_used,
-    )
-    .await?;
+    write_execution_audit(&transaction, auth, audit_action, execution_id, transition).await?;
     transaction.commit().await?;
     Ok(event_response(event))
 }
@@ -277,10 +342,7 @@ async fn write_execution_audit<C: sea_orm::ConnectionTrait>(
     auth: &AuthenticatedUser,
     action: &str,
     execution_id: &str,
-    stage: &str,
-    result_status: &str,
-    failure_kind: Option<&str>,
-    fallback_used: bool,
+    transition: &ExecutionTransition<'_>,
 ) -> Result<(), ApiError> {
     case_service::write_audit(
         db,
@@ -291,10 +353,11 @@ async fn write_execution_audit<C: sea_orm::ConnectionTrait>(
         execution_id.to_owned(),
         Some(json!({
             "execution_id": execution_id,
-            "stage": stage,
-            "result_status": result_status,
-            "failure_kind": failure_kind,
-            "fallback_used": fallback_used,
+            "stage": transition.stage,
+            "status": transition.status,
+            "result_status": transition.result_status,
+            "failure_kind": transition.failure_kind,
+            "fallback_used": transition.fallback_used,
         })),
     )
     .await

--- a/src/application/services/mod.rs
+++ b/src/application/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin_service;
+pub mod ai_execution_service;
 pub mod auth_service;
 pub mod case_collaboration_service;
 pub mod case_resource_service;

--- a/src/persistence/entities/ai_execution_events.rs
+++ b/src/persistence/entities/ai_execution_events.rs
@@ -1,0 +1,28 @@
+use sea_orm::entity::prelude::*;
+use serde::Serialize;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize)]
+#[sea_orm(table_name = "ai_execution_events")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub execution_id: String,
+    pub event_id: i64,
+    pub event_type: String,
+    pub stage: Option<String>,
+    pub created_at: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::ai_executions::Entity",
+        from = "Column::ExecutionId",
+        to = "super::ai_executions::Column::Id",
+        on_update = "Cascade",
+        on_delete = "Cascade"
+    )]
+    Execution,
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/persistence/entities/ai_executions.rs
+++ b/src/persistence/entities/ai_executions.rs
@@ -1,0 +1,42 @@
+use sea_orm::entity::prelude::*;
+use serde::Serialize;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Serialize)]
+#[sea_orm(table_name = "ai_executions")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub owner_user_id: String,
+    pub intake_session_id: Option<String>,
+    pub workflow: String,
+    pub stage: String,
+    pub status: String,
+    pub failure_kind: Option<String>,
+    pub result_status: Option<String>,
+    pub fallback_used: bool,
+    pub last_event_id: i64,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::users::Entity",
+        from = "Column::OwnerUserId",
+        to = "super::users::Column::Id",
+        on_update = "Cascade",
+        on_delete = "Restrict"
+    )]
+    Owner,
+    #[sea_orm(
+        belongs_to = "super::intake_sessions::Entity",
+        from = "Column::IntakeSessionId",
+        to = "super::intake_sessions::Column::Id",
+        on_update = "Cascade",
+        on_delete = "SetNull"
+    )]
+    IntakeSession,
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/persistence/entities/mod.rs
+++ b/src/persistence/entities/mod.rs
@@ -1,3 +1,5 @@
+pub mod ai_execution_events;
+pub mod ai_executions;
 pub mod ai_prompt_templates;
 pub mod archive_drafts;
 pub mod archive_review_materials;

--- a/tests/api/case_collaboration_get_post.rs
+++ b/tests/api/case_collaboration_get_post.rs
@@ -5,7 +5,10 @@ use actix_web::{
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use serde_json::{Value, json};
 
-use crate::support::{ADMIN, COMMANDER, FAMILY, LEARNER, TestContext, VOLUNTEER, assert_error};
+use crate::support::{
+    ADMIN, COMMANDER, FAMILY, LEARNER, TestContext, VOLUNTEER, assert_error,
+    read_sse_completed_json,
+};
 use angui::entities::{clue_drafts, summary_drafts};
 
 #[actix_web::test]
@@ -144,7 +147,7 @@ async fn case_collaboration_endpoints_apply_roles_lifecycle_and_degraded_fallbac
     )
     .await;
     assert_eq!(clue_drafts.status(), StatusCode::CREATED);
-    let clue_drafts: Value = test::read_body_json(clue_drafts).await;
+    let clue_drafts = read_sse_completed_json(clue_drafts).await;
     assert_eq!(clue_drafts[0]["status"], "draft");
     assert_eq!(clue_drafts[0]["raw_record_reference"], "fictional-call-1");
     assert_eq!(clue_drafts[0]["degradation_status"], "rule_based_fallback");
@@ -251,7 +254,7 @@ async fn case_collaboration_endpoints_apply_roles_lifecycle_and_degraded_fallbac
     )
     .await;
     assert_eq!(draft.status(), StatusCode::CREATED);
-    let draft: Value = test::read_body_json(draft).await;
+    let draft = read_sse_completed_json(draft).await;
     assert_eq!(draft["status"], "pending_review");
     assert_eq!(draft["publication_eligible"], true);
     assert!(draft["provider_model"].is_null());
@@ -301,7 +304,7 @@ async fn case_collaboration_endpoints_apply_roles_lifecycle_and_degraded_fallbac
     )
     .await;
     assert_eq!(second_draft.status(), StatusCode::CREATED);
-    let second_draft: Value = test::read_body_json(second_draft).await;
+    let second_draft = read_sse_completed_json(second_draft).await;
     let second_draft_id = second_draft["id"].as_str().expect("second draft id");
     let superseding_publish = test::call_service(
         &app,

--- a/tests/api/case_collaboration_get_post.rs
+++ b/tests/api/case_collaboration_get_post.rs
@@ -215,6 +215,18 @@ async fn case_collaboration_endpoints_apply_roles_lifecycle_and_degraded_fallbac
     assert_eq!(pois["source"], "fixed_demo_fallback");
     assert_eq!(pois["degradation_status"], "degraded");
     assert!(pois["items"][0]["longitude"].is_null());
+    let transit = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/cases/{case_id}/pois?category=transit"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(transit.status(), StatusCode::OK);
+    let transit: Value = test::read_body_json(transit).await;
+    assert_eq!(transit["items"][0]["category"], "transit");
+    assert_eq!(transit["degradation_status"], "degraded");
     assert_error(
         test::call_service(
             &app,

--- a/tests/api/intake_session_confirm_post.rs
+++ b/tests/api/intake_session_confirm_post.rs
@@ -314,6 +314,63 @@ async fn initial_review_stream_exposes_safe_progress_before_the_completed_review
     assert_eq!(events.last(), Some(&"completed"));
     assert!(!stream.contains("system_instruction"));
     assert!(!stream.contains("raw_prompt"));
+
+    let execution_id = stream
+        .split("\n\n")
+        .find(|frame| frame.contains("event: started"))
+        .and_then(|frame| frame.lines().find_map(|line| line.strip_prefix("data: ")))
+        .and_then(|payload| serde_json::from_str::<Value>(payload).ok())
+        .and_then(|payload| payload["execution_id"].as_str().map(str::to_owned))
+        .expect("started event should expose a stable execution id");
+
+    let execution = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/ai/executions/{execution_id}"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(execution.status(), StatusCode::OK);
+    let execution: Value = test::read_body_json(execution).await;
+    assert_eq!(execution["status"], "completed");
+    assert_eq!(execution["stage"], "ready_for_review");
+    assert_eq!(execution["result_status"], "review_ready");
+    assert!(execution["last_event_id"].as_i64().unwrap_or_default() >= 5);
+
+    let execution_events = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/ai/executions/{execution_id}/events?after=0"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(execution_events.status(), StatusCode::OK);
+    let event_body = test::read_body(execution_events).await;
+    let event_stream = std::str::from_utf8(&event_body).expect("event stream is UTF-8");
+    assert!(event_stream.contains("event: ai_review.started"));
+    assert!(event_stream.contains("event: ai_review.completed"));
+    assert!(!event_stream.contains("Fictional confirmed elder"));
+
+    let audit_metadata: Vec<String> = audit_events::Entity::find()
+        .filter(audit_events::Column::EntityId.eq(&execution_id))
+        .all(&context.database)
+        .await
+        .expect("execution audits should be readable")
+        .into_iter()
+        .filter_map(|event| event.metadata_json)
+        .collect();
+    assert!(
+        audit_metadata
+            .iter()
+            .any(|metadata| metadata.contains(&execution_id))
+    );
+    assert!(
+        audit_metadata
+            .iter()
+            .all(|metadata| !metadata.contains("Fictional confirmed elder"))
+    );
 }
 
 #[actix_web::test]

--- a/tests/api/intake_session_confirm_post.rs
+++ b/tests/api/intake_session_confirm_post.rs
@@ -353,6 +353,36 @@ async fn initial_review_stream_exposes_safe_progress_before_the_completed_review
     assert!(event_stream.contains("event: ai_review.completed"));
     assert!(!event_stream.contains("Fictional confirmed elder"));
 
+    let after_last_event = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!(
+                "/api/ai/executions/{execution_id}/events?after={}",
+                execution["last_event_id"].as_i64().unwrap_or_default()
+            ))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(after_last_event.status(), StatusCode::OK);
+    assert!(test::read_body(after_last_event).await.is_empty());
+
+    let other_token = context.token(COMMANDER).await;
+    for uri in [
+        format!("/api/ai/executions/{execution_id}"),
+        format!("/api/ai/executions/{execution_id}/events?after=0"),
+    ] {
+        let response = test::call_service(
+            &app,
+            test::TestRequest::get()
+                .uri(&uri)
+                .insert_header((header::AUTHORIZATION, format!("Bearer {other_token}")))
+                .to_request(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
     let audit_metadata: Vec<String> = audit_events::Entity::find()
         .filter(audit_events::Column::EntityId.eq(&execution_id))
         .all(&context.database)


### PR DESCRIPTION
## Summary

- Adds durable, owner-scoped AI execution state and ordered safe lifecycle events for Intake, clue-draft, and generated summary-draft workflows.
- Restores safe progress after refresh or a disconnected stream: the UI polls execution status and only re-reads the existing draft/review resource after completion.
- Preserves the human review state machine; no prompt, chain-of-thought, raw provider stream, or unvalidated candidate text is persisted in execution events.
- Clarifies nearby-resource `409` handling and adds the transit fallback regression coverage.

## Verification

- `cargo fmt --all`
- `cargo test --test api_contract`
- frontend TypeScript build
- frontend Vitest
- frontend lint
- frontend Vite production build

Fixes #185
Fixes #186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 AI 执行状态查询与生命周期事件增量回放。
  * AI 审核、画像及草稿生成支持实时进度，并可在页面刷新后自动恢复。
  * SSE 事件包含稳定的执行编号和递增事件编号，支持有序、去重处理。
  * 新增失败、超时、网络重试及降级状态提示。

* **文档**
  * 更新 API 文档与 OpenAPI 规范，补充执行查询、事件流及数据保护说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->