### PR TITLE
feat: govern learning categories and tags

### DIFF
--- a/docs/learning-content-governance.md
+++ b/docs/learning-content-governance.md
@@ -1,5 +1,17 @@
 # 学习内容治理操作说明
 
+## 分类与标签治理（#193）
+
+- `learning_categories` 是分类的唯一治理来源：学习者只能通过 `POST /api/learning/categories/proposals` 提交 `pending` 申请；管理员以带理由的 `enable`、`reject`、`disable` 操作处理。分类名称会压缩内部空白并以大小写无关的规范键去重。
+- 学习资源保留原有 `tags_json`，以便既有数据和三数据库部署平滑兼容；服务端对标签压缩空白、按规范键去重，并限制为最多 12 个。资源列表支持 `category_id` 与 `tag` 的 AND 组合筛选。
+- `learning_resources.category_id` 和 `category_name` 均可为空。旧资源无需回填，仍可读、可搜索；新资源只能选择 `enabled` 分类。分类被停用后不会回写或隐藏历史资源，响应使用资源写入时的分类名称快照，保证版本和审计可追溯。
+- 学习者只能从学习中心调用 `POST /api/learning/resources/drafts`，且服务端强制 `visibility=learner` 与 `permitted_use=training`。该端点只写入 `submitted` 事件，之后仍必须由不同管理员完成去标识、审核和发布；它不会提供任何绕过内容治理的发布能力。
+- 分类的申请与状态变更写入专用 `learning_category_review_events`，并写入不含资源正文、案例内容或个人信息的总审计事件。分类审计只记录分类 ID、动作、操作者、时间和受限理由。
+
+### 迁移与回滚
+
+迁移 `m0044_add_learning_category_governance` 为 SQLite、PostgreSQL、MySQL 同步创建分类和分类审计表，并为资源追加两个可空列与索引。向上迁移不改写历史资源。若分类表已写入数据，或任一资源已经关联分类，向下迁移会被 Rust 的安全检查拒绝；应先按数据保留策略导出/归档并显式清理，而不是在生产库中强制回滚。
+
 学习中心不会从案件原始资料、聊天记录、完整身份信息、联系方式、病史或精确轨迹自动生成可读内容。学习资源和题目必须由管理员通过受控接口录入，并依次完成脱敏、独立审核和发布。
 
 ## 状态与职责

--- a/docs/learning-content-governance.md
+++ b/docs/learning-content-governance.md
@@ -2,7 +2,7 @@
 
 ## 分类与标签治理（#193）
 
-- `learning_categories` 是分类的唯一治理来源：学习者只能通过 `POST /api/learning/categories/proposals` 提交 `pending` 申请；管理员以带理由的 `enable`、`reject`、`disable` 操作处理。分类名称会压缩内部空白并以大小写无关的规范键去重。
+- `learning_categories` 是分类的唯一治理来源：学习者只能通过 `POST /api/learning/categories/proposals` 提交 `pending` 申请；管理员以带理由的 `enable`、`reject`、`disable` 操作处理。分类名称会压缩内部空白并以大小写无关的规范键去重；被驳回或停用的同名分类可以由学习者附带新理由重新提交，原记录回到 `pending`，历史审核事件保留。
 - 学习资源保留原有 `tags_json`，以便既有数据和三数据库部署平滑兼容；服务端对标签压缩空白、按规范键去重，并限制为最多 12 个。资源列表支持 `category_id` 与 `tag` 的 AND 组合筛选。
 - `learning_resources.category_id` 和 `category_name` 均可为空。旧资源无需回填，仍可读、可搜索；新资源只能选择 `enabled` 分类。分类被停用后不会回写或隐藏历史资源，响应使用资源写入时的分类名称快照，保证版本和审计可追溯。
 - 学习者只能从学习中心调用 `POST /api/learning/resources/drafts`，且服务端强制 `visibility=learner` 与 `permitted_use=training`。该端点只写入 `submitted` 事件，之后仍必须由不同管理员完成去标识、审核和发布；它不会提供任何绕过内容治理的发布能力。

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1928,6 +1928,7 @@ paths:
       tags: [Learning]
       operationId: proposeLearningCategory
       summary: Submit a normalized category proposal for administrator review
+      description: A rejected or disabled same-name category is resubmitted to pending with a new learner reason while preserving its review history. Pending and enabled same-name categories return 409.
       security: [{ bearerAuth: [] }]
       x-account-types: [learner]
       requestBody: { required: true, content: { application/json: { schema: { $ref: "#/components/schemas/CreateLearningCategoryRequest" } } } }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1905,9 +1905,53 @@ paths:
       security: [{ bearerAuth: [] }]
       x-account-types: [member, learner]
       x-data-classification: public-or-training
+      parameters:
+        - { name: category_id, in: query, required: false, schema: { type: string }, description: Filter by one assigned category; unclassified historical resources remain available without this filter. }
+        - { name: tag, in: query, required: false, schema: { type: string }, description: Normalized tag filter, combined with category_id using AND semantics. }
       responses:
         "200": { description: Reviewed learning resources }
         "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/learning/categories:
+    get:
+      tags: [Learning]
+      operationId: listEnabledLearningCategories
+      summary: List categories selectable for new learning-resource drafts
+      security: [{ bearerAuth: [] }]
+      x-account-types: [member, learner]
+      responses:
+        "200": { description: Enabled categories only, content: { application/json: { schema: { type: array, items: { $ref: "#/components/schemas/LearningCategory" } } } } }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+
+  /api/learning/categories/proposals:
+    post:
+      tags: [Learning]
+      operationId: proposeLearningCategory
+      summary: Submit a normalized category proposal for administrator review
+      security: [{ bearerAuth: [] }]
+      x-account-types: [learner]
+      requestBody: { required: true, content: { application/json: { schema: { $ref: "#/components/schemas/CreateLearningCategoryRequest" } } } }
+      responses:
+        "201": { description: Pending category proposal, content: { application/json: { schema: { $ref: "#/components/schemas/LearningCategory" } } } }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "409": { $ref: "#/components/responses/Conflict" }
+
+  /api/learning/resources/drafts:
+    post:
+      tags: [Learning]
+      operationId: submitLearnerLearningResourceDraft
+      summary: Submit a learner-only training draft for the existing independent governance chain
+      description: Learner submissions are fixed to learner visibility and training use. They are never published by this endpoint.
+      security: [{ bearerAuth: [] }]
+      x-account-types: [learner]
+      requestBody: { required: true, content: { application/json: { schema: { $ref: "#/components/schemas/CreateLearningResourceRequest" } } } }
+      responses:
+        "201": { description: Submitted draft, content: { application/json: { schema: { $ref: "#/components/schemas/ManagedLearningResource" } } } }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
 
   /api/learning/questions:
     get:
@@ -1965,6 +2009,69 @@ paths:
         content: { application/json: { schema: { $ref: "#/components/schemas/CreateLearningResourceRequest" } } }
       responses:
         "201": { description: Submitted resource version, content: { application/json: { schema: { $ref: "#/components/schemas/ManagedLearningResource" } } } }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { $ref: "#/components/responses/Conflict" }
+
+  /api/admin/learning/categories:
+    get:
+      tags: [Learning governance]
+      operationId: listManagedLearningCategories
+      summary: List category proposals and lifecycle state
+      security: [{ bearerAuth: [] }]
+      x-global-capabilities: [admin]
+      responses:
+        "200": { description: All categories, content: { application/json: { schema: { type: array, items: { $ref: "#/components/schemas/ManagedLearningCategory" } } } } }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+
+  /api/admin/learning/categories/{category_id}/enable:
+    post:
+      tags: [Learning governance]
+      operationId: enableLearningCategory
+      summary: Enable a pending learning category
+      security: [{ bearerAuth: [] }]
+      x-global-capabilities: [admin]
+      parameters: [{ name: category_id, in: path, required: true, schema: { type: string } }]
+      requestBody: { required: true, content: { application/json: { schema: { $ref: "#/components/schemas/LearningContentActionRequest" } } } }
+      responses:
+        "200": { description: Enabled category, content: { application/json: { schema: { $ref: "#/components/schemas/LearningCategory" } } } }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { $ref: "#/components/responses/Conflict" }
+
+  /api/admin/learning/categories/{category_id}/reject:
+    post:
+      tags: [Learning governance]
+      operationId: rejectLearningCategory
+      summary: Reject a pending learning category
+      security: [{ bearerAuth: [] }]
+      x-global-capabilities: [admin]
+      parameters: [{ name: category_id, in: path, required: true, schema: { type: string } }]
+      requestBody: { required: true, content: { application/json: { schema: { $ref: "#/components/schemas/LearningContentActionRequest" } } } }
+      responses:
+        "200": { description: Rejected category, content: { application/json: { schema: { $ref: "#/components/schemas/LearningCategory" } } } }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { $ref: "#/components/responses/Conflict" }
+
+  /api/admin/learning/categories/{category_id}/disable:
+    post:
+      tags: [Learning governance]
+      operationId: disableLearningCategory
+      summary: Disable an enabled learning category
+      security: [{ bearerAuth: [] }]
+      x-global-capabilities: [admin]
+      parameters: [{ name: category_id, in: path, required: true, schema: { type: string } }]
+      requestBody: { required: true, content: { application/json: { schema: { $ref: "#/components/schemas/LearningContentActionRequest" } } } }
+      responses:
+        "200": { description: Disabled category, content: { application/json: { schema: { $ref: "#/components/schemas/LearningCategory" } } } }
         "400": { $ref: "#/components/responses/ValidationError" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
@@ -2343,7 +2450,7 @@ components:
     LearningResource:
       type: object
       additionalProperties: false
-      required: [id, title, summary, content, resource_type, tags, source_name, source_url, previous_version_id, version, effective_at]
+      required: [id, title, summary, content, resource_type, tags, category, source_name, source_url, previous_version_id, version, effective_at]
       properties:
         id: { type: string }
         title: { type: string }
@@ -2351,11 +2458,32 @@ components:
         content: { type: string }
         resource_type: { type: string, enum: [team_intro, manual, prevention, case_study] }
         tags: { type: array, items: { type: string } }
+        category: { anyOf: [{ $ref: "#/components/schemas/LearningCategory" }, { type: "null" }], description: Assigned category snapshot. Null keeps historical resources compatible. }
         source_name: { type: string }
         source_url: { type: [string, "null"], format: uri }
         previous_version_id: { type: [string, "null"], description: Immutable direct predecessor. Null denotes a first version. }
         version: { type: integer, minimum: 1 }
         effective_at: { type: string, format: date-time }
+
+    LearningCategory:
+      type: object
+      additionalProperties: false
+      required: [id, name, status]
+      properties:
+        id: { type: string }
+        name: { type: string, maxLength: 160 }
+        status: { type: string, enum: [pending, enabled, rejected, disabled, assigned] }
+
+    ManagedLearningCategory:
+      allOf:
+        - $ref: "#/components/schemas/LearningCategory"
+        - type: object
+          required: [submitted_by_user_id, reviewed_by_user_id, created_at, updated_at]
+          properties:
+            submitted_by_user_id: { type: string }
+            reviewed_by_user_id: { type: [string, "null"] }
+            created_at: { type: string, format: date-time }
+            updated_at: { type: string, format: date-time }
 
     LearningQuestionOption:
       type: object
@@ -2430,12 +2558,21 @@ components:
         content: { type: string, minLength: 1, maxLength: 20000 }
         resource_type: { type: string, enum: [team_intro, manual, prevention, case_study] }
         tags: { type: array, items: { type: string } }
+        category_id: { type: [string, "null"], description: Optional enabled category. Null retains compatibility for historical and uncategorized resources. }
         source_name: { type: string, minLength: 1, maxLength: 240 }
         source_url: { type: [string, "null"], format: uri }
         previous_version_id: { type: [string, "null"], description: Set only to correct one currently published, governance-approved resource version. }
         visibility: { type: string, enum: [public, authenticated, volunteer, learner] }
         effective_at: { type: string, format: date-time }
         permitted_use: { type: string, enum: [training, public_information] }
+        submission_reason: { type: string, minLength: 1, maxLength: 1000 }
+
+    CreateLearningCategoryRequest:
+      type: object
+      additionalProperties: false
+      required: [name, submission_reason]
+      properties:
+        name: { type: string, minLength: 1, maxLength: 160 }
         submission_reason: { type: string, minLength: 1, maxLength: 1000 }
 
     CreateLearningQuestionRequest:

--- a/frontend/e2e/learning-governance.spec.ts
+++ b/frontend/e2e/learning-governance.spec.ts
@@ -129,8 +129,44 @@ test("learner category governance carries a draft through publication and filter
   await expect(publishedCard).toContainText(categoryName);
   await expect(publishedCard).toContainText("#e2e-tag");
 
+  const categoryFilterResponse = page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return (
+      response.request().method() === "GET" &&
+      url.pathname === "/api/learning/resources" &&
+      url.searchParams.get("category_id") === categoryId &&
+      !url.searchParams.has("tag")
+    );
+  });
   await page.getByLabel("分类筛选").selectOption(categoryId);
