### PR TITLE
fix(intake): skip AI follow-up for required phase-one fields

### DIFF
--- a/frontend/src/pages/FamilyIntakeForm.test.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.test.tsx
@@ -389,6 +389,7 @@ describe("FamilyIntakeForm", () => {
         },
       ),
     );
+    expect(mocked.getIntakeAiFollowUp).not.toHaveBeenCalled();
   });
 
   it("uploads only a controlled JPEG or PNG portrait", async () => {
@@ -462,11 +463,121 @@ describe("FamilyIntakeForm", () => {
         expect.objectContaining({ field: "last_seen" }),
       ),
     );
+    expect(mocked.getIntakeAiFollowUp).not.toHaveBeenCalled();
     await waitFor(() => {
       const stored = window.sessionStorage.getItem("angui:intake-tab-draft:family-1");
       expect(stored).not.toBeNull();
       expect(JSON.parse(stored ?? "{}").session.question_set_version).toBe(3);
     });
+  });
+
+  it.each([
+    [
+      "police-report status",
+      {
+        ...reportDetailsSession,
+        completed_phase_one_fields: [
+          "basic_information",
+          "last_seen",
+          "suspicious_motive",
+        ],
+        missing_fields: ["police_report_status", "family_phone"],
+        missing_phase_one_fields: ["police_report_status", "family_phone"],
+        next_question: {
+          field: "police_report_status",
+          prompt: "是否报警",
+          required: true,
+        },
+      },
+      "已报警",
+    ],
+    [
+      "family phone",
+      {
+        ...reportDetailsSession,
+        completed_phase_one_fields: [
+          "basic_information",
+          "last_seen",
+          "suspicious_motive",
+          "police_report_status",
+        ],
+        missing_fields: ["family_phone"],
+        missing_phase_one_fields: ["family_phone"],
+        next_question: {
+          field: "family_phone",
+          prompt: "家属电话",
+          required: true,
+        },
+      },
+      "13800138000",
+    ],
+  ])("does not request AI follow-up for required %s", async (label, session, answer) => {
+    window.sessionStorage.setItem(
+      "angui:intake-tab-draft:family-1",
+      JSON.stringify({ session, answer: "" }),
+    );
+    mocked.submitIntakeAnswer.mockResolvedValue(answerResponse(session));
+
+    render(
+      <FamilyIntakeForm
+        onCancel={vi.fn()}
+        onConfirmed={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    if (label === "police-report status") {
+      fireEvent.change(await screen.findByRole("combobox"), {
+        target: { value: answer },
+      });
+    } else {
+      fireEvent.change(await screen.findByRole("textbox"), {
+        target: { value: answer },
+      });
+    }
+    fireEvent.click(screen.getByRole("button", { name: "保存并继续" }));
+
+    await waitFor(() =>
+      expect(mocked.submitIntakeAnswer).toHaveBeenCalledWith(
+        "family-session",
+        "intake-1",
+        expect.objectContaining({ field: session.next_question?.field }),
+      ),
+    );
+    expect(mocked.getIntakeAiFollowUp).not.toHaveBeenCalled();
+  });
+
+  it("keeps AI follow-up for an optional phase-two clue", async () => {
+    window.sessionStorage.setItem(
+      "angui:intake-tab-draft:family-1",
+      JSON.stringify({ session: phaseTwoSession, answer: "" }),
+    );
+    mocked.submitIntakeAnswer.mockResolvedValue(answerResponse(phaseTwoSession));
+
+    render(
+      <FamilyIntakeForm
+        onCancel={vi.fn()}
+        onConfirmed={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    fireEvent.change(await screen.findByRole("textbox"), {
+      target: { value: "社区公园" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "保存并继续" }));
+
+    await waitFor(() =>
+      expect(mocked.submitIntakeAnswer).toHaveBeenCalledWith(
+        "family-session",
+        "intake-1",
+        expect.objectContaining({ field: "frequent_locations" }),
+      ),
+    );
+    await waitFor(() =>
+      expect(mocked.getIntakeAiFollowUp).toHaveBeenCalledWith(
+        "family-session",
+        "intake-1",
+      ),
+    );
   });
 
   it("keeps v2 sessions free of the v3 photo requirement", async () => {

--- a/frontend/src/pages/FamilyIntakeForm.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.tsx
@@ -160,6 +160,25 @@ const blankBasicInformation: BasicInformationDraft = {
   appearance: "",
 };
 
+function isPhaseOneIntakeField(field: string, questionSetVersion: number) {
+  const phaseOneFields =
+    questionSetVersion >= 3
+      ? [
+          "basic_information",
+          "last_seen",
+          "suspicious_motive",
+          "police_report_status",
+          "family_phone",
+        ]
+      : [
+          "basic_information",
+          "health_status",
+          "behavior_habits",
+          "last_seen",
+        ];
+  return phaseOneFields.includes(field);
+}
+
 export function FamilyIntakeForm({
   onCancel,
   onConfirmed,
@@ -513,27 +532,30 @@ export function FamilyIntakeForm({
         replace,
       });
       const next = sessionFromAnswerResponse(response);
-      setIsFetchingAiFollowUp(true);
-      let guidance: IntakeAiFollowUpResponse;
-      try {
-        guidance = await getIntakeAiFollowUp(token, next.id);
-      } finally {
-        setIsFetchingAiFollowUp(false);
+      let guidedSession = next;
+      if (!isPhaseOneIntakeField(field, session.question_set_version)) {
+        setIsFetchingAiFollowUp(true);
+        let guidance: IntakeAiFollowUpResponse;
+        try {
+          guidance = await getIntakeAiFollowUp(token, next.id);
+        } finally {
+          setIsFetchingAiFollowUp(false);
+        }
+        guidedSession = guidance.question
+          ? {
+              ...next,
+              next_question: {
+                field: guidance.question.field,
+                prompt: guidance.question.prompt,
+                required: false,
+              },
+              guidance_mode:
+                guidance.degradation_status === "available"
+                  ? ("ai_assisted" as const)
+                  : ("rule_based" as const),
+            }
+          : next;
       }
-      const guidedSession = guidance.question
-        ? {
-            ...next,
-            next_question: {
-              field: guidance.question.field,
-              prompt: guidance.question.prompt,
-              required: false,
-            },
-            guidance_mode:
-              guidance.degradation_status === "available"
-                ? ("ai_assisted" as const)
-                : ("rule_based" as const),
-          }
-        : next;
       setSession(guidedSession);
       setInitialReview(null);
       setConfirmedInitialReviewIssues([]);


### PR DESCRIPTION
- classify phase-one fields by intake question set version
- bypass AI guidance requests after required intake answers
- retain AI follow-up for optional phase-two clues
- add coverage for police report, family phone, and clue flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能优化**
  * 优化家属信息采集流程：提交第一阶段必填信息后，将直接进入会话状态，不再触发额外的 AI 追问。
  * 对第二阶段的可选线索（如常去地点）继续提供 AI 追问，引导补充相关信息。

* **测试**
  * 新增测试，覆盖不同问询版本、报警状态、家属电话及可选线索的提交场景。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->