### PR TITLE
fix(preview): use compatible C++ runtime

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           set -euo pipefail
           docker build --pull --file - --tag "${PREVIEW_RUNTIME_IMAGE}" "${GITHUB_WORKSPACE}/deploy/preview" <<'EOF'
-          FROM debian:bookworm-slim
+          FROM ubuntu:24.04
 
           RUN apt-get update \
               && apt-get install -y --no-install-recommends ca-certificates curl libde265-0 \

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           set -euo pipefail
           docker build --pull --file - --tag "${PREVIEW_RUNTIME_IMAGE}" "${GITHUB_WORKSPACE}/deploy/preview" <<'EOF'
-          FROM debian:bookworm-slim
+          FROM ubuntu:24.04
 
           RUN apt-get update \
               && apt-get install -y --no-install-recommends ca-certificates curl libde265-0 \


### PR DESCRIPTION
## Summary\n- use Ubuntu 24.04 for the trusted preview runtime image\n- provide the GLIBCXX_3.4.31 ABI required by CI-built HEIC-enabled binaries\n- retain the libde265 runtime decoder added by #198\n\n## Verification\n- git diff --check\n\nThis PR changes only the branch and pull-request preview workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 更新预览环境的运行时基础镜像，以提升环境兼容性与稳定性。
  - 预览构建、运行及部署流程保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->