+  const categoryResources = (await (await categoryFilterResponse).json()) as Array<{
+    id: string;
+    category: { id: string } | null;
+  }>;
+  expect(categoryResources).toEqual([
+    expect.objectContaining({
+      id: draft.id,
+      category: expect.objectContaining({ id: categoryId }),
+    }),
+  ]);
   await expect(publishedCard).toBeVisible();
+
+  const tagFilterResponse = page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return (
+      response.request().method() === "GET" &&
+      url.pathname === "/api/learning/resources" &&
+      url.searchParams.get("category_id") === categoryId &&
+      url.searchParams.get("tag") === "e2e-tag"
+    );
+  });
   await page.getByLabel("标签筛选").selectOption("e2e-tag");
+  const tagResources = (await (await tagFilterResponse).json()) as Array<{
+    id: string;
+    tags: string[];
+  }>;
+  expect(tagResources).toEqual([
+    expect.objectContaining({ id: draft.id, tags: ["e2e-tag", "onboarding"] }),
+  ]);
   await expect(publishedCard).toBeVisible();
 });

--- a/frontend/e2e/learning-governance.spec.ts
+++ b/frontend/e2e/learning-governance.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 import {
   accounts,
+  apiGet,
   apiPost,
   createPublishedLearningResource,
   tokenFor,
@@ -38,4 +39,98 @@ test("published learning content is visible to learners and withdrawal revokes i
   );
   await page.reload();
   await expect(page.getByText(resource.title)).toHaveCount(0);
+});
+
+test("learner category governance carries a draft through publication and filtering", async ({
+  page,
+  request,
+}, testInfo) => {
+  const suffix = uniqueTestSuffix(testInfo);
+  const categoryName = `E2E category ${suffix}`;
+  const resourceTitle = `E2E categorized learning ${suffix}`;
+  const learnerToken = await tokenFor(request, accounts.learner);
+  const adminToken = await tokenFor(request, accounts.admin);
+
+  const proposal = await apiPost(
+    request,
+    learnerToken,
+    "/api/learning/categories/proposals",
+    {
+      name: categoryName,
+      submission_reason: "E2E verifies learner category governance.",
+    },
+  );
+  expect(proposal.status).toBe("pending");
+  const categoryId = proposal.id as string;
+
+  const enabled = await apiPost(
+    request,
+    adminToken,
+    `/api/admin/learning/categories/${categoryId}/enable`,
+    { reason: "E2E category is suitable for the learning center." },
+  );
+  expect(enabled.status).toBe("enabled");
+
+  await useAccount(page, learnerToken, "/learning");
+  const draftSection = page
+    .locator("section")
+    .filter({ has: page.getByRole("heading", { name: "提交学习资源草稿" }) });
+  await expect(draftSection).toBeVisible();
+  await page.getByLabel("草稿标题").fill(resourceTitle);
+  await page.getByLabel("草稿来源名称").fill("E2E learning group");
+  await page.getByLabel("草稿标签").fill("e2e-tag, onboarding");
+  await page.getByLabel("摘要").fill("A categorized E2E learning summary.");
+  await page.getByLabel("正文").fill("A categorized E2E learning body.");
+  await page.getByLabel("提交理由").fill("E2E verifies the learner draft workflow.");
+  await draftSection.locator("select").selectOption(categoryId);
+  await page.getByRole("button", { name: "提交草稿" }).click();
+  await expect(page.getByRole("status")).toContainText("草稿已提交");
+
+  const managedResources = await apiGet(
+    request,
+    adminToken,
+    "/api/admin/learning/resources",
+  );
+  const draft = managedResources.find(
+    (resource: { title: string }) => resource.title === resourceTitle,
+  ) as {
+    id: string;
+    category: { id: string } | null;
+    lifecycle: { state: string };
+  };
+  expect(draft).toBeTruthy();
+  expect(draft.category?.id).toBe(categoryId);
+  expect(draft.lifecycle.state).toBe("submitted");
+
+  const commanderToken = await tokenFor(request, accounts.commander);
+  const volunteerToken = await tokenFor(request, accounts.volunteer);
+  await apiPost(
+    request,
+    commanderToken,
+    `/api/admin/learning/resources/${draft.id}/deidentify`,
+    { reason: "E2E independent de-identification." },
+  );
+  await apiPost(
+    request,
+    volunteerToken,
+    `/api/admin/learning/resources/${draft.id}/review`,
+    { reason: "E2E independent content review." },
+  );
+  await apiPost(
+    request,
+    adminToken,
+    `/api/admin/learning/resources/${draft.id}/publish`,
+    { reason: "E2E publication approval." },
+  );
+
+  await page.reload();
+  const publishedCard = page.locator("article").filter({ hasText: resourceTitle });
+  await expect(publishedCard).toHaveCount(1);
+  await expect(publishedCard).toContainText(categoryName);
+  await expect(publishedCard).toContainText("#e2e-tag");
+
+  await page.getByLabel("分类筛选").selectOption(categoryId);
+  await expect(publishedCard).toBeVisible();
+  await page.getByLabel("标签筛选").selectOption("e2e-tag");
+  await expect(publishedCard).toBeVisible();
 });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -13,8 +13,10 @@ const mocked = vi.hoisted(() => ({
   listLearningResources: vi.fn().mockResolvedValue([]),
   getPublicPreventionCard: vi.fn().mockResolvedValue(null),
   listLearningQuestions: vi.fn().mockResolvedValue([]),
+  listLearningCategories: vi.fn().mockResolvedValue([]),
   listManagedLearningResources: vi.fn().mockResolvedValue([]),
   listManagedLearningQuestions: vi.fn().mockResolvedValue([]),
+  listManagedLearningCategories: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("./auth/useAuth", () => ({ useAuth: () => mocked.auth }));
@@ -40,10 +42,14 @@ vi.mock("./api/learning", () => ({
     mocked.getPublicPreventionCard(...args),
   listLearningQuestions: (...args: unknown[]) =>
     mocked.listLearningQuestions(...args),
+  listLearningCategories: (...args: unknown[]) =>
+    mocked.listLearningCategories(...args),
   listManagedLearningResources: (...args: unknown[]) =>
     mocked.listManagedLearningResources(...args),
   listManagedLearningQuestions: (...args: unknown[]) =>
     mocked.listManagedLearningQuestions(...args),
+  listManagedLearningCategories: (...args: unknown[]) =>
+    mocked.listManagedLearningCategories(...args),
   askKnowledge: vi.fn(),
   submitLearningAnswer: vi.fn(),
 }));

--- a/frontend/src/api/learning.ts
+++ b/frontend/src/api/learning.ts
@@ -7,11 +7,23 @@ export interface LearningResource {
   content: string;
   resource_type: "team_intro" | "manual" | "prevention" | "case_study";
   tags: string[];
+  category?: LearningCategory | null;
   source_name: string;
   source_url: string | null;
   previous_version_id?: string | null;
   version: number;
   effective_at: string;
+}
+export interface LearningCategory {
+  id: string;
+  name: string;
+  status: "pending" | "enabled" | "rejected" | "disabled" | "assigned";
+}
+export interface ManagedLearningCategory extends LearningCategory {
+  submitted_by_user_id: string;
+  reviewed_by_user_id: string | null;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface LearningQuestionOption {
@@ -81,6 +93,7 @@ export interface CreateLearningResourceInput {
   content: string;
   resource_type: LearningResource["resource_type"];
   tags: string[];
+  category_id?: string | null;
   source_name: string;
   source_url: string | null;
   visibility: "public" | "authenticated" | "volunteer" | "learner";
@@ -105,8 +118,35 @@ export interface CreateLearningQuestionInput {
   previous_version_id?: string | null;
 }
 
-export const listLearningResources = (token: string) =>
-  apiRequest<LearningResource[]>("/learning/resources", {}, token);
+export const listLearningResources = (
+  token: string,
+  filters: { category_id?: string; tag?: string } = {},
+) => {
+  const query = new URLSearchParams(
+    Object.entries(filters).filter(([, value]) => Boolean(value)) as [string, string][],
+  );
+  const suffix = query.size ? `?${query}` : "";
+  return apiRequest<LearningResource[]>(`/learning/resources${suffix}`, {}, token);
+};
+export const listLearningCategories = (token: string) =>
+  apiRequest<LearningCategory[]>("/learning/categories", {}, token);
+export const submitLearningCategoryProposal = (
+  token: string,
+  name: string,
+  submission_reason: string,
+) => apiRequest<LearningCategory>(
+  "/learning/categories/proposals",
+  { method: "POST", body: JSON.stringify({ name, submission_reason }) },
+  token,
+);
+export const submitLearningResourceDraft = (
+  token: string,
+  input: CreateLearningResourceInput,
+) => apiRequest<ManagedLearningResource>(
+  "/learning/resources/drafts",
+  { method: "POST", body: JSON.stringify(input) },
+  token,
+);
 export const getPublicPreventionCard = () =>
   apiRequest<LearningResource>("/learning/public/prevention-card");
 export const listLearningQuestions = (token: string) =>
@@ -132,6 +172,18 @@ export const askKnowledge = (token: string, question: string) =>
   );
 export const listManagedLearningResources = (token: string) =>
   apiRequest<ManagedLearningResource[]>("/admin/learning/resources", {}, token);
+export const listManagedLearningCategories = (token: string) =>
+  apiRequest<ManagedLearningCategory[]>("/admin/learning/categories", {}, token);
+export const transitionManagedLearningCategory = (
+  token: string,
+  categoryId: string,
+  action: "enable" | "reject" | "disable",
+  reason: string,
+) => apiRequest<LearningCategory>(
+  `/admin/learning/categories/${categoryId}/${action}`,
+  { method: "POST", body: JSON.stringify({ reason }) },
+  token,
+);
 export const listManagedLearningQuestions = (token: string) =>
   apiRequest<ManagedLearningQuestion[]>("/admin/learning/questions", {}, token);
 export const createManagedLearningResource = (

--- a/frontend/src/pages/LearningCenterPage.test.tsx
+++ b/frontend/src/pages/LearningCenterPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiClientError } from "../api/client";
 import { LearningCenterPage } from "./LearningCenterPage";
@@ -7,12 +7,20 @@ const mocked = vi.hoisted(() => ({
   getPublicPreventionCard: vi.fn(),
   askKnowledge: vi.fn(),
   listLearningQuestions: vi.fn(),
+  listLearningCategories: vi.fn(),
   listLearningResources: vi.fn(),
+  submitLearningCategoryProposal: vi.fn(),
+  submitLearningResourceDraft: vi.fn(),
   token: "learner-session" as string | null,
 }));
 
 vi.mock("../auth/useAuth", () => ({
-  useAuth: () => ({ token: mocked.token }),
+  useAuth: () => ({
+    token: mocked.token,
+    user: mocked.token
+      ? { account_type: "learner", id: "learner-1" }
+      : undefined,
+  }),
 }));
 
 vi.mock("../api/learning", () => ({
@@ -22,6 +30,12 @@ vi.mock("../api/learning", () => ({
     mocked.listLearningQuestions(...args),
   listLearningResources: (...args: unknown[]) =>
     mocked.listLearningResources(...args),
+  listLearningCategories: (...args: unknown[]) =>
+    mocked.listLearningCategories(...args),
+  submitLearningCategoryProposal: (...args: unknown[]) =>
+    mocked.submitLearningCategoryProposal(...args),
+  submitLearningResourceDraft: (...args: unknown[]) =>
+    mocked.submitLearningResourceDraft(...args),
   askKnowledge: (...args: unknown[]) => mocked.askKnowledge(...args),
   submitLearningAnswer: vi.fn(),
 }));
@@ -31,6 +45,13 @@ describe("LearningCenterPage", () => {
     mocked.token = "learner-session";
     mocked.listLearningResources.mockResolvedValue([]);
     mocked.listLearningQuestions.mockResolvedValue([]);
+    mocked.listLearningCategories.mockResolvedValue([]);
+    mocked.submitLearningCategoryProposal.mockResolvedValue({
+      id: "category-new",
+      name: "新分类",
+      status: "pending",
+    });
+    mocked.submitLearningResourceDraft.mockResolvedValue({});
   });
 
   it("renders only the approved public prevention card supplied by the API", async () => {
@@ -168,5 +189,129 @@ describe("LearningCenterPage", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByText("已发布手册")).toBeInTheDocument();
+  });
+
+  it("renders category and tag chips and sends server-side filter changes", async () => {
+    mocked.getPublicPreventionCard.mockRejectedValue(
+      new ApiClientError(404, "not_found", "没有卡片"),
+    );
+    mocked.listLearningCategories.mockResolvedValue([
+      { id: "cat-safety", name: "安全基础", status: "enabled" },
+    ]);
+    mocked.listLearningResources.mockResolvedValue([
+      {
+        id: "resource-safety",
+        title: "安全手册",
+        summary: "摘要",
+        content: "正文",
+        resource_type: "manual",
+        tags: ["基础"],
+        category: { id: "cat-safety", name: "安全基础", status: "assigned" },
+        source_name: "来源",
+        source_url: null,
+        version: 1,
+        effective_at: "2026-08-05T00:00:00.000Z",
+      },
+    ]);
+
+    render(<LearningCenterPage />);
+    expect(await screen.findByText("安全手册")).toBeInTheDocument();
+    expect(screen.getAllByText("安全基础").length).toBeGreaterThan(0);
+    expect(screen.getByText("#基础")).toBeInTheDocument();
+
+    mocked.listLearningResources.mockClear();
+    fireEvent.change(screen.getByLabelText("分类筛选"), {
+      target: { value: "cat-safety" },
+    });
+    await waitFor(() =>
+      expect(mocked.listLearningResources).toHaveBeenLastCalledWith(
+        "learner-session",
+        { category_id: "cat-safety", tag: "" },
+      ),
+    );
+
+    mocked.listLearningResources.mockClear();
+    fireEvent.change(screen.getByLabelText("标签筛选"), {
+      target: { value: "基础" },
+    });
+    await waitFor(() =>
+      expect(mocked.listLearningResources).toHaveBeenLastCalledWith(
+        "learner-session",
+        { category_id: "cat-safety", tag: "基础" },
+      ),
+    );
+  });
+
+  it("submits learner drafts with normalized tags and fixed learner training scope", async () => {
+    mocked.getPublicPreventionCard.mockRejectedValue(
+      new ApiClientError(404, "not_found", "没有卡片"),
+    );
+    mocked.listLearningCategories.mockResolvedValue([
+      { id: "cat-safety", name: "安全基础", status: "enabled" },
+    ]);
+    render(<LearningCenterPage />);
+
+    await screen.findByRole("heading", { name: "提交学习资源草稿" });
+    fireEvent.change(screen.getByLabelText("草稿标题"), {
+      target: { value: "新人安全提示" },
+    });
+    fireEvent.change(screen.getByLabelText("草稿来源名称"), {
+      target: { value: "学习小组" },
+    });
+    fireEvent.change(screen.getByLabelText("草稿标签"), {
+      target: { value: "基础, 安全，基础" },
+    });
+    fireEvent.change(screen.getByLabelText("摘要"), {
+      target: { value: "摘要" },
+    });
+    fireEvent.change(screen.getByLabelText("正文"), {
+      target: { value: "正文" },
+    });
+    fireEvent.change(screen.getByLabelText("提交理由"), {
+      target: { value: "供新人学习" },
+    });
+    const draftSection = screen
+      .getByRole("heading", { name: "提交学习资源草稿" })
+      .closest("section");
+    expect(draftSection).not.toBeNull();
+    fireEvent.change(draftSection!.querySelector("select")!, {
+      target: { value: "cat-safety" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "提交草稿" }));
+
+    await waitFor(() => expect(mocked.submitLearningResourceDraft).toHaveBeenCalled());
+    const [, input] = mocked.submitLearningResourceDraft.mock.calls.at(-1)!;
+    expect(input).toMatchObject({
+      title: "新人安全提示",
+      category_id: "cat-safety",
+      tags: ["基础", "安全", "基础"],
+      visibility: "learner",
+      permitted_use: "training",
+    });
+  });
+
+  it("submits a learner category proposal with a reason", async () => {
+    mocked.getPublicPreventionCard.mockRejectedValue(
+      new ApiClientError(404, "not_found", "没有卡片"),
+    );
+    render(<LearningCenterPage />);
+
+    await screen.findByRole("heading", { name: "提交学习资源草稿" });
+    fireEvent.change(screen.getByLabelText("申请分类名称"), {
+      target: { value: "现场沟通" },
+    });
+    fireEvent.change(screen.getByLabelText("申请分类理由"), {
+      target: { value: "便于新人按场景学习" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "申请分类" }));
+
+    await waitFor(() =>
+      expect(mocked.submitLearningCategoryProposal).toHaveBeenCalledWith(
+        "learner-session",
+        "现场沟通",
+        "便于新人按场景学习",
+      ),
+    );
+    expect(screen.getByRole("status")).toHaveTextContent("分类申请已提交");
   });
 });

--- a/frontend/src/pages/LearningCenterPage.test.tsx
+++ b/frontend/src/pages/LearningCenterPage.test.tsx
@@ -290,6 +290,39 @@ describe("LearningCenterPage", () => {
     });
   });
 
+  it("shows a retryable error and re-enables the learner draft submission after failure", async () => {
+    mocked.getPublicPreventionCard.mockRejectedValue(
+      new ApiClientError(404, "not_found", "没有卡片"),
+    );
+    mocked.submitLearningResourceDraft.mockRejectedValue(
+      new ApiClientError(503, "request_failed", "草稿服务暂时不可用"),
+    );
+    render(<LearningCenterPage />);
+
+    await screen.findByRole("heading", { name: "提交学习资源草稿" });
+    fireEvent.change(screen.getByLabelText("草稿标题"), {
+      target: { value: "失败草稿" },
+    });
+    fireEvent.change(screen.getByLabelText("草稿来源名称"), {
+      target: { value: "学习小组" },
+    });
+    fireEvent.change(screen.getByLabelText("摘要"), {
+      target: { value: "摘要" },
+    });
+    fireEvent.change(screen.getByLabelText("正文"), {
+      target: { value: "正文" },
+    });
+    fireEvent.change(screen.getByLabelText("提交理由"), {
+      target: { value: "覆盖失败后的重试路径" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "提交草稿" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent("草稿服务暂时不可用"),
+    );
+    expect(screen.getByRole("button", { name: "提交草稿" })).toBeEnabled();
+  });
+
   it("submits a learner category proposal with a reason", async () => {
     mocked.getPublicPreventionCard.mockRejectedValue(
       new ApiClientError(404, "not_found", "没有卡片"),
@@ -313,5 +346,30 @@ describe("LearningCenterPage", () => {
       ),
     );
     expect(screen.getByRole("status")).toHaveTextContent("分类申请已提交");
+  });
+
+  it("shows a visible error when a learner category proposal fails", async () => {
+    mocked.getPublicPreventionCard.mockRejectedValue(
+      new ApiClientError(404, "not_found", "没有卡片"),
+    );
+    mocked.submitLearningCategoryProposal.mockRejectedValue(
+      new ApiClientError(503, "request_failed", "分类申请服务暂时不可用"),
+    );
+    render(<LearningCenterPage />);
+
+    await screen.findByRole("heading", { name: "提交学习资源草稿" });
+    fireEvent.change(screen.getByLabelText("申请分类名称"), {
+      target: { value: "现场沟通" },
+    });
+    fireEvent.change(screen.getByLabelText("申请分类理由"), {
+      target: { value: "覆盖失败提示" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "申请分类" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "分类申请服务暂时不可用",
+      ),
+    );
   });
 });

--- a/frontend/src/pages/LearningCenterPage.tsx
+++ b/frontend/src/pages/LearningCenterPage.tsx
@@ -4,12 +4,17 @@ import { useCallback, useEffect, useState } from "react";
 import {
   askKnowledge,
   getPublicPreventionCard,
+  listLearningCategories,
   listLearningQuestions,
   listLearningResources,
+  submitLearningCategoryProposal,
   submitLearningAnswer,
+  submitLearningResourceDraft,
 } from "../api/learning";
 import type {
   KnowledgeAnswer,
+  CreateLearningResourceInput,
+  LearningCategory,
   LearningQuestion,
   LearningResource,
 } from "../api/learning";
@@ -32,10 +37,23 @@ function messageFrom(cause: unknown) {
 }
 
 export function LearningCenterPage() {
-  const { token } = useAuth();
+  const { token, user } = useAuth();
   const preventionCacheReady = usePreventionCacheReady();
   const [resources, setResources] = useState<LearningResource[]>([]);
   const [questions, setQuestions] = useState<LearningQuestion[]>([]);
+  const [categories, setCategories] = useState<LearningCategory[]>([]);
+  const [selectedCategory, setSelectedCategory] = useState("");
+  const [selectedTag, setSelectedTag] = useState("");
+  const [draftTags, setDraftTags] = useState("");
+  const [draftError, setDraftError] = useState("");
+  const [isSubmittingDraft, setIsSubmittingDraft] = useState(false);
+  const [draft, setDraft] = useState<CreateLearningResourceInput>({
+    title: "", summary: "", content: "", resource_type: "manual", tags: [], category_id: null,
+    source_name: "", source_url: null, visibility: "learner", effective_at: new Date().toISOString(),
+    permitted_use: "training", submission_reason: "",
+  });
+  const [categoryProposal, setCategoryProposal] = useState("");
+  const [categoryProposalReason, setCategoryProposalReason] = useState("");
   const [preventionCard, setPreventionCard] = useState<LearningResource | null>(
     null,
   );
@@ -60,11 +78,18 @@ export function LearningCenterPage() {
     setError("");
     try {
       const [nextResources, nextQuestions] = await Promise.all([
-        listLearningResources(token),
+        listLearningResources(token, { category_id: selectedCategory, tag: selectedTag }),
         listLearningQuestions(token),
       ]);
       setResources(nextResources);
       setQuestions(nextQuestions);
+      // Categories are progressive enhancement for legacy deployments. A
+      // missing category endpoint must not hide already published resources.
+      setCategories(
+        typeof listLearningCategories === "function"
+          ? await listLearningCategories(token).catch(() => [])
+          : [],
+      );
       try {
         setPreventionCard(await getPublicPreventionCard());
       } catch (cause) {
@@ -77,7 +102,7 @@ export function LearningCenterPage() {
     } finally {
       setIsLoading(false);
     }
-  }, [token]);
+  }, [selectedCategory, selectedTag, token]);
 
   useEffect(() => {
     void load();
@@ -101,6 +126,44 @@ export function LearningCenterPage() {
       .catch((cause) => setError(messageFrom(cause)))
       .finally(() => setAnsweringQuestion(""));
   };
+
+  const submitDraft = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!token) return;
+    setDraftError("");
+    setIsSubmittingDraft(true);
+    void submitLearningResourceDraft(token, {
+      ...draft,
+      tags: draftTags.split(/[,，]/).map((tag) => tag.trim()).filter(Boolean),
+      source_url: draft.source_url?.trim() || null,
+    })
+      .then(() => {
+        setDraft({
+          ...draft, title: "", summary: "", content: "", tags: [], category_id: null,
+          source_name: "", source_url: null, submission_reason: "", effective_at: new Date().toISOString(),
+        });
+        setDraftTags("");
+        setDraftError("草稿已提交，等待独立去标识、审核与发布流程。");
+      })
+      .catch((cause) => setDraftError(messageFrom(cause)))
+      .finally(() => setIsSubmittingDraft(false));
+  };
+
+  const proposeCategory = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!token || !categoryProposal.trim() || !categoryProposalReason.trim()) return;
+    setDraftError("");
+    void submitLearningCategoryProposal(token, categoryProposal, categoryProposalReason)
+      .then(() => {
+        setCategoryProposal("");
+        setCategoryProposalReason("");
+        setDraftError("分类申请已提交，管理员启用后即可在资源草稿中选择。");
+        return load();
+      })
+      .catch((cause) => setDraftError(messageFrom(cause)));
+  };
+
+  const availableTags = Array.from(new Set(resources.flatMap((resource) => resource.tags))).sort();
 
   return (
     <main className="mx-auto w-full max-w-7xl px-4 py-7 sm:px-6 lg:px-10 lg:py-10">
@@ -179,6 +242,22 @@ export function LearningCenterPage() {
             <Chip.Label>{resources.length} 项</Chip.Label>
           </Chip>
         </header>
+        <div className="grid gap-3 border-b border-slate-100 px-5 py-4 sm:grid-cols-2">
+          <label className="grid gap-1 text-sm text-slate-700">
+            分类筛选
+            <select className="h-10 rounded-md border border-slate-300 bg-white px-3" value={selectedCategory} onChange={(event) => setSelectedCategory(event.target.value)}>
+              <option value="">全部分类（含历史未分类）</option>
+              {categories.map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}
+            </select>
+          </label>
+          <label className="grid gap-1 text-sm text-slate-700">
+            标签筛选
+            <select className="h-10 rounded-md border border-slate-300 bg-white px-3" value={selectedTag} onChange={(event) => setSelectedTag(event.target.value)}>
+              <option value="">全部标签</option>
+              {availableTags.map((tag) => <option key={tag} value={tag}>{tag}</option>)}
+            </select>
+          </label>
+        </div>
         {resources.length === 0 ? (
           <p className="m-0 px-5 py-8 text-sm text-slate-600">
             暂无已发布学习资源。资源需经过审核后才会出现在这里。
@@ -199,6 +278,16 @@ export function LearningCenterPage() {
                   <Chip size="sm" variant="soft">
                     <Chip.Label>v{resource.version}</Chip.Label>
                   </Chip>
+                  {resource.category && (
+                    <Chip size="sm" variant="soft">
+                      <Chip.Label>{resource.category.name}</Chip.Label>
+                    </Chip>
+                  )}
+                  {resource.tags.map((tag) => (
+                    <Chip key={tag} size="sm" variant="soft">
+                      <Chip.Label>#{tag}</Chip.Label>
+                    </Chip>
+                  ))}
                 </div>
                 <p className="mb-0 mt-1 text-sm text-slate-600">
                   {resource.summary}
@@ -230,6 +319,35 @@ export function LearningCenterPage() {
           </div>
         )}
       </section>
+      {user?.account_type === "learner" && (
+        <section className="mb-7 border-y border-slate-200 bg-white" aria-labelledby="contribute-learning-title">
+          <header className="border-b border-slate-200 px-5 py-4">
+            <h2 id="contribute-learning-title" className="m-0 text-base font-bold text-slate-950">提交学习资源草稿</h2>
+            <p className="mb-0 mt-1 text-sm text-slate-600">草稿不会直接展示；它必须经过独立去标识、审核和发布。</p>
+          </header>
+          <form className="grid gap-3 p-5 lg:grid-cols-2" onSubmit={submitDraft}>
+            <label className="grid gap-1 text-sm text-slate-700">标题<Input aria-label="草稿标题" value={draft.title} onChange={(event) => setDraft({ ...draft, title: event.target.value })} required /></label>
+            <label className="grid gap-1 text-sm text-slate-700">来源名称<Input aria-label="草稿来源名称" value={draft.source_name} onChange={(event) => setDraft({ ...draft, source_name: event.target.value })} required /></label>
+            <label className="grid gap-1 text-sm text-slate-700">分类
+              <select className="h-10 rounded-md border border-slate-300 bg-white px-3" value={draft.category_id ?? ""} onChange={(event) => setDraft({ ...draft, category_id: event.target.value || null })}>
+                <option value="">未分类</option>{categories.map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}
+              </select>
+            </label>
+            <label className="grid gap-1 text-sm text-slate-700">标签（逗号分隔）<Input aria-label="草稿标签" value={draftTags} onChange={(event) => setDraftTags(event.target.value)} /></label>
+            <label className="grid gap-1 text-sm text-slate-700 lg:col-span-2">摘要<textarea className="min-h-20 rounded-md border border-slate-300 px-3 py-2" value={draft.summary} onChange={(event) => setDraft({ ...draft, summary: event.target.value })} required /></label>
+            <label className="grid gap-1 text-sm text-slate-700 lg:col-span-2">正文<textarea className="min-h-32 rounded-md border border-slate-300 px-3 py-2" value={draft.content} onChange={(event) => setDraft({ ...draft, content: event.target.value })} required /></label>
+            <label className="grid gap-1 text-sm text-slate-700 lg:col-span-2">提交理由<textarea className="min-h-20 rounded-md border border-slate-300 px-3 py-2" value={draft.submission_reason} onChange={(event) => setDraft({ ...draft, submission_reason: event.target.value })} required /></label>
+            <div className="lg:col-span-2"><Button type="submit" isDisabled={isSubmittingDraft}>{isSubmittingDraft ? <Spinner size="sm" /> : "提交草稿"}</Button></div>
+          </form>
+          <form className="grid gap-3 border-t border-slate-100 p-5 lg:grid-cols-2" onSubmit={proposeCategory}>
+            <p className="m-0 text-sm font-semibold text-slate-950 lg:col-span-2">没有合适的分类？提交分类申请</p>
+            <Input aria-label="申请分类名称" value={categoryProposal} onChange={(event) => setCategoryProposal(event.target.value)} placeholder="分类名称" required />
+            <Input aria-label="申请分类理由" value={categoryProposalReason} onChange={(event) => setCategoryProposalReason(event.target.value)} placeholder="申请理由" required />
+            <div className="lg:col-span-2"><Button type="submit" variant="secondary">申请分类</Button></div>
+          </form>
+          {draftError && <p className="m-0 px-5 pb-5 text-sm text-slate-700" role="status">{draftError}</p>}
+        </section>
+      )}
       <div className="grid gap-7 lg:grid-cols-2">
         <section
           className="border-y border-slate-200 bg-white"

--- a/frontend/src/pages/LearningCenterPage.tsx
+++ b/frontend/src/pages/LearningCenterPage.tsx
@@ -36,6 +36,14 @@ function messageFrom(cause: unknown) {
     : "暂时无法完成学习中心操作，请稍后重试。";
 }
 
+function isMissingCategoryEndpoint(cause: unknown) {
+  return (
+    cause instanceof ApiClientError &&
+    cause.status === 404 &&
+    cause.code === "not_found"
+  );
+}
+
 export function LearningCenterPage() {
   const { token, user } = useAuth();
   const preventionCacheReady = usePreventionCacheReady();
@@ -85,11 +93,14 @@ export function LearningCenterPage() {
       setQuestions(nextQuestions);
       // Categories are progressive enhancement for legacy deployments. A
       // missing category endpoint must not hide already published resources.
-      setCategories(
+      const nextCategories =
         typeof listLearningCategories === "function"
-          ? await listLearningCategories(token).catch(() => [])
-          : [],
-      );
+          ? await listLearningCategories(token).catch((cause) => {
+              if (isMissingCategoryEndpoint(cause)) return [];
+              throw cause;
+            })
+          : [];
+      setCategories(nextCategories);
       try {
         setPreventionCard(await getPublicPreventionCard());
       } catch (cause) {

--- a/frontend/src/pages/LearningGovernancePage.test.tsx
+++ b/frontend/src/pages/LearningGovernancePage.test.tsx
@@ -220,6 +220,18 @@ describe("LearningGovernancePage", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows a retryable error instead of an empty category list when category loading fails", async () => {
+    mocked.listCategories.mockRejectedValue(
+      new ApiClientError(503, "request_failed", "分类治理服务暂时不可用"),
+    );
+    render(<LearningGovernancePage />);
+
+    expect(
+      await screen.findByText("分类治理服务暂时不可用"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "重试" })).toBeInTheDocument();
+  });
+
   it("offers category lifecycle actions and sends the administrator reason", async () => {
     mocked.listCategories.mockResolvedValue([
       {

--- a/frontend/src/pages/LearningGovernancePage.test.tsx
+++ b/frontend/src/pages/LearningGovernancePage.test.tsx
@@ -7,6 +7,8 @@ const mocked = vi.hoisted(() => ({
   listResources: vi.fn(),
   listQuestions: vi.fn(),
   transitionResource: vi.fn(),
+  listCategories: vi.fn(),
+  transitionCategory: vi.fn(),
 }));
 
 vi.mock("../auth/useAuth", () => ({
@@ -27,6 +29,10 @@ vi.mock("../api/learning", () => ({
     mocked.listResources(...args),
   listManagedLearningQuestions: (...args: unknown[]) =>
     mocked.listQuestions(...args),
+  listManagedLearningCategories: (...args: unknown[]) =>
+    mocked.listCategories(...args),
+  transitionManagedLearningCategory: (...args: unknown[]) =>
+    mocked.transitionCategory(...args),
   transitionManagedLearningResource: (...args: unknown[]) =>
     mocked.transitionResource(...args),
   transitionManagedLearningQuestion: vi.fn(),
@@ -63,7 +69,14 @@ describe("LearningGovernancePage", () => {
   beforeEach(() => {
     mocked.listResources.mockResolvedValue([submittedResource()]);
     mocked.listQuestions.mockResolvedValue([]);
+    mocked.listCategories.mockResolvedValue([]);
     mocked.transitionResource.mockReset();
+    mocked.transitionCategory.mockReset();
+    mocked.transitionCategory.mockResolvedValue({
+      id: "category-1",
+      name: "安全基础",
+      status: "enabled",
+    });
   });
 
   it("does not allow the submitter to confirm de-identification", async () => {
@@ -205,5 +218,49 @@ describe("LearningGovernancePage", () => {
     expect(
       screen.getByRole("heading", { name: "学习内容治理" }),
     ).toBeInTheDocument();
+  });
+
+  it("offers category lifecycle actions and sends the administrator reason", async () => {
+    mocked.listCategories.mockResolvedValue([
+      {
+        id: "category-pending",
+        name: "安全基础",
+        status: "pending",
+        submitted_by_user_id: "learner-1",
+        reviewed_by_user_id: null,
+        created_at: "2026-08-05T00:00:00.000Z",
+        updated_at: "2026-08-05T00:00:00.000Z",
+      },
+      {
+        id: "category-enabled",
+        name: "沟通技巧",
+        status: "enabled",
+        submitted_by_user_id: "learner-2",
+        reviewed_by_user_id: "admin-1",
+        created_at: "2026-08-04T00:00:00.000Z",
+        updated_at: "2026-08-04T00:00:00.000Z",
+      },
+    ]);
+    render(<LearningGovernancePage />);
+
+    expect(await screen.findByText("安全基础")).toBeInTheDocument();
+    expect(screen.getAllByText("沟通技巧").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "启用" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "驳回" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "停用" })).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("操作理由"), {
+      target: { value: "分类符合新人课程结构" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "启用" }));
+
+    await waitFor(() =>
+      expect(mocked.transitionCategory).toHaveBeenCalledWith(
+        "admin-session",
+        "category-pending",
+        "enable",
+        "分类符合新人课程结构",
+      ),
+    );
   });
 });

--- a/frontend/src/pages/LearningGovernancePage.tsx
+++ b/frontend/src/pages/LearningGovernancePage.tsx
@@ -63,6 +63,14 @@ function errorMessage(cause: unknown) {
     : "暂时无法完成内容治理操作，请稍后重试。";
 }
 
+function isMissingCategoryEndpoint(cause: unknown) {
+  return (
+    cause instanceof ApiClientError &&
+    cause.status === 404 &&
+    cause.code === "not_found"
+  );
+}
+
 function parseTags(value: string) {
   return value
     .split("，")
@@ -215,11 +223,14 @@ export function LearningGovernancePage() {
       setQuestions(nextQuestions);
       // Keep resource governance usable while rolling out the optional
       // category-governance endpoint to older deployments.
-      setCategories(
+      const nextCategories =
         typeof listManagedLearningCategories === "function"
-          ? await listManagedLearningCategories(token).catch(() => [])
-          : [],
-      );
+          ? await listManagedLearningCategories(token).catch((cause) => {
+              if (isMissingCategoryEndpoint(cause)) return [];
+              throw cause;
+            })
+          : [];
+      setCategories(nextCategories);
     } catch (cause) {
       setLoadError(errorMessage(cause));
     } finally {

--- a/frontend/src/pages/LearningGovernancePage.tsx
+++ b/frontend/src/pages/LearningGovernancePage.tsx
@@ -4,8 +4,10 @@ import { useCallback, useEffect, useState } from "react";
 import {
   createManagedLearningQuestion,
   createManagedLearningResource,
+  listManagedLearningCategories,
   listManagedLearningQuestions,
   listManagedLearningResources,
+  transitionManagedLearningCategory,
   transitionManagedLearningQuestion,
   transitionManagedLearningResource,
 } from "../api/learning";
@@ -13,6 +15,7 @@ import type {
   CreateLearningQuestionInput,
   CreateLearningResourceInput,
   LearningContentLifecycle,
+  ManagedLearningCategory,
   ManagedLearningQuestion,
   ManagedLearningResource,
 } from "../api/learning";
@@ -156,6 +159,7 @@ function LifecycleActions({
 export function LearningGovernancePage() {
   const { token, user } = useAuth();
   const [resources, setResources] = useState<ManagedLearningResource[]>([]);
+  const [categories, setCategories] = useState<ManagedLearningCategory[]>([]);
   const [questions, setQuestions] = useState<ManagedLearningQuestion[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [loadError, setLoadError] = useState("");
@@ -169,6 +173,7 @@ export function LearningGovernancePage() {
       content: "",
       resource_type: "manual",
       tags: [],
+      category_id: null,
       source_name: "",
       source_url: null,
       visibility: "learner",
@@ -208,6 +213,13 @@ export function LearningGovernancePage() {
       ]);
       setResources(nextResources);
       setQuestions(nextQuestions);
+      // Keep resource governance usable while rolling out the optional
+      // category-governance endpoint to older deployments.
+      setCategories(
+        typeof listManagedLearningCategories === "function"
+          ? await listManagedLearningCategories(token).catch(() => [])
+          : [],
+      );
     } catch (cause) {
       setLoadError(errorMessage(cause));
     } finally {
@@ -258,6 +270,25 @@ export function LearningGovernancePage() {
       .catch((cause) => setOperationError(errorMessage(cause)))
       .finally(() => setBusyId(""));
   };
+  const actOnCategory = (
+    category: ManagedLearningCategory,
+    action: "enable" | "reject" | "disable",
+  ) => {
+    if (!token || !reason.trim()) {
+      setOperationError("请填写本次操作理由。");
+      return;
+    }
+    setOperationError("");
+    setBusyId(category.id);
+    void transitionManagedLearningCategory(token, category.id, action, reason)
+      .then(() => {
+        setReason("");
+        return load();
+      })
+      .catch((cause) => setOperationError(errorMessage(cause)))
+      .finally(() => setBusyId(""));
+  };
+
   const submitResource = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (!token) return;
@@ -275,6 +306,7 @@ export function LearningGovernancePage() {
           summary: "",
           content: "",
           tags: [],
+          category_id: null,
           source_name: "",
           source_url: null,
           previous_version_id: null,
@@ -354,6 +386,36 @@ export function LearningGovernancePage() {
           {operationError}
         </div>
       )}
+      <section
+        className="mb-7 border-y border-slate-200 bg-white"
+        aria-labelledby="category-governance-title"
+      >
+        <header className="border-b border-slate-200 px-5 py-4">
+          <h2 id="category-governance-title" className="m-0 text-base font-bold text-slate-950">
+            知识分类治理
+          </h2>
+        </header>
+        <div className="divide-y divide-slate-100">
+          {categories.length === 0 ? (
+            <p className="m-0 px-5 py-6 text-sm text-slate-600">暂无分类申请。</p>
+          ) : categories.map((category) => (
+            <div key={category.id} className="flex flex-wrap items-center justify-between gap-3 px-5 py-4">
+              <div>
+                <p className="m-0 text-sm font-semibold text-slate-950">{category.name}</p>
+                <p className="mb-0 mt-1 text-xs text-slate-500">状态：{category.status}</p>
+              </div>
+              {category.status === "pending" ? (
+                <div className="flex gap-2">
+                  <Button size="sm" isDisabled={busyId === category.id} onPress={() => actOnCategory(category, "enable")}>启用</Button>
+                  <Button size="sm" variant="danger" isDisabled={busyId === category.id} onPress={() => actOnCategory(category, "reject")}>驳回</Button>
+                </div>
+              ) : category.status === "enabled" ? (
+                <Button size="sm" variant="danger" isDisabled={busyId === category.id} onPress={() => actOnCategory(category, "disable")}>停用</Button>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      </section>
       <section className="border-y border-slate-200 bg-white">
         <header className="flex items-center gap-2 border-b border-slate-200 px-5 py-4">
           <FilePlus2 size={18} aria-hidden="true" />
@@ -470,6 +532,28 @@ export function LearningGovernancePage() {
               value={resourceTags}
               onChange={(event) => setResourceTags(event.target.value)}
             />
+          </label>
+          <label className="grid gap-1 text-sm text-slate-700">
+            分类
+            <select
+              className="h-10 rounded-md border border-slate-300 bg-white px-3"
+              value={resourceForm.category_id ?? ""}
+              onChange={(event) =>
+                setResourceForm({
+                  ...resourceForm,
+                  category_id: event.target.value || null,
+                })
+              }
+            >
+              <option value="">未分类（兼容历史资源）</option>
+              {categories
+                .filter((category) => category.status === "enabled")
+                .map((category) => (
+                  <option key={category.id} value={category.id}>
+                    {category.name}
+                  </option>
+                ))}
+            </select>
           </label>
           <TextareaField
             className="lg:col-span-2"

--- a/migration/sql/mysql/down/0044_remove_learning_category_governance.sql
+++ b/migration/sql/mysql/down/0044_remove_learning_category_governance.sql
@@ -1,6 +1,6 @@
-DROP INDEX idx_learning_resources_category ON learning_resources;
--- statement-break
 ALTER TABLE learning_resources DROP FOREIGN KEY fk_learning_resources_category;
+-- statement-break
+DROP INDEX idx_learning_resources_category ON learning_resources;
 -- statement-break
 ALTER TABLE learning_resources DROP COLUMN category_name;
 -- statement-break

--- a/migration/sql/mysql/down/0044_remove_learning_category_governance.sql
+++ b/migration/sql/mysql/down/0044_remove_learning_category_governance.sql
@@ -1,0 +1,11 @@
+DROP INDEX idx_learning_resources_category ON learning_resources;
+-- statement-break
+ALTER TABLE learning_resources DROP FOREIGN KEY fk_learning_resources_category;
+-- statement-break
+ALTER TABLE learning_resources DROP COLUMN category_name;
+-- statement-break
+ALTER TABLE learning_resources DROP COLUMN category_id;
+-- statement-break
+DROP TABLE IF EXISTS learning_category_review_events;
+-- statement-break
+DROP TABLE IF EXISTS learning_categories;

--- a/migration/sql/mysql/up/0044_add_learning_category_governance.sql
+++ b/migration/sql/mysql/up/0044_add_learning_category_governance.sql
@@ -1,0 +1,37 @@
+CREATE TABLE learning_categories (
+    id VARCHAR(64) PRIMARY KEY,
+    name VARCHAR(160) NOT NULL,
+    normalized_name VARCHAR(160) NOT NULL UNIQUE,
+    status VARCHAR(16) NOT NULL,
+    submitted_by_user_id VARCHAR(64) NOT NULL,
+    reviewed_by_user_id VARCHAR(64) NULL,
+    created_at VARCHAR(40) NOT NULL,
+    updated_at VARCHAR(40) NOT NULL,
+    CONSTRAINT chk_learning_categories_status CHECK (status IN ('pending', 'enabled', 'rejected', 'disabled')),
+    CONSTRAINT fk_learning_categories_submitter FOREIGN KEY (submitted_by_user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_learning_categories_reviewer FOREIGN KEY (reviewed_by_user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE RESTRICT
+);
+-- statement-break
+CREATE INDEX idx_learning_categories_status_name ON learning_categories(status, name);
+-- statement-break
+CREATE TABLE learning_category_review_events (
+    id VARCHAR(64) PRIMARY KEY,
+    category_id VARCHAR(64) NOT NULL,
+    event_type VARCHAR(16) NOT NULL,
+    actor_user_id VARCHAR(64) NOT NULL,
+    reason TEXT NOT NULL,
+    created_at VARCHAR(40) NOT NULL,
+    CONSTRAINT chk_learning_category_review_events_type CHECK (event_type IN ('submitted', 'enabled', 'rejected', 'disabled')),
+    CONSTRAINT fk_learning_category_review_events_category FOREIGN KEY (category_id) REFERENCES learning_categories(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+    CONSTRAINT fk_learning_category_review_events_actor FOREIGN KEY (actor_user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE RESTRICT
+);
+-- statement-break
+CREATE INDEX idx_learning_category_review_events_category_created ON learning_category_review_events(category_id, created_at);
+-- statement-break
+ALTER TABLE learning_resources ADD COLUMN category_id VARCHAR(64) NULL;
+-- statement-break
+ALTER TABLE learning_resources ADD COLUMN category_name VARCHAR(160) NULL;
+-- statement-break
+ALTER TABLE learning_resources ADD CONSTRAINT fk_learning_resources_category FOREIGN KEY (category_id) REFERENCES learning_categories(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+-- statement-break
+CREATE INDEX idx_learning_resources_category ON learning_resources(category_id);

--- a/migration/sql/mysql/up/0044_add_learning_category_governance.sql
+++ b/migration/sql/mysql/up/0044_add_learning_category_governance.sql
@@ -32,6 +32,6 @@ ALTER TABLE learning_resources ADD COLUMN category_id VARCHAR(64) NULL;
 -- statement-break
 ALTER TABLE learning_resources ADD COLUMN category_name VARCHAR(160) NULL;
 -- statement-break
-ALTER TABLE learning_resources ADD CONSTRAINT fk_learning_resources_category FOREIGN KEY (category_id) REFERENCES learning_categories(id) ON UPDATE CASCADE ON DELETE RESTRICT;
--- statement-break
 CREATE INDEX idx_learning_resources_category ON learning_resources(category_id);
+-- statement-break
+ALTER TABLE learning_resources ADD CONSTRAINT fk_learning_resources_category FOREIGN KEY (category_id) REFERENCES learning_categories(id) ON UPDATE CASCADE ON DELETE RESTRICT;

--- a/migration/sql/postgres/down/0044_remove_learning_category_governance.sql
+++ b/migration/sql/postgres/down/0044_remove_learning_category_governance.sql
@@ -1,0 +1,9 @@
+DROP INDEX IF EXISTS idx_learning_resources_category;
+-- statement-break
+ALTER TABLE learning_resources DROP COLUMN category_name;
+-- statement-break
+ALTER TABLE learning_resources DROP COLUMN category_id;
+-- statement-break
+DROP TABLE IF EXISTS learning_category_review_events;
+-- statement-break
+DROP TABLE IF EXISTS learning_categories;

--- a/migration/sql/postgres/up/0044_add_learning_category_governance.sql
+++ b/migration/sql/postgres/up/0044_add_learning_category_governance.sql
@@ -1,0 +1,29 @@
+CREATE TABLE learning_categories (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    normalized_name TEXT NOT NULL UNIQUE,
+    status TEXT NOT NULL CHECK (status IN ('pending', 'enabled', 'rejected', 'disabled')),
+    submitted_by_user_id TEXT NOT NULL REFERENCES users(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+    reviewed_by_user_id TEXT NULL REFERENCES users(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+-- statement-break
+CREATE INDEX idx_learning_categories_status_name ON learning_categories(status, name);
+-- statement-break
+CREATE TABLE learning_category_review_events (
+    id TEXT PRIMARY KEY,
+    category_id TEXT NOT NULL REFERENCES learning_categories(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+    event_type TEXT NOT NULL CHECK (event_type IN ('submitted', 'enabled', 'rejected', 'disabled')),
+    actor_user_id TEXT NOT NULL REFERENCES users(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+    reason TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+-- statement-break
+CREATE INDEX idx_learning_category_review_events_category_created ON learning_category_review_events(category_id, created_at);
+-- statement-break
+ALTER TABLE learning_resources ADD COLUMN category_id TEXT NULL REFERENCES learning_categories(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+-- statement-break
+ALTER TABLE learning_resources ADD COLUMN category_name TEXT NULL;
+-- statement-break
+CREATE INDEX idx_learning_resources_category ON learning_resources(category_id);

--- a/migration/sql/sqlite/down/0044_remove_learning_category_governance.sql
+++ b/migration/sql/sqlite/down/0044_remove_learning_category_governance.sql
@@ -1,0 +1,9 @@
+DROP INDEX IF EXISTS idx_learning_resources_category;
+-- statement-break
+ALTER TABLE learning_resources DROP COLUMN category_name;
+-- statement-break
+ALTER TABLE learning_resources DROP COLUMN category_id;
+-- statement-break
+DROP TABLE IF EXISTS learning_category_review_events;
+-- statement-break
+DROP TABLE IF EXISTS learning_categories;

--- a/migration/sql/sqlite/up/0044_add_learning_category_governance.sql
+++ b/migration/sql/sqlite/up/0044_add_learning_category_governance.sql
@@ -1,0 +1,33 @@
+CREATE TABLE learning_categories (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    normalized_name TEXT NOT NULL UNIQUE,
+    status TEXT NOT NULL CHECK (status IN ('pending', 'enabled', 'rejected', 'disabled')),
+    submitted_by_user_id TEXT NOT NULL,
+    reviewed_by_user_id TEXT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (submitted_by_user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+    FOREIGN KEY (reviewed_by_user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE RESTRICT
+);
+-- statement-break
+CREATE INDEX idx_learning_categories_status_name ON learning_categories(status, name);
+-- statement-break
+CREATE TABLE learning_category_review_events (
+    id TEXT PRIMARY KEY NOT NULL,
+    category_id TEXT NOT NULL,
+    event_type TEXT NOT NULL CHECK (event_type IN ('submitted', 'enabled', 'rejected', 'disabled')),
+    actor_user_id TEXT NOT NULL,
+    reason TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY (category_id) REFERENCES learning_categories(id) ON UPDATE CASCADE ON DELETE RESTRICT,
+    FOREIGN KEY (actor_user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE RESTRICT
+);
+-- statement-break
+CREATE INDEX idx_learning_category_review_events_category_created ON learning_category_review_events(category_id, created_at);
+-- statement-break
+ALTER TABLE learning_resources ADD COLUMN category_id TEXT NULL REFERENCES learning_categories(id) ON UPDATE CASCADE ON DELETE RESTRICT;
+-- statement-break
+ALTER TABLE learning_resources ADD COLUMN category_name TEXT NULL;
+-- statement-break
+CREATE INDEX idx_learning_resources_category ON learning_resources(category_id);

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -43,6 +43,7 @@ mod m0040_enforce_learning_lifecycle_event_uniqueness;
 mod m0041_add_learning_content_version_lineage;
 mod m0042_create_ai_executions;
 mod m0043_add_intake_report_details;
+mod m0044_add_learning_category_governance;
 
 use sea_orm_migration::sea_orm::{DbBackend, Statement};
 
@@ -95,6 +96,7 @@ impl MigratorTrait for Migrator {
             Box::new(m0041_add_learning_content_version_lineage::Migration),
             Box::new(m0042_create_ai_executions::Migration),
             Box::new(m0043_add_intake_report_details::Migration),
+            Box::new(m0044_add_learning_category_governance::Migration),
         ]
     }
 }

--- a/migration/src/m0044_add_learning_category_governance.rs
+++ b/migration/src/m0044_add_learning_category_governance.rs
@@ -1,0 +1,53 @@
+use crate::{ensure_rollback_is_safe, execute_script, sql_for_backend};
+use sea_orm_migration::prelude::*;
+
+pub struct Migration;
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m0044_add_learning_category_governance"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        execute_script(
+            manager,
+            sql_for_backend(
+                manager,
+                include_str!("../sql/sqlite/up/0044_add_learning_category_governance.sql"),
+                include_str!("../sql/postgres/up/0044_add_learning_category_governance.sql"),
+                include_str!("../sql/mysql/up/0044_add_learning_category_governance.sql"),
+            ),
+        )
+        .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        ensure_rollback_is_safe(
+            manager,
+            &[
+                (
+                    "learning categories or resource category assignments exist",
+                    "SELECT 1 FROM learning_categories LIMIT 1",
+                ),
+                (
+                    "learning resources use a governed category",
+                    "SELECT 1 FROM learning_resources WHERE category_id IS NOT NULL LIMIT 1",
+                ),
+            ],
+        )
+        .await?;
+        execute_script(
+            manager,
+            sql_for_backend(
+                manager,
+                include_str!("../sql/sqlite/down/0044_remove_learning_category_governance.sql"),
+                include_str!("../sql/postgres/down/0044_remove_learning_category_governance.sql"),
+                include_str!("../sql/mysql/down/0044_remove_learning_category_governance.sql"),
+            ),
+        )
+        .await
+    }
+}

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -24,6 +24,24 @@ pub struct AuthenticatedUser {
 pub struct LearningResourceQuery {
     pub resource_type: Option<String>,
     pub tag: Option<String>,
+    pub category_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LearningCategoryResponse {
+    pub id: String,
+    pub name: String,
+    pub status: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ManagedLearningCategoryResponse {
+    #[serde(flatten)]
+    pub category: LearningCategoryResponse,
+    pub submitted_by_user_id: String,
+    pub reviewed_by_user_id: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -34,6 +52,7 @@ pub struct LearningResourceResponse {
     pub content: String,
     pub resource_type: String,
     pub tags: Vec<String>,
+    pub category: Option<LearningCategoryResponse>,
     pub source_name: String,
     pub source_url: Option<String>,
     pub previous_version_id: Option<String>,
@@ -104,12 +123,25 @@ pub struct CreateLearningResourceRequest {
     pub content: String,
     pub resource_type: String,
     pub tags: Vec<String>,
+    pub category_id: Option<String>,
     pub source_name: String,
     pub source_url: Option<String>,
     pub previous_version_id: Option<String>,
     pub visibility: String,
     pub effective_at: String,
     pub permitted_use: String,
+    pub submission_reason: String,
+}
+
+/// A learner may submit a draft but can never self-publish it. The resource
+/// shape is intentionally shared with administrators so validation and the
+/// independent review lifecycle cannot drift.
+pub type SubmitLearningResourceDraftRequest = CreateLearningResourceRequest;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreateLearningCategoryRequest {
+    pub name: String,
     pub submission_reason: String,
 }
 

--- a/src/api/routes/learning.rs
+++ b/src/api/routes/learning.rs
@@ -4,9 +4,9 @@ use crate::{
     app_state::AppState,
     error::ApiError,
     models::{
-        AuthenticatedUser, CreateLearningQuestionRequest, CreateLearningResourceRequest,
-        KnowledgeAskRequest, LearningContentActionRequest, LearningQuestionQuery,
-        LearningResourceQuery, SubmitLearningAnswerRequest,
+        AuthenticatedUser, CreateLearningCategoryRequest, CreateLearningQuestionRequest,
+        CreateLearningResourceRequest, KnowledgeAskRequest, LearningContentActionRequest,
+        LearningQuestionQuery, LearningResourceQuery, SubmitLearningAnswerRequest,
     },
     services::learning_service,
 };
@@ -20,6 +20,9 @@ pub fn configure(config: &mut web::ServiceConfig) {
                     web::get().to(public_prevention_card),
                 )
                 .route("/resources", web::get().to(list_resources))
+                .route("/resources/drafts", web::post().to(submit_resource_draft))
+                .route("/categories", web::get().to(list_enabled_categories))
+                .route("/categories/proposals", web::post().to(propose_category))
                 .route("/questions", web::get().to(list_questions))
                 .route(
                     "/questions/{question_id}/answers",
@@ -30,6 +33,19 @@ pub fn configure(config: &mut web::ServiceConfig) {
             web::scope("/admin/learning")
                 .route("/resources", web::get().to(list_managed_resources))
                 .route("/resources", web::post().to(create_resource))
+                .route("/categories", web::get().to(list_managed_categories))
+                .route(
+                    "/categories/{category_id}/enable",
+                    web::post().to(enable_category),
+                )
+                .route(
+                    "/categories/{category_id}/reject",
+                    web::post().to(reject_category),
+                )
+                .route(
+                    "/categories/{category_id}/disable",
+                    web::post().to(disable_category),
+                )
                 .route(
                     "/resources/{resource_id}/deidentify",
                     web::post().to(deidentify_resource),
@@ -89,6 +105,32 @@ async fn list_resources(
         .json(learning_service::list_resources(&state.db, &auth, query.into_inner()).await?))
 }
 
+async fn list_enabled_categories(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+) -> Result<HttpResponse, ApiError> {
+    Ok(HttpResponse::Ok().json(learning_service::list_enabled_categories(&state.db, &auth).await?))
+}
+
+async fn propose_category(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    request: web::Json<CreateLearningCategoryRequest>,
+) -> Result<HttpResponse, ApiError> {
+    Ok(HttpResponse::Created()
+        .json(learning_service::propose_category(&state.db, &auth, request.into_inner()).await?))
+}
+
+async fn submit_resource_draft(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    request: web::Json<CreateLearningResourceRequest>,
+) -> Result<HttpResponse, ApiError> {
+    Ok(HttpResponse::Created().json(
+        learning_service::submit_resource_draft(&state.db, &auth, request.into_inner()).await?,
+    ))
+}
+
 async fn list_questions(
     auth: AuthenticatedUser,
     state: web::Data<AppState>,
@@ -124,6 +166,67 @@ async fn list_managed_resources(
     state: web::Data<AppState>,
 ) -> Result<HttpResponse, ApiError> {
     Ok(HttpResponse::Ok().json(learning_service::list_managed_resources(&state.db, &auth).await?))
+}
+
+async fn list_managed_categories(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+) -> Result<HttpResponse, ApiError> {
+    Ok(HttpResponse::Ok().json(learning_service::list_managed_categories(&state.db, &auth).await?))
+}
+
+async fn enable_category(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    category_id: web::Path<String>,
+    request: web::Json<LearningContentActionRequest>,
+) -> Result<HttpResponse, ApiError> {
+    Ok(HttpResponse::Ok().json(
+        learning_service::transition_category(
+            &state.db,
+            &auth,
+            &category_id,
+            "enable",
+            request.into_inner(),
+        )
+        .await?,
+    ))
+}
+
+async fn reject_category(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    category_id: web::Path<String>,
+    request: web::Json<LearningContentActionRequest>,
+) -> Result<HttpResponse, ApiError> {
+    Ok(HttpResponse::Ok().json(
+        learning_service::transition_category(
+            &state.db,
+            &auth,
+            &category_id,
+            "reject",
+            request.into_inner(),
+        )
+        .await?,
+    ))
+}
+
+async fn disable_category(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    category_id: web::Path<String>,
+    request: web::Json<LearningContentActionRequest>,
+) -> Result<HttpResponse, ApiError> {
+    Ok(HttpResponse::Ok().json(
+        learning_service::transition_category(
+            &state.db,
+            &auth,
+            &category_id,
+            "disable",
+            request.into_inner(),
+        )
+        .await?,
+    ))
 }
 
 async fn create_resource(

--- a/src/application/services/learning_service.rs
+++ b/src/application/services/learning_service.rs
@@ -3,23 +3,24 @@ use std::collections::{HashMap, HashSet};
 use chrono::{DateTime, SecondsFormat, Utc};
 use sea_orm::sea_query::{Expr, OnConflict};
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder, Set,
-    TransactionTrait, TryInsertResult,
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, IntoActiveModel, QueryFilter,
+    QueryOrder, Set, TransactionTrait, TryInsertResult,
 };
 use serde_json::json;
 
 use crate::{
     entities::{
-        learning_content_review_events, learning_question_answers, learning_questions,
-        learning_resources,
+        learning_categories, learning_category_review_events, learning_content_review_events,
+        learning_question_answers, learning_questions, learning_resources,
     },
     error::ApiError,
     models::{
-        AuthenticatedUser, CreateLearningQuestionRequest, CreateLearningResourceRequest,
-        KnowledgeAnswerResponse, KnowledgeAskRequest, LearningAnswerSource,
-        LearningContentActionRequest, LearningContentLifecycleResponse,
-        LearningContentReviewEventResponse, LearningQuestionQuery, LearningQuestionResponse,
-        LearningResourceQuery, LearningResourceResponse, ManagedLearningQuestionResponse,
+        AuthenticatedUser, CreateLearningCategoryRequest, CreateLearningQuestionRequest,
+        CreateLearningResourceRequest, KnowledgeAnswerResponse, KnowledgeAskRequest,
+        LearningAnswerSource, LearningCategoryResponse, LearningContentActionRequest,
+        LearningContentLifecycleResponse, LearningContentReviewEventResponse,
+        LearningQuestionQuery, LearningQuestionResponse, LearningResourceQuery,
+        LearningResourceResponse, ManagedLearningCategoryResponse, ManagedLearningQuestionResponse,
         ManagedLearningResourceResponse, SubmitLearningAnswerRequest, SubmitLearningAnswerResponse,
     },
     roles::{AccountType, GlobalCapability},
@@ -101,8 +102,151 @@ pub async fn list_resources(
                 })
             })
         })
+        .filter(|resource| {
+            query.category_id.as_ref().is_none_or(|category_id| {
+                resource.category_id.as_deref() == Some(category_id.trim())
+            })
+        })
         .map(resource_response)
         .collect()
+}
+
+/// Lists only categories that may be selected for a new resource. Historical
+/// resources retain their category snapshot even after a category is disabled.
+pub async fn list_enabled_categories(
+    db: &DatabaseConnection,
+    _auth: &AuthenticatedUser,
+) -> Result<Vec<LearningCategoryResponse>, ApiError> {
+    learning_categories::Entity::find()
+        .filter(learning_categories::Column::Status.eq("enabled"))
+        .order_by_asc(learning_categories::Column::Name)
+        .all(db)
+        .await?
+        .into_iter()
+        .map(category_response)
+        .collect()
+}
+
+pub async fn list_managed_categories(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+) -> Result<Vec<ManagedLearningCategoryResponse>, ApiError> {
+    require_admin(auth)?;
+    learning_categories::Entity::find()
+        .order_by_asc(learning_categories::Column::Name)
+        .all(db)
+        .await?
+        .into_iter()
+        .map(|category| {
+            Ok(ManagedLearningCategoryResponse {
+                category: category_response(category.clone())?,
+                submitted_by_user_id: category.submitted_by_user_id,
+                reviewed_by_user_id: category.reviewed_by_user_id,
+                created_at: category.created_at,
+                updated_at: category.updated_at,
+            })
+        })
+        .collect()
+}
+
+pub async fn propose_category(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    request: CreateLearningCategoryRequest,
+) -> Result<LearningCategoryResponse, ApiError> {
+    require_learner(auth)?;
+    let name = normalized_name(&request.name, "category", 160)?;
+    let reason = required_text(&request.submission_reason, "submission_reason", 1_000)?;
+    let id = case_service::new_id();
+    let timestamp = now();
+    let transaction = db.begin().await?;
+    let inserted = learning_categories::Entity::insert(learning_categories::ActiveModel {
+        id: Set(id.clone()),
+        name: Set(name.clone()),
+        normalized_name: Set(normalized_key(&name)),
+        status: Set("pending".to_owned()),
+        submitted_by_user_id: Set(auth.id.clone()),
+        reviewed_by_user_id: Set(None),
+        created_at: Set(timestamp.clone()),
+        updated_at: Set(timestamp.clone()),
+    })
+    .on_conflict(
+        OnConflict::column(learning_categories::Column::NormalizedName)
+            .do_nothing()
+            .to_owned(),
+    )
+    .do_nothing()
+    .exec(&transaction)
+    .await?;
+    if !matches!(inserted, TryInsertResult::Inserted(_)) {
+        return Err(ApiError::Conflict(
+            "category already exists or is awaiting review".to_owned(),
+        ));
+    }
+    append_category_event(&transaction, auth, &id, "submitted", &reason).await?;
+    write_learning_audit(
+        &transaction,
+        auth,
+        "learning_category.submitted",
+        &id,
+        0,
+        "training",
+    )
+    .await?;
+    transaction.commit().await?;
+    Ok(LearningCategoryResponse {
+        id,
+        name,
+        status: "pending".to_owned(),
+    })
+}
+
+pub async fn transition_category(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    category_id: &str,
+    action: &str,
+    request: LearningContentActionRequest,
+) -> Result<LearningCategoryResponse, ApiError> {
+    require_admin(auth)?;
+    let reason = required_text(&request.reason, "reason", 1_000)?;
+    let category = learning_categories::Entity::find_by_id(category_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| ApiError::NotFound("learning category does not exist".to_owned()))?;
+    let permitted = matches!(
+        (category.status.as_str(), action),
+        ("pending", "enable") | ("pending", "reject") | ("enabled", "disable")
+    );
+    if !permitted {
+        return Err(ApiError::Conflict(
+            "category lifecycle transition is not allowed".to_owned(),
+        ));
+    }
+    let status = match action {
+        "enable" => "enabled",
+        "reject" => "rejected",
+        "disable" => "disabled",
+        _ => return Err(ApiError::Validation("unknown category action".to_owned())),
+    };
+    let transaction = db.begin().await?;
+    let mut update = category.into_active_model();
+    update.status = Set(status.to_owned());
+    update.reviewed_by_user_id = Set(Some(auth.id.clone()));
+    update.updated_at = Set(now());
+    let category = update.update(&transaction).await?;
+    append_category_event(&transaction, auth, &category.id, status, &reason).await?;
+    write_learning_audit(
+        &transaction,
+        auth,
+        &format!("learning_category.{status}"),
+        &category.id,
+        0,
+        "training",
+    )
+    .await?;
+    transaction.commit().await?;
+    category_response(category)
 }
 
 pub async fn list_questions(
@@ -263,6 +407,7 @@ pub async fn ask_knowledge(
         LearningResourceQuery {
             resource_type: None,
             tag: None,
+            category_id: None,
         },
     )
     .await?;
@@ -346,6 +491,27 @@ pub async fn create_resource(
     request: CreateLearningResourceRequest,
 ) -> Result<ManagedLearningResourceResponse, ApiError> {
     require_admin(auth)?;
+    create_resource_inner(db, auth, request, false).await
+}
+
+/// A learner can contribute a draft, but its audience and permitted use are
+/// deliberately fixed. It still enters the same independent governance chain
+/// as administrator-authored content and is never readable on submission.
+pub async fn submit_resource_draft(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    request: CreateLearningResourceRequest,
+) -> Result<ManagedLearningResourceResponse, ApiError> {
+    require_learner(auth)?;
+    create_resource_inner(db, auth, request, true).await
+}
+
+async fn create_resource_inner(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    request: CreateLearningResourceRequest,
+    learner_submission: bool,
+) -> Result<ManagedLearningResourceResponse, ApiError> {
     let title = required_text(&request.title, "title", 160)?;
     let summary = required_text(&request.summary, "summary", 800)?;
     let content = required_text(&request.content, "content", 20_000)?;
@@ -364,12 +530,19 @@ pub async fn create_resource(
         "permitted_use",
         &["training", "public_information"],
     )?;
+    if learner_submission && (visibility != "learner" || permitted_use != "training") {
+        return Err(ApiError::Forbidden(
+            "learner drafts must use learner visibility and training-only use".to_owned(),
+        ));
+    }
     let source_name = required_text(&request.source_name, "source_name", 240)?;
     let source_url = validate_source_url(request.source_url)?;
     let effective_at = valid_timestamp(&request.effective_at, "effective_at")?;
     let submission_reason = required_text(&request.submission_reason, "submission_reason", 1_000)?;
     let tags_json =
         serde_json::to_string(&normalized_tags(&request.tags)?).map_err(|_| ApiError::Internal)?;
+    let (category_id, category_name) =
+        enabled_category_assignment(db, request.category_id.as_deref()).await?;
     let (previous_version_id, version) =
         resource_revision(db, request.previous_version_id.as_deref()).await?;
     let timestamp = now();
@@ -382,6 +555,8 @@ pub async fn create_resource(
         content: Set(content),
         resource_type: Set(resource_type),
         tags_json: Set(tags_json),
+        category_id: Set(category_id),
+        category_name: Set(category_name),
         source_name: Set(source_name),
         source_url: Set(source_url),
         previous_version_id: Set(previous_version_id),
@@ -1077,6 +1252,26 @@ async fn write_learning_audit(
     .await
 }
 
+async fn append_category_event(
+    transaction: &sea_orm::DatabaseTransaction,
+    auth: &AuthenticatedUser,
+    category_id: &str,
+    event_type: &str,
+    reason: &str,
+) -> Result<(), ApiError> {
+    learning_category_review_events::Entity::insert(learning_category_review_events::ActiveModel {
+        id: Set(case_service::new_id()),
+        category_id: Set(category_id.to_owned()),
+        event_type: Set(event_type.to_owned()),
+        actor_user_id: Set(auth.id.clone()),
+        reason: Set(reason.to_owned()),
+        created_at: Set(now()),
+    })
+    .exec(transaction)
+    .await?;
+    Ok(())
+}
+
 async fn visible_question(
     db: &DatabaseConnection,
     auth: &AuthenticatedUser,
@@ -1139,6 +1334,25 @@ async fn resource_revision(
     Ok((Some(previous.id), previous.version + 1))
 }
 
+async fn enabled_category_assignment(
+    db: &DatabaseConnection,
+    category_id: Option<&str>,
+) -> Result<(Option<String>, Option<String>), ApiError> {
+    let Some(category_id) = category_id.map(str::trim).filter(|id| !id.is_empty()) else {
+        return Ok((None, None));
+    };
+    let category = learning_categories::Entity::find_by_id(category_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| ApiError::Validation("category_id does not exist".to_owned()))?;
+    if category.status != "enabled" {
+        return Err(ApiError::Validation(
+            "category_id is not enabled".to_owned(),
+        ));
+    }
+    Ok((Some(category.id), Some(category.name)))
+}
+
 async fn question_revision(
     db: &DatabaseConnection,
     previous_version_id: Option<&str>,
@@ -1181,11 +1395,32 @@ fn resource_response(
         content: resource.content,
         resource_type: resource.resource_type,
         tags: parse_string_array(&resource.tags_json)?,
+        category: match (resource.category_id, resource.category_name) {
+            (Some(id), Some(name)) => Some(LearningCategoryResponse {
+                id,
+                name,
+                // This is a historical resource snapshot. Its category may now
+                // be disabled, but that must not hide a previously published
+                // learning record.
+                status: "assigned".to_owned(),
+            }),
+            _ => None,
+        },
         source_name: resource.source_name,
         source_url: resource.source_url,
         previous_version_id: resource.previous_version_id,
         version: resource.version,
         effective_at: resource.effective_at,
+    })
+}
+
+fn category_response(
+    category: learning_categories::Model,
+) -> Result<LearningCategoryResponse, ApiError> {
+    Ok(LearningCategoryResponse {
+        id: category.id,
+        name: category.name,
+        status: category.status,
     })
 }
 
@@ -1423,6 +1658,14 @@ fn require_admin(auth: &AuthenticatedUser) -> Result<(), ApiError> {
         .ok_or_else(|| ApiError::Forbidden("只有管理员可以管理学习内容".to_owned()))
 }
 
+fn require_learner(auth: &AuthenticatedUser) -> Result<(), ApiError> {
+    (auth.account_type == AccountType::Learner)
+        .then_some(())
+        .ok_or_else(|| {
+            ApiError::Forbidden("only learner accounts may submit learning drafts".to_owned())
+        })
+}
+
 fn required_text(value: &str, field: &str, maximum: usize) -> Result<String, ApiError> {
     let value = value.trim();
     if value.is_empty() || value.chars().count() > maximum {
@@ -1448,12 +1691,31 @@ fn normalized_tags(tags: &[String]) -> Result<Vec<String>, ApiError> {
     }
     let tags: Vec<_> = tags
         .iter()
-        .map(|tag| required_text(tag, "tag", 64))
+        .map(|tag| normalized_name(tag, "tag", 64))
         .collect::<Result<_, _>>()?;
-    if tags.iter().collect::<HashSet<_>>().len() != tags.len() {
+    if tags
+        .iter()
+        .map(|tag| normalized_key(tag))
+        .collect::<HashSet<_>>()
+        .len()
+        != tags.len()
+    {
         return Err(ApiError::Validation("标签不能重复".to_owned()));
     }
     Ok(tags)
+}
+
+fn normalized_name(value: &str, field: &str, maximum: usize) -> Result<String, ApiError> {
+    let value = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    required_text(&value, field, maximum)
+}
+
+fn normalized_key(value: &str) -> String {
+    value
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
 }
 
 fn valid_timestamp(value: &str, field: &str) -> Result<String, ApiError> {

--- a/src/application/services/learning_service.rs
+++ b/src/application/services/learning_service.rs
@@ -3,8 +3,8 @@ use std::collections::{HashMap, HashSet};
 use chrono::{DateTime, SecondsFormat, Utc};
 use sea_orm::sea_query::{Expr, OnConflict};
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, IntoActiveModel, QueryFilter,
-    QueryOrder, Set, TransactionTrait, TryInsertResult,
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder, Set,
+    TransactionTrait, TryInsertResult,
 };
 use serde_json::json;
 
@@ -157,11 +157,11 @@ pub async fn propose_category(
     require_learner(auth)?;
     let name = normalized_name(&request.name, "category", 160)?;
     let reason = required_text(&request.submission_reason, "submission_reason", 1_000)?;
-    let id = case_service::new_id();
+    let requested_id = case_service::new_id();
     let timestamp = now();
     let transaction = db.begin().await?;
     let inserted = learning_categories::Entity::insert(learning_categories::ActiveModel {
-        id: Set(id.clone()),
+        id: Set(requested_id.clone()),
         name: Set(name.clone()),
         normalized_name: Set(normalized_key(&name)),
         status: Set("pending".to_owned()),
@@ -178,21 +178,55 @@ pub async fn propose_category(
     .do_nothing()
     .exec(&transaction)
     .await?;
-    if !matches!(inserted, TryInsertResult::Inserted(_)) {
-        return Err(ApiError::Conflict(
-            "category already exists or is awaiting review".to_owned(),
-        ));
-    }
+    let (id, name, audit_action) = if matches!(inserted, TryInsertResult::Inserted(_)) {
+        (requested_id, name, "learning_category.submitted")
+    } else {
+        let existing = learning_categories::Entity::find()
+            .filter(learning_categories::Column::NormalizedName.eq(normalized_key(&name)))
+            .one(&transaction)
+            .await?
+            .ok_or(ApiError::Internal)?;
+        match existing.status.as_str() {
+            "pending" => {
+                return Err(ApiError::Conflict(
+                    "category is already awaiting review".to_owned(),
+                ));
+            }
+            "enabled" => {
+                return Err(ApiError::Conflict("category is already enabled".to_owned()));
+            }
+            "rejected" | "disabled" => {
+                let update = learning_categories::Entity::update_many()
+                    .col_expr(learning_categories::Column::Status, Expr::value("pending"))
+                    .col_expr(
+                        learning_categories::Column::SubmittedByUserId,
+                        Expr::value(auth.id.clone()),
+                    )
+                    .col_expr(
+                        learning_categories::Column::ReviewedByUserId,
+                        Expr::value(Option::<String>::None),
+                    )
+                    .col_expr(
+                        learning_categories::Column::UpdatedAt,
+                        Expr::value(timestamp.clone()),
+                    )
+                    .filter(learning_categories::Column::Id.eq(&existing.id))
+                    .filter(learning_categories::Column::Status.eq(&existing.status))
+                    .exec(&transaction)
+                    .await?;
+                if update.rows_affected != 1 {
+                    return Err(ApiError::Conflict(
+                        "category lifecycle changed before the proposal could be resubmitted"
+                            .to_owned(),
+                    ));
+                }
+                (existing.id, existing.name, "learning_category.resubmitted")
+            }
+            _ => return Err(ApiError::Internal),
+        }
+    };
     append_category_event(&transaction, auth, &id, "submitted", &reason).await?;
-    write_learning_audit(
-        &transaction,
-        auth,
-        "learning_category.submitted",
-        &id,
-        0,
-        "training",
-    )
-    .await?;
+    write_learning_audit(&transaction, auth, audit_action, &id, 0, "training").await?;
     transaction.commit().await?;
     Ok(LearningCategoryResponse {
         id,
@@ -210,31 +244,42 @@ pub async fn transition_category(
 ) -> Result<LearningCategoryResponse, ApiError> {
     require_admin(auth)?;
     let reason = required_text(&request.reason, "reason", 1_000)?;
+    let (expected_status, status) = match action {
+        "enable" => ("pending", "enabled"),
+        "reject" => ("pending", "rejected"),
+        "disable" => ("enabled", "disabled"),
+        _ => return Err(ApiError::Validation("unknown category action".to_owned())),
+    };
+    let transaction = db.begin().await?;
     let category = learning_categories::Entity::find_by_id(category_id)
-        .one(db)
+        .one(&transaction)
         .await?
         .ok_or_else(|| ApiError::NotFound("learning category does not exist".to_owned()))?;
-    let permitted = matches!(
-        (category.status.as_str(), action),
-        ("pending", "enable") | ("pending", "reject") | ("enabled", "disable")
-    );
-    if !permitted {
+    if category.status != expected_status {
         return Err(ApiError::Conflict(
             "category lifecycle transition is not allowed".to_owned(),
         ));
     }
-    let status = match action {
-        "enable" => "enabled",
-        "reject" => "rejected",
-        "disable" => "disabled",
-        _ => return Err(ApiError::Validation("unknown category action".to_owned())),
-    };
-    let transaction = db.begin().await?;
-    let mut update = category.into_active_model();
-    update.status = Set(status.to_owned());
-    update.reviewed_by_user_id = Set(Some(auth.id.clone()));
-    update.updated_at = Set(now());
-    let category = update.update(&transaction).await?;
+    let update = learning_categories::Entity::update_many()
+        .col_expr(learning_categories::Column::Status, Expr::value(status))
+        .col_expr(
+            learning_categories::Column::ReviewedByUserId,
+            Expr::value(Some(auth.id.clone())),
+        )
+        .col_expr(learning_categories::Column::UpdatedAt, Expr::value(now()))
+        .filter(learning_categories::Column::Id.eq(&category.id))
+        .filter(learning_categories::Column::Status.eq(expected_status))
+        .exec(&transaction)
+        .await?;
+    if update.rows_affected != 1 {
+        return Err(ApiError::Conflict(
+            "category lifecycle changed before this transition could be applied".to_owned(),
+        ));
+    }
+    let category = learning_categories::Entity::find_by_id(category_id)
+        .one(&transaction)
+        .await?
+        .ok_or(ApiError::Internal)?;
     append_category_event(&transaction, auth, &category.id, status, &reason).await?;
     write_learning_audit(
         &transaction,

--- a/src/persistence/entities/learning_categories.rs
+++ b/src/persistence/entities/learning_categories.rs
@@ -1,0 +1,20 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "learning_categories")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub name: String,
+    pub normalized_name: String,
+    pub status: String,
+    pub submitted_by_user_id: String,
+    pub reviewed_by_user_id: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/persistence/entities/learning_category_review_events.rs
+++ b/src/persistence/entities/learning_category_review_events.rs
@@ -1,0 +1,18 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "learning_category_review_events")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub category_id: String,
+    pub event_type: String,
+    pub actor_user_id: String,
+    pub reason: String,
+    pub created_at: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/src/persistence/entities/learning_resources.rs
+++ b/src/persistence/entities/learning_resources.rs
@@ -10,6 +10,8 @@ pub struct Model {
     pub content: String,
     pub resource_type: String,
     pub tags_json: String,
+    pub category_id: Option<String>,
+    pub category_name: Option<String>,
     pub source_name: String,
     pub source_url: Option<String>,
     pub previous_version_id: Option<String>,

--- a/src/persistence/entities/mod.rs
+++ b/src/persistence/entities/mod.rs
@@ -22,6 +22,8 @@ pub mod intake_question_definitions;
 pub mod intake_session_answers;
 pub mod intake_session_photos;
 pub mod intake_sessions;
+pub mod learning_categories;
+pub mod learning_category_review_events;
 pub mod learning_content_review_events;
 pub mod learning_question_answers;
 pub mod learning_questions;

--- a/tests/api/learning_api.rs
+++ b/tests/api/learning_api.rs
@@ -916,6 +916,73 @@ async fn learner_category_proposals_gate_resource_drafts_and_keep_legacy_resourc
         test::read_body_json::<Value, _>(disabled_categories).await,
         json!([])
     );
+
+    let resubmitted_after_disable = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/learning/categories/proposals")
+            .insert_header((
+                header::AUTHORIZATION,
+                format!("Bearer {}", context.token(LEARNER).await),
+            ))
+            .set_json(json!({ "name": "safe orientation", "submission_reason": "The category is needed again for a revised newcomer curriculum." }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(resubmitted_after_disable.status(), StatusCode::CREATED);
+    let resubmitted_after_disable: Value = test::read_body_json(resubmitted_after_disable).await;
+    assert_eq!(resubmitted_after_disable["id"], category_id);
+    assert_eq!(resubmitted_after_disable["status"], "pending");
+
+    let duplicate_pending = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/learning/categories/proposals")
+            .insert_header((
+                header::AUTHORIZATION,
+                format!("Bearer {}", context.token(LEARNER).await),
+            ))
+            .set_json(json!({ "name": "Safe Orientation", "submission_reason": "This duplicate must remain pending only once." }))
+            .to_request(),
+    )
+    .await;
+    assert_error(duplicate_pending, StatusCode::CONFLICT, "conflict").await;
+
+    let reject_resubmission = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!(
+                "/api/admin/learning/categories/{category_id}/reject"
+            ))
+            .insert_header((
+                header::AUTHORIZATION,
+                format!("Bearer {}", context.token(ADMIN).await),
+            ))
+            .set_json(
+                json!({ "reason": "The revised curriculum still needs a narrower category." }),
+            )
+            .to_request(),
+    )
+    .await;
+    assert_eq!(reject_resubmission.status(), StatusCode::OK);
+
+    let resubmitted_after_rejection = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/learning/categories/proposals")
+            .insert_header((
+                header::AUTHORIZATION,
+                format!("Bearer {}", context.token(LEARNER).await),
+            ))
+            .set_json(json!({ "name": "SAFE ORIENTATION", "submission_reason": "A learner revised the proposal after administrator feedback." }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(resubmitted_after_rejection.status(), StatusCode::CREATED);
+    let resubmitted_after_rejection: Value =
+        test::read_body_json(resubmitted_after_rejection).await;
+    assert_eq!(resubmitted_after_rejection["id"], category_id);
+    assert_eq!(resubmitted_after_rejection["status"], "pending");
 }
 
 async fn grant_admin(context: &TestContext, email: &str) {

--- a/tests/api/learning_api.rs
+++ b/tests/api/learning_api.rs
@@ -777,6 +777,147 @@ async fn learning_content_requires_independent_governance_and_withdrawal_revokes
     assert_error(answer_after_withdrawal, StatusCode::NOT_FOUND, "not_found").await;
 }
 
+#[actix_web::test]
+async fn learner_category_proposals_gate_resource_drafts_and_keep_legacy_resources_compatible() {
+    let context = TestContext::new().await;
+    let app = crate::init_api_app!(&context);
+
+    let proposal = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/learning/categories/proposals")
+            .insert_header((header::AUTHORIZATION, format!("Bearer {}", context.token(LEARNER).await)))
+            .set_json(json!({ "name": "  Safe   Orientation  ", "submission_reason": "New learner material needs a governed category." }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(proposal.status(), StatusCode::CREATED);
+    let proposal: Value = test::read_body_json(proposal).await;
+    let category_id = proposal["id"].as_str().expect("category id").to_owned();
+    assert_eq!(proposal["name"], "Safe Orientation");
+    assert_eq!(proposal["status"], "pending");
+
+    let pending_categories = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/api/learning/categories")
+            .insert_header((
+                header::AUTHORIZATION,
+                format!("Bearer {}", context.token(LEARNER).await),
+            ))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(
+        test::read_body_json::<Value, _>(pending_categories).await,
+        json!([])
+    );
+
+    let enable = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!(
+                "/api/admin/learning/categories/{category_id}/enable"
+            ))
+            .insert_header((
+                header::AUTHORIZATION,
+                format!("Bearer {}", context.token(ADMIN).await),
+            ))
+            .set_json(json!({ "reason": "Category is suitable for newcomer training." }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(enable.status(), StatusCode::OK);
+
+    let draft = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/learning/resources/drafts")
+            .insert_header((
+                header::AUTHORIZATION,
+                format!("Bearer {}", context.token(LEARNER).await),
+            ))
+            .set_json(json!({
+                "title": "Newcomer safety notes",
+                "summary": "Synthetic training-only summary.",
+                "content": "Synthetic training-only body that contains no real case material.",
+                "resource_type": "manual",
+                "tags": [" Orientation ", "orientation"],
+                "category_id": category_id,
+                "source_name": "Synthetic source",
+                "source_url": null,
+                "visibility": "learner",
+                "effective_at": "2020-01-01T00:00:00.000Z",
+                "permitted_use": "training",
+                "submission_reason": "A learner contributed a draft for independent review."
+            }))
+            .to_request(),
+    )
+    .await;
+    assert_error(draft, StatusCode::BAD_REQUEST, "validation_error").await;
+
+    let valid_draft = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri("/api/learning/resources/drafts")
+            .insert_header((
+                header::AUTHORIZATION,
+                format!("Bearer {}", context.token(LEARNER).await),
+            ))
+            .set_json(json!({
+                "title": "Newcomer safety notes",
+                "summary": "Synthetic training-only summary.",
+                "content": "Synthetic training-only body that contains no real case material.",
+                "resource_type": "manual",
+                "tags": [" Orientation "],
+                "category_id": category_id,
+                "source_name": "Synthetic source",
+                "source_url": null,
+                "visibility": "learner",
+                "effective_at": "2020-01-01T00:00:00.000Z",
+                "permitted_use": "training",
+                "submission_reason": "A learner contributed a draft for independent review."
+            }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(valid_draft.status(), StatusCode::CREATED);
+    let valid_draft: Value = test::read_body_json(valid_draft).await;
+    assert_eq!(valid_draft["category"]["name"], "Safe Orientation");
+    assert_eq!(valid_draft["lifecycle"]["state"], "submitted");
+
+    let disabled = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!(
+                "/api/admin/learning/categories/{category_id}/disable"
+            ))
+            .insert_header((
+                header::AUTHORIZATION,
+                format!("Bearer {}", context.token(ADMIN).await),
+            ))
+            .set_json(json!({ "reason": "Temporarily remove this selection from new drafts." }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(disabled.status(), StatusCode::OK);
+    let disabled_categories = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri("/api/learning/categories")
+            .insert_header((
+                header::AUTHORIZATION,
+                format!("Bearer {}", context.token(LEARNER).await),
+            ))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(
+        test::read_body_json::<Value, _>(disabled_categories).await,
+        json!([])
+    );
+}
+
 async fn grant_admin(context: &TestContext, email: &str) {
     context
         .database

--- a/tests/api/openapi_intake_contract.rs
+++ b/tests/api/openapi_intake_contract.rs
@@ -678,6 +678,55 @@ fn learning_governance_openapi_contract_documents_versions_and_independent_actio
 }
 
 #[test]
+fn learning_category_openapi_contract_matches_explicit_transition_routes() {
+    for (path, operation_id, summary) in [
+        (
+            "/api/admin/learning/categories/{category_id}/enable:\n",
+            "operationId: enableLearningCategory",
+            "Enable a pending learning category",
+        ),
+        (
+            "/api/admin/learning/categories/{category_id}/reject:\n",
+            "operationId: rejectLearningCategory",
+            "Reject a pending learning category",
+        ),
+        (
+            "/api/admin/learning/categories/{category_id}/disable:\n",
+            "operationId: disableLearningCategory",
+            "Disable an enabled learning category",
+        ),
+    ] {
+        let operation = operation(path);
+        for expected in [
+            "post:",
+            operation_id,
+            summary,
+            "name: category_id",
+            "x-global-capabilities: [admin]",
+            "#/components/schemas/LearningContentActionRequest",
+            "#/components/schemas/LearningCategory",
+        ] {
+            assert!(
+                operation.contains(expected),
+                "OpenAPI category operation {path} must declare {expected:?}"
+            );
+        }
+        assert!(
+            !operation.contains("name: action"),
+            "explicit category route {path} must not expose a synthetic action path parameter"
+        );
+    }
+    assert_schema_contains(
+        "LearningCategory",
+        &[
+            "status:",
+            "enum: [pending, enabled, rejected, disabled, assigned]",
+        ],
+    );
+    assert_schema_contains("CreateLearningResourceRequest", &["category_id:", "tags:"]);
+}
+
+#[test]
 fn clue_attachment_openapi_contract_keeps_evidence_case_restricted() {
     let attachment_operation = operation("/api/clues/{clue_id}/attachments:\n");
     for expected in [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能
- 学习中心新增分类与标签筛选，并展示资源分类信息。
- 学习者可提交资源草稿及分类申请。
- 管理员可查看分类，并执行启用、驳回或停用操作。
- 新增分类规范化、重复标签校验及分类状态治理。
- 资源支持按分类和标签筛选，分类停用不影响历史资源展示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->