### PR TITLE
fix: 对齐 OpenAPI 并完善 intake AI follow-up 契约

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -401,6 +401,28 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /api/intake-sessions/{session_id}/ai-follow-up:
+    parameters:
+      - $ref: "#/components/parameters/IntakeSessionId"
+    get:
+      tags: [Intake sessions]
+      operationId: getIntakeAiFollowUp
+      summary: Get one optional AI-guided intake follow-up
+      description: Only the session creator can request an optional phase-two follow-up. Required phase-one collection always remains rule-based. The service returns an AI-generated question only when its JSON passes the configured field, length, and skippability checks; unavailable providers, timeouts, policy failures, and invalid output return the deterministic static question. The response is advisory only and does not create, confirm, publish, or modify any intake data.
+      security: [{ bearerAuth: [] }]
+      x-account-types: [member]
+      x-data-classification: sensitive
+      responses:
+        "200":
+          description: Optional AI follow-up, a deterministic fallback, or no question when optional follow-up is not applicable
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/IntakeAiFollowUpResponse" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
   /api/intake-sessions/{session_id}/confirm:
     parameters:
       - $ref: "#/components/parameters/IntakeSessionId"
@@ -3114,6 +3136,34 @@ components:
         generated_at: { type: string, format: date-time }
         requires_family_acknowledgement: { type: boolean }
         ready_for_second_confirmation: { type: boolean }
+
+    IntakeAiFollowUp:
+      type: object
+      additionalProperties: false
+      required: [field, prompt, purpose, missing_fields, skippable]
+      properties:
+        field: { type: string, minLength: 1 }
+        prompt: { type: string, minLength: 1, maxLength: 500 }
+        purpose: { type: string, minLength: 1, maxLength: 300 }
+        missing_fields:
+          type: array
+          uniqueItems: true
+          items: { type: string }
+        skippable: { type: boolean, const: true }
+
+    IntakeAiFollowUpResponse:
+      type: object
+      additionalProperties: false
+      required: [question, degradation_status, generated_at]
+      properties:
+        question:
+          oneOf:
+            - { $ref: "#/components/schemas/IntakeAiFollowUp" }
+            - { type: "null" }
+        degradation_status:
+          type: string
+          enum: [available, rule_based_fallback, not_applicable]
+        generated_at: { type: string, format: date-time }
 
     ConfirmedIntakeProfile:
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -38,6 +38,8 @@ tags:
     description: 服务健康检查
   - name: Authentication
     description: 服务端会话登录、查询和撤销
+  - name: Access requests
+    description: 账号访问申请、邮箱验证、管理员审核和密码设置
   - name: Cases
     description: 案件、老人资料、案件成员和案件内线索；必须先通过案件成员关系授权
   - name: Clues
@@ -189,6 +191,65 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "500":
           $ref: "#/components/responses/InternalError"
+
+  /api/auth/access-requests:
+    post:
+      tags: [Access requests]
+      operationId: createAccessRequest
+      summary: 提交账号访问申请
+      description: 无需认证。服务端对邮箱地址返回一致的受理消息，并发送有效期为 24 小时的邮箱验证链接；原始验证令牌只会出现在邮件中，数据库只保存其哈希值。
+      security: []
+      x-account-types: []
+      x-data-classification: account-private
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/CreateAccessRequest" }
+      responses:
+        "200": { description: 申请已受理，等待邮箱验证, content: { application/json: { schema: { $ref: "#/components/schemas/AccessRequestReceipt" } } } }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
+  /api/auth/access-requests/verify:
+    post:
+      tags: [Access requests]
+      operationId: verifyAccessRequest
+      summary: 验证账号访问申请邮箱
+      description: 无需认证。验证令牌仅可使用一次，且在签发 24 小时后失效；验证成功后，申请进入管理员人工审核队列。
+      security: []
+      x-account-types: []
+      x-data-classification: account-private
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/VerifyAccessRequest" }
+      responses:
+        "200": { description: 邮箱已验证，申请等待人工审核, content: { application/json: { schema: { $ref: "#/components/schemas/AccessRequestReceipt" } } } }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
+  /api/auth/password-setup:
+    post:
+      tags: [Access requests]
+      operationId: setPassword
+      summary: 使用审核通过后的链接设置密码
+      description: 无需认证。仅接受管理员批准后签发的一次性密码设置令牌；密码长度必须为 12 至 256 个字符。成功后账户激活，令牌立即失效。
+      security: []
+      x-account-types: []
+      x-data-classification: account-private
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/PasswordSetupRequest" }
+      responses:
+        "204": { description: 密码已设置，账户已激活 }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "500": { $ref: "#/components/responses/InternalError" }
 
   /api/users/me/profile:
     get:
