### PR TITLE
fix(preview): rebuild runtime image with HEIC decoder

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -88,6 +88,37 @@ jobs:
           # bootstrap command's 12-256 character requirement without escaping.
           printf 'password=%s\n' "$(openssl rand -hex 24)" >> "${GITHUB_OUTPUT}"
 
+      - name: Refresh preview runtime image
+        shell: bash
+        env:
+          PREVIEW_RUNTIME_IMAGE: ${{ vars.PREVIEW_RUNTIME_IMAGE || 'angui-preview-runtime:bookworm' }}
+        run: |
+          set -euo pipefail
+          docker build --pull --file - --tag "${PREVIEW_RUNTIME_IMAGE}" "${GITHUB_WORKSPACE}/deploy/preview" <<'EOF'
+          FROM debian:bookworm-slim
+
+          RUN apt-get update \
+              && apt-get install -y --no-install-recommends ca-certificates curl libde265-0 \
+              && rm -rf /var/lib/apt/lists/* \
+              && useradd --create-home --uid 10001 angui \
+              && install -d -o angui -g angui /app/data
+
+          WORKDIR /app
+
+          ENV ANGUI_HOST=0.0.0.0 \
+              ANGUI_PORT=8080 \
+              ANGUI_FRONTEND_ORIGIN=http://localhost:8080 \
+              DATABASE_URL=sqlite://data/angui.db?mode=rwc \
+              RUST_LOG=info
+
+          USER angui
+          EXPOSE 8080
+          HEALTHCHECK --interval=15s --timeout=3s --start-period=10s --retries=5 \
+            CMD curl --fail --silent http://127.0.0.1:8080/api/health >/dev/null || exit 1
+
+          CMD ["angui"]
+          EOF
+
       - name: Deploy pull request preview locally
         shell: bash
         env:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -80,6 +80,37 @@ jobs:
           set -euo pipefail
           printf 'password=%s\n' "$(openssl rand -hex 24)" >> "${GITHUB_OUTPUT}"
 
+      - name: Refresh preview runtime image
+        shell: bash
+        env:
+          PREVIEW_RUNTIME_IMAGE: ${{ vars.PREVIEW_RUNTIME_IMAGE || 'angui-preview-runtime:bookworm' }}
+        run: |
+          set -euo pipefail
+          docker build --pull --file - --tag "${PREVIEW_RUNTIME_IMAGE}" "${GITHUB_WORKSPACE}/deploy/preview" <<'EOF'
+          FROM debian:bookworm-slim
+
+          RUN apt-get update \
+              && apt-get install -y --no-install-recommends ca-certificates curl libde265-0 \
+              && rm -rf /var/lib/apt/lists/* \
+              && useradd --create-home --uid 10001 angui \
+              && install -d -o angui -g angui /app/data
+
+          WORKDIR /app
+
+          ENV ANGUI_HOST=0.0.0.0 \
+              ANGUI_PORT=8080 \
+              ANGUI_FRONTEND_ORIGIN=http://localhost:8080 \
+              DATABASE_URL=sqlite://data/angui.db?mode=rwc \
+              RUST_LOG=info
+
+          USER angui
+          EXPOSE 8080
+          HEALTHCHECK --interval=15s --timeout=3s --start-period=10s --retries=5 \
+            CMD curl --fail --silent http://127.0.0.1:8080/api/health >/dev/null || exit 1
+
+          CMD ["angui"]
+          EOF
+
       - name: Deploy branch preview locally
         shell: bash
         env:


### PR DESCRIPTION
## Summary\n- rebuild the trusted preview runtime image before branch and PR deployments\n- include the libde265 runtime decoder required by HEIC-enabled release artifacts\n- preserve the existing runtime user, environment, health check, and command\n\n## Verification\n- git diff --check\n\nThis PR changes only .github preview workflows. Deployment tooling remains checked out from the trusted default branch; no PR deployment scripts or Dockerfiles are executed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化预览环境部署流程，自动构建并刷新运行时镜像。
  * 预览服务现具备健康检查、端口配置及必要运行环境。
  * 运行时服务改用非 root 权限启动，提升预览环境安全性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->