@@ -1711,6 +1772,52 @@ paths:
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
 
+  /api/admin/access-requests:
+    get:
+      tags: [Access requests]
+      operationId: listAccessRequests
+      summary: 列出账号访问申请
+      description: 仅平台管理员可调用。返回申请审核所需的账号信息和邮箱验证状态，不返回验证令牌、审核理由或密码相关数据。
+      security: [{ bearerAuth: [] }]
+      x-account-types: [member]
+      x-global-capabilities: [admin]
+      x-data-classification: restricted-admin
+      responses:
+        "200": { description: 按创建时间倒序的账号访问申请列表, content: { application/json: { schema: { type: array, items: { $ref: "#/components/schemas/AdminAccessRequest" } } } } }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
+  /api/admin/access-requests/{request_id}/review:
+    parameters:
+      - name: request_id
+        in: path
+        required: true
+        description: 账号访问申请 UUID。
+        schema: { type: string, format: uuid }
+    patch:
+      tags: [Access requests]
+      operationId: reviewAccessRequest
+      summary: 审核账号访问申请
+      description: 仅平台管理员可调用，且申请必须已完成邮箱验证并处于 `pending_review`。批准时服务端创建停用账户并发送一次性密码设置链接；拒绝时必须提供审核理由。管理员不能通过该接口授予管理员能力。
+      security: [{ bearerAuth: [] }]
+      x-account-types: [member]
+      x-global-capabilities: [admin]
+      x-data-classification: restricted-admin
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/ReviewAccessRequest" }
+      responses:
+        "200": { description: 已审核的账号访问申请, content: { application/json: { schema: { $ref: "#/components/schemas/AdminAccessRequest" } } } }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { $ref: "#/components/responses/Conflict" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
   /api/admin/users:
     get:
       tags: [Admin]
@@ -2470,6 +2577,98 @@ components:
                   message: database operation failed
 
   schemas:
+    CreateAccessRequest:
+      type: object
+      additionalProperties: false
+      required: [email, display_name, requested_role]
+      properties:
+        email:
+          type: string
+          minLength: 3
+          maxLength: 320
+          format: email
+          description: 申请人的邮箱地址；服务端会去除首尾空白并转换为小写。
+        display_name:
+          type: string
+          minLength: 1
+          maxLength: 120
+          description: 申请人的显示名称。
+        requested_role:
+          type: string
+          enum: [family, volunteer, commander]
+          description: 申请的业务角色；不支持通过申请授予管理员能力。
+
+    VerifyAccessRequest:
+      type: object
+      additionalProperties: false
+      required: [token]
+      properties:
+        token:
+          type: string
+          minLength: 1
+          description: 邮件中的一次性邮箱验证令牌。
+
+    PasswordSetupRequest:
+      type: object
+      additionalProperties: false
+      required: [token, password]
+      properties:
+        token:
+          type: string
+          minLength: 1
+          description: 管理员批准后邮件中的一次性密码设置令牌。
+        password:
+          type: string
+          minLength: 12
+          maxLength: 256
+          format: password
+          description: 新密码；服务端仅校验长度，不会在响应或审计元数据中返回该值。
+
+    AccessRequestReceipt:
+      type: object
+      additionalProperties: false
+      required: [id, status, message]
+      properties:
+        id: { type: string, format: uuid }
+        status:
+          type: string
+          enum: [pending_verification, pending_review]
+        message:
+          type: string
+          description: 面向申请人的中文状态提示；不用于判定邮箱或账号是否存在。
+
+    ReviewAccessRequest:
+      type: object
+      additionalProperties: false
+      required: [action]
+      properties:
+        action:
+          type: string
+          enum: [approve, reject]
+        role:
+          type: string
+          enum: [family, volunteer, commander]
+          description: 批准时可替代申请角色；省略时使用申请的角色。
+        reason:
+          type: [string, "null"]
+          minLength: 1
+          description: 拒绝时必填的人工审核理由；批准时可选。
+
+    AdminAccessRequest:
+      type: object
+      additionalProperties: false
+      required: [id, email, display_name, requested_role, status, email_verified_at, created_at]
+      properties:
+        id: { type: string, format: uuid }
+        email: { type: string, format: email }
+        display_name: { type: string }
+        requested_role: { type: string, enum: [family, volunteer, commander] }
+        status:
+          type: string
+          enum: [pending_verification, pending_review, approved, rejected]
+        email_verified_at: { type: [string, "null"], format: date-time }
+        created_at: { type: string, format: date-time }
+
     LearningResource:
       type: object
       additionalProperties: false

--- a/frontend/src/pages/FamilyIntakeForm.test.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.test.tsx
@@ -630,6 +630,38 @@ describe("FamilyIntakeForm", () => {
     );
   });
 
+  it("keeps the saved rule-based question when AI follow-up is unavailable", async () => {
+    window.sessionStorage.setItem(
+      "angui:intake-tab-draft:family-1",
+      JSON.stringify({ session: phaseTwoSession, answer: "" }),
+    );
+    mocked.submitIntakeAnswer.mockResolvedValue(answerResponse(phaseTwoSession));
+    mocked.getIntakeAiFollowUp.mockRejectedValue(new Error("AI guidance unavailable"));
+
+    render(
+      <FamilyIntakeForm
+        onCancel={vi.fn()}
+        onConfirmed={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    fireEvent.change(await screen.findByRole("textbox"), {
+      target: { value: "社区公园" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "保存并继续" }));
+
+    await waitFor(() =>
+      expect(mocked.getIntakeAiFollowUp).toHaveBeenCalledWith(
+        "family-session",
+        "intake-1",
+      ),
+    );
+    expect(
+      await screen.findByRole("heading", { name: "常去地点" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
   it("keeps v2 sessions free of the v3 photo requirement", async () => {
     window.sessionStorage.setItem(
       "angui:intake-tab-draft:family-1",

--- a/frontend/src/pages/FamilyIntakeForm.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.tsx
@@ -608,26 +608,28 @@ export function FamilyIntakeForm({
       let guidedSession = next;
       if (!isPhaseOneIntakeField(field, session.question_set_version)) {
         setIsFetchingAiFollowUp(true);
-        let guidance: IntakeAiFollowUpResponse;
         try {
-          guidance = await getIntakeAiFollowUp(token, next.id);
+          const guidance: IntakeAiFollowUpResponse = await getIntakeAiFollowUp(token, next.id);
+          guidedSession = guidance.question
+            ? {
+                ...next,
+                next_question: {
+                  field: guidance.question.field,
+                  prompt: guidance.question.prompt,
+                  required: false,
+                },
+                guidance_mode:
+                  guidance.degradation_status === "available"
+                    ? ("ai_assisted" as const)
+                    : ("rule_based" as const),
+              }
+            : next;
+        } catch {
+          // The answer has already been accepted. Keep the server's rule-based
+          // next question when optional AI guidance cannot be fetched.
         } finally {
           setIsFetchingAiFollowUp(false);
         }
-        guidedSession = guidance.question
-          ? {
-              ...next,
-              next_question: {
-                field: guidance.question.field,
-                prompt: guidance.question.prompt,
-                required: false,
-              },
-              guidance_mode:
-                guidance.degradation_status === "available"
-                  ? ("ai_assisted" as const)
-                  : ("rule_based" as const),
-            }
-          : next;
       }
       setSession(guidedSession);
       setInitialReview(null);

--- a/src/application/services/access_request_service.rs
+++ b/src/application/services/access_request_service.rs
@@ -121,13 +121,9 @@ pub async fn verify(db: &DatabaseConnection, raw: &str) -> Result<AccessRequestR
         .filter(auth_email_tokens::Column::ConsumedAt.is_null())
         .one(db)
         .await?
-        .ok_or_else(|| {
-            ApiError::Unauthorized("verification link is invalid or expired".to_owned())
-        })?;
+        .ok_or_else(|| ApiError::Unauthorized("验证链接无效或已过期".to_owned()))?;
     if token.expires_at <= now() {
-        return Err(ApiError::Unauthorized(
-            "verification link is invalid or expired".to_owned(),
-        ));
+        return Err(ApiError::Unauthorized("验证链接无效或已过期".to_owned()));
     }
     let request_id = token.access_request_id.clone().ok_or(ApiError::Internal)?;
     let transaction = db.begin().await?;
@@ -185,21 +181,21 @@ pub async fn review(
     let action = input.action.trim().to_lowercase();
     if !["approve", "reject"].contains(&action.as_str()) {
         return Err(ApiError::Validation(
-            "action must be approve or reject".to_owned(),
+            "action 必须为 approve 或 reject".to_owned(),
         ));
     }
     if action == "reject" && input.reason.as_deref().unwrap_or("").trim().is_empty() {
         return Err(ApiError::Validation(
-            "rejection reason is required".to_owned(),
+            "拒绝申请时必须提供审核理由".to_owned(),
         ));
     }
     let request = access_requests::Entity::find_by_id(id)
         .one(db)
         .await?
-        .ok_or_else(|| ApiError::NotFound("access request was not found".to_owned()))?;
+        .ok_or_else(|| ApiError::NotFound("未找到账号访问申请".to_owned()))?;
     if request.status != "pending_review" {
         return Err(ApiError::Conflict(
-            "access request is not awaiting review".to_owned(),
+            "账号访问申请当前不处于待审核状态".to_owned(),
         ));
     }
     let transaction = db.begin().await?;
@@ -304,7 +300,7 @@ pub async fn set_password(
 ) -> Result<(), ApiError> {
     if !(12..=256).contains(&input.password.chars().count()) {
         return Err(ApiError::Validation(
-            "password must contain between 12 and 256 characters".to_owned(),
+            "密码长度必须为 12 至 256 个字符".to_owned(),
         ));
     }
     let token = auth_email_tokens::Entity::find()
@@ -313,12 +309,10 @@ pub async fn set_password(
         .filter(auth_email_tokens::Column::ConsumedAt.is_null())
         .one(db)
         .await?
-        .ok_or_else(|| {
-            ApiError::Unauthorized("password setup link is invalid or expired".to_owned())
-        })?;
+        .ok_or_else(|| ApiError::Unauthorized("密码设置链接无效或已过期".to_owned()))?;
     if token.expires_at <= now() {
         return Err(ApiError::Unauthorized(
-            "password setup link is invalid or expired".to_owned(),
+            "密码设置链接无效或已过期".to_owned(),
         ));
     }
     let user_id = token.user_id.clone().ok_or(ApiError::Internal)?;
@@ -345,29 +339,27 @@ fn role_mapping(role: &str) -> Result<(AccountType, Vec<GlobalCapability>), ApiE
         "family" => Ok((AccountType::Member, vec![])),
         "volunteer" => Ok((AccountType::Member, vec![GlobalCapability::Volunteer])),
         "commander" => Ok((AccountType::Member, vec![GlobalCapability::Commander])),
-        _ => Err(ApiError::Validation("role is unsupported".to_owned())),
+        _ => Err(ApiError::Validation("不支持该角色".to_owned())),
     }
 }
 fn require_admin(auth: &AuthenticatedUser) -> Result<(), ApiError> {
     if auth.global_capabilities.contains(&GlobalCapability::Admin) {
         Ok(())
     } else {
-        Err(ApiError::Forbidden(
-            "administrator capability is required".to_owned(),
-        ))
+        Err(ApiError::Forbidden("需要管理员能力".to_owned()))
     }
 }
 fn normalize_email(v: &str) -> Result<String, ApiError> {
     let v = v.trim().to_lowercase();
     if v.is_empty() || v.len() > 320 || !v.contains('@') {
-        Err(ApiError::Validation("email is invalid".to_owned()))
+        Err(ApiError::Validation("邮箱格式无效".to_owned()))
     } else {
         Ok(v)
     }
 }
 fn validate_name(v: &str) -> Result<(), ApiError> {
     if v.trim().is_empty() || v.chars().count() > 120 {
-        Err(ApiError::Validation("display_name is invalid".to_owned()))
+        Err(ApiError::Validation("显示名称无效".to_owned()))
     } else {
         Ok(())
     }
@@ -376,7 +368,7 @@ fn validate_role(v: &str) -> Result<(), ApiError> {
     if ["family", "volunteer", "commander"].contains(&v.trim().to_lowercase().as_str()) {
         Ok(())
     } else {
-        Err(ApiError::Validation("role is unsupported".to_owned()))
+        Err(ApiError::Validation("不支持该角色".to_owned()))
     }
 }
 fn token() -> String {

--- a/src/application/services/intake_session_service.rs
+++ b/src/application/services/intake_session_service.rs
@@ -759,18 +759,22 @@ pub async fn get_ai_follow_up(
         .await?
         .ok_or_else(|| ApiError::NotFound("intake session was not found".to_owned()))?;
     require_session_creator(&session, auth)?;
+    if !can_request_ai_follow_up(&session.status) {
+        return Ok(IntakeAiFollowUpResponse {
+            question: None,
+            degradation_status: "not_applicable".to_owned(),
+            generated_at: now(),
+        });
+    }
     let questions = questions_for_version(db, session.question_set_version).await?;
     let answers = parse_answers(&session)?;
     let missing = missing_fields(&answers, &questions);
-    let fallback = next_question_for_phase(
-        &questions,
-        &missing,
-        &IntakePhaseProgress::for_answers(&answers, session.question_set_version),
-    );
+    let phase = IntakePhaseProgress::for_answers(&answers, session.question_set_version);
+    let fallback = next_optional_follow_up_question(&questions, &missing, &phase);
     let Some(fallback) = fallback else {
         return Ok(IntakeAiFollowUpResponse {
             question: None,
-            degradation_status: "rule_based_complete".to_owned(),
+            degradation_status: "not_applicable".to_owned(),
             generated_at: now(),
         });
     };
@@ -799,11 +803,20 @@ pub async fn get_ai_follow_up(
     let (question, degradation_status, _audit_status) = match execution {
         AiExecutionResult::Completed { output, .. } => {
             match gateway.decode_json::<IntakeAiFollowUp>(&output) {
-                Ok(question) if valid_follow_up(&question, &missing, &questions) => (
-                    Some(normalize_follow_up(question)),
-                    "available".to_owned(),
-                    AiTaskStatus::Completed,
-                ),
+                Ok(question)
+                    if valid_follow_up(
+                        &question,
+                        &missing,
+                        &questions,
+                        session.question_set_version,
+                    ) =>
+                {
+                    (
+                        Some(normalize_follow_up(question)),
+                        "available".to_owned(),
+                        AiTaskStatus::Completed,
+                    )
+                }
                 _ => (
                     Some(static_follow_up(fallback, missing.clone())),
                     "rule_based_fallback".to_owned(),
@@ -905,16 +918,20 @@ fn valid_follow_up(
     question: &IntakeAiFollowUp,
     missing: &[String],
     questions: &[intake_question_definitions::Model],
+    question_set_version: i32,
 ) -> bool {
     question.skippable
         && missing.contains(&question.field)
-        && questions
-            .iter()
-            .any(|definition| definition.field_code == question.field)
+        && questions.iter().any(|definition| {
+            definition.field_code == question.field
+                && !definition.is_required
+                && question_phase(&definition.field_code, question_set_version) == "phase_two"
+        })
         && !question.prompt.trim().is_empty()
         && question.prompt.chars().count() <= 500
         && !question.purpose.trim().is_empty()
         && question.purpose.chars().count() <= 300
+        && question.missing_fields.contains(&question.field)
         && question
             .missing_fields
             .iter()
@@ -1843,6 +1860,10 @@ fn require_session_creator(
     Ok(())
 }
 
+fn can_request_ai_follow_up(status: &str) -> bool {
+    matches!(status, "collecting" | "ready_for_confirmation")
+}
+
 fn parse_answers(session: &intake_sessions::Model) -> Result<IntakeInitialAnswers, ApiError> {
     serde_json::from_str(&session.answers_json).map_err(|_| ApiError::Internal)
 }
@@ -2208,6 +2229,31 @@ fn next_question_for_phase(
         })
 }
 
+/// AI follow-up is deliberately limited to optional phase-two intake fields.
+/// Required collection remains deterministic so an unavailable provider never
+/// changes the path to first human confirmation.
+fn next_optional_follow_up_question(
+    questions: &[intake_question_definitions::Model],
+    missing_fields: &[String],
+    phase: &IntakePhaseProgress,
+) -> Option<IntakeQuestion> {
+    if !phase.phase_transition_ready {
+        return None;
+    }
+    questions
+        .iter()
+        .find(|question| {
+            !question.is_required
+                && question_phase(&question.field_code, question.version) == "phase_two"
+                && missing_fields.contains(&question.field_code)
+        })
+        .map(|question| IntakeQuestion {
+            field: question.field_code.clone(),
+            prompt: question.prompt.clone(),
+            required: false,
+        })
+}
+
 fn missing_fields(
     answers: &IntakeInitialAnswers,
     questions: &[intake_question_definitions::Model],
@@ -2441,11 +2487,13 @@ fn now() -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        InitialReviewModelIssue, InitialReviewModelOutput, IntakeInitialAnswers, answers_for_ai,
-        append_content_quality_issues, decode_profile_extraction_output, profile_extraction_schema,
-        profile_extraction_system_instruction, validate_basic_information_details,
+        InitialReviewModelIssue, InitialReviewModelOutput, IntakeAiFollowUp, IntakeInitialAnswers,
+        answers_for_ai, append_content_quality_issues, can_request_ai_follow_up,
+        decode_profile_extraction_output, profile_extraction_schema,
+        profile_extraction_system_instruction, valid_follow_up, validate_basic_information_details,
         validate_initial_review_output, validate_profile_extraction,
     };
+    use crate::entities::intake_question_definitions;
 
     fn answers() -> IntakeInitialAnswers {
         IntakeInitialAnswers {
@@ -2627,5 +2675,49 @@ mod tests {
         assert_eq!(issues.len(), 1);
         assert_eq!(issues[0].field, "basic_information");
         assert!(issues[0].evidence_summary.contains("信息不足"));
+    }
+
+    #[test]
+    fn follow_up_rejects_required_or_unknown_fields_from_a_provider() {
+        let questions = vec![intake_question_definitions::Model {
+            id: "intake-q-test".to_owned(),
+            version: 2,
+            field_code: "frequent_locations".to_owned(),
+            prompt: "Which places are frequently visited?".to_owned(),
+            display_order: 1,
+            is_required: false,
+            max_answer_chars: 800,
+            status: "active".to_owned(),
+            created_at: "2026-08-14T00:00:00Z".to_owned(),
+            updated_at: "2026-08-14T00:00:00Z".to_owned(),
+        }];
+        let missing = vec!["frequent_locations".to_owned()];
+        let valid = IntakeAiFollowUp {
+            field: "frequent_locations".to_owned(),
+            prompt: "Which places are frequently visited?".to_owned(),
+            purpose: "Collect an optional location for human review.".to_owned(),
+            missing_fields: missing.clone(),
+            skippable: true,
+        };
+
+        assert!(valid_follow_up(&valid, &missing, &questions, 2));
+
+        let mut required = valid.clone();
+        required.skippable = false;
+        assert!(!valid_follow_up(&required, &missing, &questions, 2));
+
+        let mut unknown = valid;
+        unknown.field = "family_phone".to_owned();
+        assert!(!valid_follow_up(&unknown, &missing, &questions, 2));
+    }
+
+    #[test]
+    fn follow_up_is_available_only_while_collecting_or_ready_for_confirmation() {
+        assert!(can_request_ai_follow_up("collecting"));
+        assert!(can_request_ai_follow_up("ready_for_confirmation"));
+        assert!(!can_request_ai_follow_up("awaiting_family_review"));
+        assert!(!can_request_ai_follow_up("ready_for_second_confirmation"));
+        assert!(!can_request_ai_follow_up("confirmed"));
+        assert!(!can_request_ai_follow_up("closed"));
     }
 }

--- a/tests/api/intake_session_ai_follow_up_get.rs
+++ b/tests/api/intake_session_ai_follow_up_get.rs
@@ -1,0 +1,121 @@
+use actix_web::{
+    http::{StatusCode, header},
+    test,
+};
+use serde_json::Value;
+
+use angui::{
+    models::{CreateIntakeSessionRequest, IntakeInitialAnswers},
+    services::intake_session_service,
+};
+
+use crate::support::{COMMANDER, FAMILY, TestContext, assert_error};
+
+async fn create_session(context: &TestContext, answers: IntakeInitialAnswers) -> String {
+    let family = context.authenticated(FAMILY).await;
+    intake_session_service::create_intake_session(
+        &context.database,
+        &family,
+        CreateIntakeSessionRequest {
+            initial_answers: answers,
+        },
+        2_000,
+    )
+    .await
+    .expect("fixture intake session should be created")
+    .id
+}
+
+#[actix_web::test]
+async fn get_ai_follow_up_returns_a_static_optional_phase_two_question_when_ai_is_unavailable() {
+    let context = TestContext::new().await;
+    let session_id = create_session(
+        &context,
+        IntakeInitialAnswers {
+            basic_information: Some("Fictional elder profile".to_owned()),
+            health_status: Some("No known health notes".to_owned()),
+            behavior_habits: Some("Enjoys a daily walk".to_owned()),
+            last_seen: Some("Fictional community gate".to_owned()),
+            ..Default::default()
+        },
+    )
+    .await;
+    let token = context.token(FAMILY).await;
+    let app = crate::init_api_app!(&context);
+
+    let response = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/intake-sessions/{session_id}/ai-follow-up"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .to_request(),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = test::read_body_json(response).await;
+    assert_eq!(body["degradation_status"], "rule_based_fallback");
+    assert_eq!(body["question"]["field"], "frequent_locations");
+    assert_eq!(body["question"]["skippable"], true);
+    assert!(
+        body["question"]["missing_fields"]
+            .as_array()
+            .is_some_and(|fields| fields.iter().any(|field| field == "frequent_locations"))
+    );
+    assert!(body["generated_at"].as_str().is_some());
+}
+
+#[actix_web::test]
+async fn get_ai_follow_up_is_not_available_until_required_phase_one_answers_are_complete() {
+    let context = TestContext::new().await;
+    let session_id = create_session(
+        &context,
+        IntakeInitialAnswers {
+            basic_information: Some("Fictional elder profile".to_owned()),
+            ..Default::default()
+        },
+    )
+    .await;
+    let token = context.token(FAMILY).await;
+    let app = crate::init_api_app!(&context);
+
+    let response = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/intake-sessions/{session_id}/ai-follow-up"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .to_request(),
+    )
+    .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = test::read_body_json(response).await;
+    assert_eq!(body["question"], Value::Null);
+    assert_eq!(body["degradation_status"], "not_applicable");
+}
+
+#[actix_web::test]
+async fn get_ai_follow_up_hides_another_members_session() {
+    let context = TestContext::new().await;
+    let session_id = create_session(
+        &context,
+        IntakeInitialAnswers {
+            basic_information: Some("Fictional elder profile".to_owned()),
+            ..Default::default()
+        },
+    )
+    .await;
+    let token = context.token(COMMANDER).await;
+    let app = crate::init_api_app!(&context);
+
+    let response = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/intake-sessions/{session_id}/ai-follow-up"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .to_request(),
+    )
+    .await;
+
+    assert_error(response, StatusCode::NOT_FOUND, "not_found").await;
+}

--- a/tests/api/mod.rs
+++ b/tests/api/mod.rs
@@ -21,6 +21,7 @@ mod cases_list_get;
 mod clue_review_patch;
 mod health_get;
 mod intake_report_details_post;
+mod intake_session_ai_follow_up_get;
 mod intake_session_answers_post;
 mod intake_session_confirm_post;
 mod intake_session_profile_draft_get;

--- a/tests/api/openapi_intake_contract.rs
+++ b/tests/api/openapi_intake_contract.rs
@@ -52,6 +52,56 @@ fn assert_schema_contains(name: &str, expected_fragments: &[&str]) {
 }
 
 #[test]
+fn access_request_openapi_contract_covers_registered_auth_and_admin_routes() {
+    for (path, operation_id) in [
+        (
+            "/api/auth/access-requests",
+            "operationId: createAccessRequest",
+        ),
+        (
+            "/api/auth/access-requests/verify",
+            "operationId: verifyAccessRequest",
+        ),
+        ("/api/auth/password-setup", "operationId: setPassword"),
+        (
+            "/api/admin/access-requests",
+            "operationId: listAccessRequests",
+        ),
+        (
+            "/api/admin/access-requests/{request_id}/review",
+            "operationId: reviewAccessRequest",
+        ),
+    ] {
+        assert!(
+            operation(path).contains(operation_id),
+            "access-request API must declare {operation_id:?}"
+        );
+    }
+    for schema_name in [
+        "CreateAccessRequest",
+        "VerifyAccessRequest",
+        "PasswordSetupRequest",
+        "AccessRequestReceipt",
+        "ReviewAccessRequest",
+        "AdminAccessRequest",
+    ] {
+        assert!(
+            !schema(schema_name).is_empty(),
+            "access-request API must declare {schema_name}"
+        );
+    }
+    let review = operation("/api/admin/access-requests/{request_id}/review");
+    for expected in [
+        "x-global-capabilities: [admin]",
+        "批准时服务端创建停用账户",
+        "#/components/schemas/ReviewAccessRequest",
+    ] {
+        assert!(review.contains(expected));
+    }
+    assert_schema_contains("ReviewAccessRequest", &["enum: [approve, reject]"]);
+}
+
+#[test]
 fn intake_openapi_contract_covers_runtime_requests_and_responses() {
     assert_schema_contains(
         "IntakeInitialAnswers",

--- a/tests/api/openapi_intake_contract.rs
+++ b/tests/api/openapi_intake_contract.rs
@@ -144,6 +144,35 @@ fn intake_openapi_contract_covers_runtime_requests_and_responses() {
             "ai_initial_review_status:",
         ],
     );
+    assert_schema_contains(
+        "IntakeAiFollowUp",
+        &[
+            "required: [field, prompt, purpose, missing_fields, skippable]",
+            "maxLength: 500",
+            "skippable: { type: boolean, const: true }",
+        ],
+    );
+    assert_schema_contains(
+        "IntakeAiFollowUpResponse",
+        &[
+            "question:",
+            "rule_based_fallback",
+            "not_applicable",
+            "generated_at:",
+        ],
+    );
+    let follow_up = operation("/api/intake-sessions/{session_id}/ai-follow-up");
+    for expected in [
+        "operationId: getIntakeAiFollowUp",
+        "x-data-classification: sensitive",
+        "IntakeAiFollowUpResponse",
+        "Required phase-one collection always remains rule-based.",
+    ] {
+        assert!(
+            follow_up.contains(expected),
+            "AI follow-up API must declare {expected:?}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## 变更内容`n`n- 补充后端已注册但此前缺失的账号访问申请、邮箱验证、密码设置和管理员审核 OpenAPI 端点。`n- 为账号访问申请补齐请求、响应和审核 Schema，并明确认证、管理员能力和数据分类约束。`n- 将账号访问流程中的用户可见错误消息统一为中文，保留错误码、字段名和状态枚举的稳定性。`n- 纳入已完成的 intake session 可选 AI follow-up：服务端路由与降级逻辑、前端客户端和家庭问询页面接入、OpenAPI 定义及测试覆盖。`n`n## 验证`n`n- 后端默认功能集完成编译。`n- intake AI follow-up 后端集成测试通过。`n- OpenAPI 对齐契约测试通过。`n- 前端生产构建、lint 和单元测试通过。`n- Playwright E2E：14 passed。`n- 可选 heic 特性未纳入本次通过结论：本机未配置 VCPKG_ROOT，libheif-sys 无法找到 vcpkg。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增账号访问申请、邮箱验证、管理员审核及密码设置流程接口与数据结构。
  - 新增管理员访问申请查询和审核接口。
  - 新增问询过程中的 AI 追问接口，支持 AI 生成与规则回退。

- **问题修复**
  - AI 追问不可用时，答案提交不再失败，并继续使用规则问题。
  - 限制 AI 追问仅在适用阶段和缺失可选信息时触发。
  - 统一访问申请相关错误提示为中文。

- **文档**
  - 完善 OpenAPI 接口、安全规则、权限要求及响应说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->