### PR TITLE
fix(review): 完善地点与老人画像审核状态

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -22,6 +22,7 @@
 | `GET` | `/api/intake-sessions/{session_id}/photos/{photo_id}` | `200` | 读取创建者受控照片，不返回公共 URL |
 | `POST` | `/api/intake-sessions/{session_id}/answers` | `201` | 追加一个未确认答案并获取下一问 |
 | `GET` | `/api/intake-sessions/{session_id}/profile-draft` | `200` | 获取家属专属、待确认的标准化画像草稿 |
+| `PATCH` | `/api/intake-sessions/{session_id}/profile-draft/{draft_id}/review` | `200` | 家属确认或拒绝一个画像草稿版本并返回真实审核状态 |
 | `POST` | `/api/intake-sessions/{session_id}/confirm` | `201` | 家属确认画像并创建正式案件 |
 | `GET` | `/api/ai/executions/{execution_id}` | `200` | 查询当前用户的受控 AI 执行阶段与安全终态 |
 | `GET` | `/api/ai/executions/{execution_id}/events` | `200` | 按事件 ID 恢复读取有序、可去重的安全 SSE 生命周期事件 |
@@ -44,6 +45,7 @@
 | `POST` | `/api/cases/{case_id}/archive-drafts` | `201` | 指挥为已结束案件创建受控内部归档草稿 |
 | `GET` | `/api/cases/{case_id}/places` | `200` | 获取按案件角色、审核状态和可见级别裁剪的地点 |
 | `POST` | `/api/cases/{case_id}/places` | `201` | 家属或指挥提交常去/关键地点，始终待人工审核 |
+| `PATCH` | `/api/cases/{case_id}/places/{place_id}/review` | `200` | 案件指挥确认或驳回待审核地点并记录理由 |
 | `GET` | `/api/cases/{case_id}/resource-configuration` | `200` | 获取当前案件可用的地点类型和图片限制 |
 | `POST` | `/api/cases/{case_id}/attachments` | `201` | 上传受控 JPEG/PNG 案件图片，始终待人工审核 |
 | `GET` | `/api/cases/{case_id}/attachments/{attachment_id}` | `200` | 按案件权限下载本人上传的图片，指挥可下载案件全部图片 |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -379,8 +379,8 @@ paths:
     get:
       tags: [Intake sessions]
       operationId: getIntakeSessionProfileDraft
-      summary: Get the unconfirmed profile draft for an intake session
-      description: Only the session creator can read this sensitive draft. It is assembled only from that session's family-provided answers, is explicitly marked `draft`, and is never a formal case fact. Each non-empty display field has field-level provenance and a generation time so it can be reviewed before confirmation.
+      summary: Get the latest profile draft version for an intake session
+      description: Only the session creator can read this sensitive version. It is assembled only from that session's family-provided answers and never becomes a formal case fact merely because the version is reviewed. Each non-empty display field has field-level provenance and a generation time; status and requires_human_confirmation report the persisted version-review state.
       security:
         - bearerAuth: []
       x-account-types: [member]
@@ -400,6 +400,35 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalError"
+
+  /api/intake-sessions/{session_id}/profile-draft/{draft_id}/review:
+    parameters:
+      - $ref: "#/components/parameters/IntakeSessionId"
+      - name: draft_id
+        in: path
+        required: true
+        schema: { type: string, format: uuid }
+    patch:
+      tags: [Intake sessions]
+      operationId: reviewIntakeProfileDraft
+      summary: Confirm or reject one generated profile draft version
+      description: Only the session creator can review a persisted draft version. A successful confirmation returns status confirmed and requires_human_confirmation false; rejection returns status superseded. The reviewed version remains separate from the final case-creation confirmation.
+      security: [{ bearerAuth: [] }]
+      x-account-types: [member]
+      x-data-classification: sensitive
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/ReviewIntakeProfileDraftRequest" }
+      responses:
+        "200": { description: Reviewed profile draft version, content: { application/json: { schema: { $ref: "#/components/schemas/IntakeProfileDraft" } } } }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { $ref: "#/components/responses/Conflict" }
+        "500": { $ref: "#/components/responses/InternalError" }
 
   /api/intake-sessions/{session_id}/ai-follow-up:
     parameters:
@@ -1445,6 +1474,41 @@ paths:
       responses:
         "201":
           description: 待审核地点已创建
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/CasePlace" }
+        "400": { $ref: "#/components/responses/ValidationError" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { $ref: "#/components/responses/Conflict" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
+  /api/cases/{case_id}/places/{place_id}/review:
+    parameters:
+      - $ref: "#/components/parameters/CaseId"
+      - name: place_id
+        in: path
+        required: true
+        schema: { type: string, format: uuid }
+    patch:
+      tags: [Cases]
+      operationId: reviewCasePlace
+      summary: 审核家属或案件成员提交的地点
+      description: 仅当前案件的 commander 可操作。地点必须仍为 pending_review，审核理由必填；确认或驳回会原子更新状态并写入审计事件。
+      security:
+        - bearerAuth: []
+      x-account-types: [member]
+      x-case-roles: [commander]
+      x-data-classification: sensitive
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/ReviewCasePlaceRequest" }
+      responses:
+        "200":
+          description: 已审核的地点
           content:
             application/json:
               schema: { $ref: "#/components/schemas/CasePlace" }
@@ -3014,12 +3078,19 @@ components:
     IntakeProfileDraft:
       type: object
       additionalProperties: false
-      required: [status, source_scope, generated_at, requires_human_confirmation, profile, field_metadata, missing_fields, assessments, confirmation_blocked_reasons, direction_hypotheses]
+      required: [id, status, source_scope, generated_at, provider_model, template_version, degradation_status, version, requires_human_confirmation, profile, field_metadata, missing_fields, assessments, confirmation_blocked_reasons, direction_hypotheses]
       properties:
-        status: { type: string, const: draft }
+        id: { type: string }
+        status: { type: string, enum: [draft, confirmed, superseded] }
         source_scope: { type: string }
         generated_at: { type: string, format: date-time }
-        requires_human_confirmation: { type: boolean, const: true }
+        provider_model: { type: [string, "null"] }
+        template_version: { type: string }
+        degradation_status: { type: string }
+        version: { type: integer, minimum: 0 }
+        requires_human_confirmation:
+          type: boolean
+          description: True only while this version remains in draft status awaiting version review.
         profile: { $ref: "#/components/schemas/IntakeProfileDraftFields" }
         field_metadata:
           type: array
@@ -3039,6 +3110,14 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/IntakeDirectionHypothesis"
+
+    ReviewIntakeProfileDraftRequest:
+      type: object
+      additionalProperties: false
+      required: [action, reason]
+      properties:
+        action: { type: string, enum: [confirm, reject] }
+        reason: { type: string, minLength: 1, maxLength: 1000 }
 
     IntakeProfileDraftFieldMetadata:
       type: object
@@ -3863,6 +3942,14 @@ components:
         longitude: { type: [number, "null"], minimum: -180, maximum: 180 }
         latitude: { type: [number, "null"], minimum: -90, maximum: 90 }
         visibility: { type: string, enum: [public, confirmed, internal] }
+
+    ReviewCasePlaceRequest:
+      type: object
+      additionalProperties: false
+      required: [status, reason]
+      properties:
+        status: { type: string, enum: [confirmed, rejected] }
+        reason: { type: string, minLength: 1, maxLength: 1000 }
 
     CaseMapView:
       type: object

--- a/frontend/src/api/cases.ts
+++ b/frontend/src/api/cases.ts
@@ -144,6 +144,11 @@ export interface CreateCasePlacePayload {
   visibility: PlaceVisibility;
 }
 
+export interface ReviewCasePlacePayload {
+  status: "confirmed" | "rejected";
+  reason: string;
+}
+
 export interface CaseResourceConfiguration {
   attachment_max_image_bytes: number;
   attachment_max_per_case: number;
@@ -1006,6 +1011,19 @@ export function createCasePlace(
   return apiRequest<CasePlace>(
     `/cases/${caseId}/places`,
     { method: "POST", body: JSON.stringify(payload) },
+    token,
+  );
+}
+
+export function reviewCasePlace(
+  token: string,
+  caseId: string,
+  placeId: string,
+  payload: ReviewCasePlacePayload,
+): Promise<CasePlace> {
+  return apiRequest<CasePlace>(
+    `/cases/${caseId}/places/${placeId}/review`,
+    { method: "PATCH", body: JSON.stringify(payload) },
     token,
   );
 }

--- a/frontend/src/api/intake.ts
+++ b/frontend/src/api/intake.ts
@@ -121,10 +121,10 @@ export interface IntakeDirectionHypothesis {
 
 export interface IntakeDraft {
   id: string;
-  status: "draft";
+  status: "draft" | "confirmed" | "superseded";
   source_scope: string;
   generated_at: string;
-  requires_human_confirmation: true;
+  requires_human_confirmation: boolean;
   profile: IntakeDraftProfile;
   field_metadata: IntakeProfileDraftFieldMetadata[];
   missing_fields: string[];

--- a/frontend/src/pages/CaseWorkspacePage.test.tsx
+++ b/frontend/src/pages/CaseWorkspacePage.test.tsx
@@ -44,6 +44,7 @@ const mocked = vi.hoisted(() => ({
   listCaseMembers: vi.fn(),
   createCaseTask: vi.fn(),
   reviewClue: vi.fn(),
+  reviewCasePlace: vi.fn(),
 }));
 
 vi.mock("../auth/useAuth", () => ({
@@ -70,6 +71,7 @@ vi.mock("../api/cases", () => ({
   createCase: vi.fn(),
   createClue: vi.fn(),
   reviewClue: (...args: unknown[]) => mocked.reviewClue(...args),
+  reviewCasePlace: (...args: unknown[]) => mocked.reviewCasePlace(...args),
   createCasePlace: vi.fn(),
   uploadCaseAttachment: vi.fn(),
   updateCaseStatus: vi.fn(),
@@ -117,6 +119,114 @@ function detail(
 }
 
 describe("CaseWorkspacePage", () => {
+  it("lets a commander review a pending family place with a reason", async () => {
+    vi.clearAllMocks();
+    const commandDetail = detail(
+      "case-command",
+      "指挥地点审核案件",
+      "commander",
+    );
+    commandDetail.places = [
+      {
+        id: "place-pending",
+        case_id: "case-command",
+        name: "模拟体检地点",
+        place_type: "medical",
+        address: "模拟医院门诊入口",
+        longitude: null,
+        latitude: null,
+        source: "family",
+        visibility: "confirmed",
+        review_status: "pending_review",
+        created_at: "2026-08-14T08:00:00Z",
+        updated_at: "2026-08-14T08:00:00Z",
+        is_own_submission: false,
+      },
+    ];
+    const reviewedDetail = {
+      ...commandDetail,
+      places: commandDetail.places.map((place) => ({
+        ...place,
+        review_status: "confirmed" as const,
+      })),
+    };
+    mocked.listCommandIntake.mockResolvedValue([]);
+    mocked.listCases.mockResolvedValue([
+      {
+        id: "case-command",
+        case_code: "AG-COMMAND",
+        status: "active",
+        access_role: "commander",
+        display_name: "指挥地点审核案件",
+        last_seen_at: null,
+        last_seen_location: null,
+        created_at: "2026-08-14T08:00:00Z",
+        updated_at: "2026-08-14T08:00:00Z",
+      },
+    ]);
+    mocked.getCase
+      .mockResolvedValueOnce(commandDetail)
+      .mockResolvedValue(reviewedDetail);
+    mocked.getCaseResourceConfiguration.mockResolvedValue({
+      attachment_max_image_bytes: 5 * 1024 * 1024,
+      attachment_max_per_case: 12,
+      case_place_types: ["medical"],
+    });
+    mocked.listCaseClues.mockResolvedValue({
+      items: [],
+      page: 1,
+      page_size: 25,
+      total: 0,
+    });
+    mocked.getCaseMapView.mockResolvedValue({ items: [] });
+    mocked.listCaseTasks.mockResolvedValue({
+      items: [],
+      page: 1,
+      page_size: 25,
+      total: 0,
+    });
+    mocked.listCaseMembers.mockResolvedValue([]);
+    mocked.reviewCasePlace.mockResolvedValue(reviewedDetail.places[0]);
+
+    render(<CaseWorkspacePage mode="commander" />);
+
+    await screen.findByRole("heading", { name: "指挥地点审核案件" });
+    const reason = await screen.findByRole("textbox", {
+      name: "审核地点“模拟体检地点”的理由",
+    });
+    const confirm = screen.getByRole("button", { name: "确认地点" });
+    expect(confirm).toBeDisabled();
+    fireEvent.change(reason, {
+      target: { value: "已与家属提供的模拟记录核对。" },
+    });
+    expect(confirm).toBeEnabled();
+    fireEvent.click(confirm);
+
+    await waitFor(() =>
+      expect(mocked.reviewCasePlace).toHaveBeenCalledWith(
+        "test-session",
+        "case-command",
+        "place-pending",
+        {
+          status: "confirmed",
+          reason: "已与家属提供的模拟记录核对。",
+        },
+      ),
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("textbox", {
+          name: "审核地点“模拟体检地点”的理由",
+        }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(
+      screen
+        .getAllByText("已确认")
+        .some((element) => element.dataset.slot === "chip-label"),
+    ).toBe(true);
+  });
+
   it("gives a family member one next action and keeps long forms collapsed", async () => {
     vi.clearAllMocks();
     mocked.listCases.mockResolvedValue([

--- a/frontend/src/pages/CaseWorkspacePage.tsx
+++ b/frontend/src/pages/CaseWorkspacePage.tsx
@@ -2,6 +2,7 @@ import { AlertDialog, Button, Chip, Input, TextArea } from "@heroui/react";
 import {
   CheckCircle2,
   ChevronRight,
+  CircleX,
   CirclePlus,
   FileSearch,
   MapPin,
@@ -40,6 +41,7 @@ import {
   listCommandIntake,
   reviewClue,
   reviewClueDraft,
+  reviewCasePlace,
   reviewSummaryDraft,
   updateCaseStatus,
   updateElderProfile,
@@ -538,6 +540,9 @@ function CaseDetailView({
     latitude: null,
     visibility: "confirmed",
   });
+  const [placeReviewReasons, setPlaceReviewReasons] = useState<
+    Record<string, string>
+  >({});
   const [attachment, setAttachment] = useState<File | null>(null);
   const [nextStatus, setNextStatus] = useState<CaseStatus>(detail.status);
   const [memberEmail, setMemberEmail] = useState("");
@@ -643,6 +648,26 @@ function CaseDetailView({
       return false;
     } finally {
       setBusy("");
+    }
+  }
+
+  async function submitPlaceReview(
+    placeId: string,
+    status: "confirmed" | "rejected",
+  ) {
+    const reason = placeReviewReasons[placeId]?.trim() ?? "";
+    if (!token || !reason) return;
+    const succeeded = await run(
+      `place-review-${placeId}`,
+      () => reviewCasePlace(token, detail.id, placeId, { status, reason }),
+      status === "confirmed" ? "地点已确认" : "地点已驳回",
+    );
+    if (succeeded) {
+      setPlaceReviewReasons((current) => {
+        const next = { ...current };
+        delete next[placeId];
+        return next;
+      });
     }
   }
 
@@ -1483,7 +1508,9 @@ function CaseDetailView({
               <h3 className="m-0 text-base font-bold text-slate-950">
                 补充地点
               </h3>
-              <span className="text-xs text-slate-500">提交后待人工审核</span>
+              <span className="text-xs text-slate-500">
+                {isCommander ? "地点审核" : "提交后待人工审核"}
+              </span>
             </div>
             <div className="mt-3 divide-y divide-slate-200 rounded-md border border-slate-200 bg-white">
               {detail.places.length === 0 ? (
@@ -1491,19 +1518,71 @@ function CaseDetailView({
                   暂无可查看的补充地点
                 </p>
               ) : (
-                detail.places.map((item) => (
-                  <div key={item.id} className="px-3 py-3 text-sm">
-                    <strong className="text-slate-900">{item.name}</strong>
-                    <span className="ml-2 text-xs text-slate-500">
-                      {item.review_status === "pending_review"
-                        ? "待人工审核"
-                        : item.review_status}
-                    </span>
-                    <p className="m-0 mt-1 text-xs text-slate-600">
-                      {item.address}
-                    </p>
-                  </div>
-                ))
+                detail.places.map((item) => {
+                  const reviewBusy = busy === `place-review-${item.id}`;
+                  const reviewReason = placeReviewReasons[item.id] ?? "";
+                  return (
+                    <div key={item.id} className="px-3 py-3 text-sm">
+                      <div className="flex flex-wrap items-start justify-between gap-2">
+                        <strong className="text-slate-900">{item.name}</strong>
+                        <Chip size="sm" variant="soft">
+                          <Chip.Label>
+                            {statusLabels[item.review_status] ??
+                              item.review_status}
+                          </Chip.Label>
+                        </Chip>
+                      </div>
+                      <p className="m-0 mt-1 text-xs text-slate-600">
+                        {item.address}
+                      </p>
+                      {isCommander &&
+                        item.review_status === "pending_review" &&
+                        detail.status !== "closed" && (
+                          <div className="mt-3 grid gap-2 border-t border-slate-100 pt-3">
+                            <Input
+                              aria-label={`审核地点“${item.name}”的理由`}
+                              placeholder="审核理由"
+                              value={reviewReason}
+                              maxLength={1000}
+                              onChange={(event) =>
+                                setPlaceReviewReasons((current) => ({
+                                  ...current,
+                                  [item.id]: event.target.value,
+                                }))
+                              }
+                              fullWidth
+                            />
+                            <div className="flex flex-wrap gap-2">
+                              <Button
+                                type="button"
+                                size="sm"
+                                variant="secondary"
+                                isDisabled={!reviewReason.trim() || reviewBusy}
+                                onPress={() =>
+                                  void submitPlaceReview(item.id, "confirmed")
+                                }
+                              >
+                                <CheckCircle2 size={15} aria-hidden="true" />
+                                {reviewBusy ? "正在审核" : "确认地点"}
+                              </Button>
+                              <Button
+                                type="button"
+                                size="sm"
+                                variant="ghost"
+                                isDisabled={!reviewReason.trim() || reviewBusy}
+                                onPress={() =>
+                                  void submitPlaceReview(item.id, "rejected")
+                                }
+                              >
+                                <CircleX size={15} aria-hidden="true" />
+                                驳回地点
+                              </Button>
+                            </div>
+                          </div>
+                        )}
+                    </div>
+                  );
+                })
               )}
             </div>
             {detail.status !== "closed" && (

--- a/frontend/src/pages/FamilyIntakeForm.test.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.test.tsx
@@ -14,12 +14,16 @@ const mocked = vi.hoisted(() => ({
   getIntakeAiInitialReview: vi.fn(),
   getIntakeAiFollowUp: vi.fn(),
   getIntakeDraft: vi.fn(),
+  generateIntakeDraft: vi.fn(),
+  diffIntakeDraftVersions: vi.fn(),
   listIntakeAnswerRevisions: vi.fn(),
   listIntakeDraftVersions: vi.fn(),
   listIntakePhotos: vi.fn(),
   downloadIntakePhoto: vi.fn(),
   acknowledgeIntakeAiInitialReview: vi.fn(),
   startIntakeAiInitialReview: vi.fn(),
+  reviewIntakeDraft: vi.fn(),
+  restoreIntakeDraft: vi.fn(),
   submitIntakeAnswer: vi.fn(),
   uploadIntakePhoto: vi.fn(),
 }));
@@ -38,6 +42,10 @@ vi.mock("../api/intake", () => ({
   getIntakeAiFollowUp: (...args: unknown[]) =>
     mocked.getIntakeAiFollowUp(...args),
   getIntakeDraft: (...args: unknown[]) => mocked.getIntakeDraft(...args),
+  generateIntakeDraft: (...args: unknown[]) =>
+    mocked.generateIntakeDraft(...args),
+  diffIntakeDraftVersions: (...args: unknown[]) =>
+    mocked.diffIntakeDraftVersions(...args),
   listIntakeAnswerRevisions: (...args: unknown[]) =>
     mocked.listIntakeAnswerRevisions(...args),
   listIntakeDraftVersions: (...args: unknown[]) =>
@@ -48,6 +56,10 @@ vi.mock("../api/intake", () => ({
     mocked.acknowledgeIntakeAiInitialReview(...args),
   startIntakeAiInitialReview: (...args: unknown[]) =>
     mocked.startIntakeAiInitialReview(...args),
+  reviewIntakeDraft: (...args: unknown[]) =>
+    mocked.reviewIntakeDraft(...args),
+  restoreIntakeDraft: (...args: unknown[]) =>
+    mocked.restoreIntakeDraft(...args),
   submitIntakeAnswer: (...args: unknown[]) =>
     mocked.submitIntakeAnswer(...args),
   uploadIntakePhoto: (...args: unknown[]) => mocked.uploadIntakePhoto(...args),
@@ -230,6 +242,53 @@ describe("FamilyIntakeForm", () => {
     mocked.listIntakePhotos.mockResolvedValue([]);
     mocked.downloadIntakePhoto.mockResolvedValue(new Blob(["preview"], { type: "image/png" }));
     window.sessionStorage.clear();
+  });
+
+  it("shows a confirmed AI profile version as confirmed on every field card", async () => {
+    const confirmedDraft: IntakeDraft = {
+      ...profileDraft,
+      status: "confirmed",
+      requires_human_confirmation: false,
+    };
+    window.sessionStorage.setItem(
+      "angui:intake-tab-draft:family-1",
+      JSON.stringify({ session: readySession, answer: "" }),
+    );
+    mocked.getIntakeDraft.mockResolvedValue(profileDraft);
+    mocked.listIntakeDraftVersions.mockResolvedValue({
+      items: [profileDraft],
+    });
+    mocked.reviewIntakeDraft.mockResolvedValue(confirmedDraft);
+
+    render(
+      <FamilyIntakeForm
+        onCancel={vi.fn()}
+        onConfirmed={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    await screen.findByText("AI 画像草稿版本");
+    fireEvent.click(screen.getByRole("button", { name: "确认" }));
+
+    await waitFor(() =>
+      expect(mocked.reviewIntakeDraft).toHaveBeenCalledWith(
+        "family-session",
+        "intake-1",
+        "profile-draft-test-1",
+        "confirm",
+        "family confirmed profile candidate",
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.queryByText(/状态：需人工确认/)).not.toBeInTheDocument(),
+    );
+    expect(screen.getAllByText(/状态：已确认/)).toHaveLength(3);
+    expect(
+      screen.getByText(
+        "当前画像版本已经家属确认，但正式案件尚未创建；请继续完成建案前的最终确认。",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "确认" })).toBeDisabled();
   });
 
   it("restores the current-tab draft and does not create a second intake session", async () => {

--- a/frontend/src/pages/FamilyIntakeForm.tsx
+++ b/frontend/src/pages/FamilyIntakeForm.tsx
@@ -75,6 +75,12 @@ const questionReasons: Record<string, string> = {
   follow_up_clues: "记录家属尚待核实的补充信息。",
 };
 
+const intakeDraftStatusLabels: Record<IntakeDraft["status"], string> = {
+  draft: "待确认",
+  confirmed: "已确认",
+  superseded: "已拒绝",
+};
+
 const acceptedPhotoMimeTypes = new Set([
   "image/jpeg",
   "image/jpg",
@@ -957,11 +963,11 @@ export function FamilyIntakeForm({
               核对老人画像草稿
             </h2>
             <p className="mb-0 mt-1 text-sm leading-6 text-slate-600">
-              每项内容均保持为草稿，只有您完成确认后才会创建正式案件。
+              请先核对当前画像版本；版本确认后仍需完成建案前的最终确认。
             </p>
           </div>
           <Chip size="sm" variant="soft">
-            <Chip.Label>需要人工确认</Chip.Label>
+            <Chip.Label>{intakeDraftStatusLabels[draft.status]}</Chip.Label>
           </Chip>
         </header>
 
@@ -976,7 +982,9 @@ export function FamilyIntakeForm({
               aria-hidden="true"
             />
             <span>
-              以下信息仅来自本次家属问询。请核对来源、时间与内容；未确认前，它们不是正式案件事实。
+              {draft.requires_human_confirmation
+                ? "以下信息仅来自本次家属问询。请核对来源、时间与内容；未确认前，它们不是正式案件事实。"
+                : "当前画像版本已经家属确认，但正式案件尚未创建；请继续完成建案前的最终确认。"}
             </span>
           </div>
         </div>
@@ -1022,7 +1030,8 @@ export function FamilyIntakeForm({
                     className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-slate-200 bg-white p-3"
                   >
                     <span className="text-xs text-slate-700">
-                      v{version.version} · {version.status} ·{" "}
+                      v{version.version} ·{" "}
+                      {intakeDraftStatusLabels[version.status]} ·{" "}
                       {version.degradation_status}
                     </span>
                     <div className="flex gap-2">
@@ -1134,6 +1143,9 @@ export function FamilyIntakeForm({
                             version.id,
                             "reject",
                             "family rejected profile candidate",
+                          );
+                          setDraft((current) =>
+                            current?.id === updated.id ? updated : current,
                           );
                           setProfileVersions((items) =>
                             items.map((item) =>
@@ -1937,7 +1949,9 @@ function DraftProfileReview({
                   {label}
                 </h4>
                 <Chip size="sm" variant="soft">
-                  <Chip.Label>草稿</Chip.Label>
+                  <Chip.Label>
+                    {intakeDraftStatusLabels[draft.status]}
+                  </Chip.Label>
                 </Chip>
               </div>
               <p className="mb-3 mt-3 min-h-12 whitespace-pre-wrap text-sm leading-6 text-slate-700">
@@ -1954,7 +1968,8 @@ function DraftProfileReview({
                     {questionLabels[source.source_field] ?? source.source_field}
                   </span>
                   <span className="block">
-                    生成于：{formatDate(source.generated_at)} · 状态：需人工确认
+                    生成于：{formatDate(source.generated_at)} · 状态：
+                    {intakeDraftStatusLabels[draft.status]}
                   </span>
                   <Button
                     className="mt-2"

--- a/src/api/models.rs
+++ b/src/api/models.rs
@@ -897,6 +897,13 @@ pub struct CreateCasePlaceRequest {
     pub visibility: PlaceVisibility,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReviewCasePlaceRequest {
+    pub status: String,
+    pub reason: String,
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PlaceVisibility {

--- a/src/api/routes/cases.rs
+++ b/src/api/routes/cases.rs
@@ -12,8 +12,8 @@ use crate::{
         AddCaseMemberRequest, AuthenticatedUser, CaseMapItem, CaseMapViewResponse, CasePoiQuery,
         CaseResourceConfigurationResponse, CreateCasePlaceRequest, CreateCaseRequest,
         CreateCaseSourceRecordRequest, CreateClueDraftRequest, CreateClueRequest,
-        CreateSummaryDraftRequest, CreateTaskRequest, ReviewClueDraftRequest,
-        ReviewSummaryDraftRequest, TaskListQuery, UpdateCaseStatusRequest,
+        CreateSummaryDraftRequest, CreateTaskRequest, ReviewCasePlaceRequest,
+        ReviewClueDraftRequest, ReviewSummaryDraftRequest, TaskListQuery, UpdateCaseStatusRequest,
         UpdateElderProfileRequest,
     },
     roles::CaseRole,
@@ -84,6 +84,10 @@ pub fn configure(config: &mut web::ServiceConfig) {
             )
             .route("/{case_id}/places", web::get().to(list_places))
             .route("/{case_id}/places", web::post().to(create_place))
+            .route(
+                "/{case_id}/places/{place_id}/review",
+                web::patch().to(review_place),
+            )
             .route(
                 "/{case_id}/resource-configuration",
                 web::get().to(get_resource_configuration),
@@ -174,6 +178,24 @@ async fn list_places(
         crate::services::case_resource_service::visible_places(&state.db, &case_id, &auth.id, role)
             .await?;
     Ok(HttpResponse::Ok().json(places))
+}
+
+async fn review_place(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    path: web::Path<(String, String)>,
+    request: web::Json<ReviewCasePlaceRequest>,
+) -> Result<HttpResponse, ApiError> {
+    let (case_id, place_id) = path.into_inner();
+    let place = crate::services::case_resource_service::review_place(
+        &state.db,
+        &auth,
+        &case_id,
+        &place_id,
+        request.into_inner(),
+    )
+    .await?;
+    Ok(HttpResponse::Ok().json(place))
 }
 
 async fn create_attachment(

--- a/src/application/services/case_resource_service.rs
+++ b/src/application/services/case_resource_service.rs
@@ -11,7 +11,7 @@ use futures_util::StreamExt;
 use image::ImageFormat;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, Condition, DatabaseConnection, DatabaseTransaction, EntityTrait,
-    PaginatorTrait, QueryFilter, QueryOrder, Set, TransactionTrait,
+    PaginatorTrait, QueryFilter, QueryOrder, Set, TransactionTrait, sea_query::Expr,
 };
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -24,6 +24,7 @@ use crate::{
     error::ApiError,
     models::{
         AuthenticatedUser, CaseAttachmentResponse, CasePlaceResponse, CreateCasePlaceRequest,
+        ReviewCasePlaceRequest,
     },
     roles::CaseRole,
     services::case_service::{require_case_role, write_audit},
@@ -117,6 +118,83 @@ pub async fn create_place(
     write_audit(&transaction, Some(case_id.to_owned()), auth, "case.place_submitted", "case_place", model.id.clone(), Some(json!({ "review_status": "pending_review", "visibility": model.visibility, "actor_case_role": role }))).await?;
     transaction.commit().await?;
     Ok(place_response(model, &auth.id))
+}
+
+pub async fn review_place(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    case_id: &str,
+    place_id: &str,
+    request: ReviewCasePlaceRequest,
+) -> Result<CasePlaceResponse, ApiError> {
+    let next_status = request.status.trim().to_lowercase();
+    if !matches!(next_status.as_str(), "confirmed" | "rejected") {
+        return Err(ApiError::Validation(
+            "place review status must be confirmed or rejected".to_owned(),
+        ));
+    }
+    let reason = request.reason.trim();
+    if !(1..=1_000).contains(&reason.chars().count()) {
+        return Err(ApiError::Validation(
+            "reason must contain 1 to 1000 characters".to_owned(),
+        ));
+    }
+
+    let transaction = db.begin().await?;
+    require_case_role(&transaction, &auth.id, case_id, &[CaseRole::Commander]).await?;
+    ensure_case_is_open(&transaction, case_id).await?;
+    let existing = case_places::Entity::find_by_id(place_id)
+        .one(&transaction)
+        .await?
+        .filter(|place| place.case_id == case_id)
+        .ok_or_else(|| ApiError::NotFound("case place was not found".to_owned()))?;
+    if existing.review_status != "pending_review" {
+        return Err(ApiError::Conflict(
+            "case place has already been reviewed".to_owned(),
+        ));
+    }
+
+    let updated_at = now();
+    let update = case_places::Entity::update_many()
+        .col_expr(
+            case_places::Column::ReviewStatus,
+            Expr::value(next_status.clone()),
+        )
+        .col_expr(
+            case_places::Column::UpdatedAt,
+            Expr::value(updated_at.clone()),
+        )
+        .filter(case_places::Column::Id.eq(place_id))
+        .filter(case_places::Column::CaseId.eq(case_id))
+        .filter(case_places::Column::ReviewStatus.eq("pending_review"))
+        .exec(&transaction)
+        .await?;
+    if update.rows_affected != 1 {
+        return Err(ApiError::Conflict(
+            "case place changed during review; reload and try again".to_owned(),
+        ));
+    }
+
+    let updated = case_places::Entity::find_by_id(place_id)
+        .one(&transaction)
+        .await?
+        .ok_or(ApiError::Internal)?;
+    write_audit(
+        &transaction,
+        Some(case_id.to_owned()),
+        auth,
+        "case.place_reviewed",
+        "case_place",
+        place_id.to_owned(),
+        Some(json!({
+            "from": existing.review_status,
+            "to": next_status,
+            "reason": reason,
+        })),
+    )
+    .await?;
+    transaction.commit().await?;
+    Ok(place_response(updated, &auth.id))
 }
 
 pub async fn store_image_attachment(

--- a/src/application/services/intake_session_service.rs
+++ b/src/application/services/intake_session_service.rs
@@ -1178,6 +1178,7 @@ fn validate_review_reason(reason: String) -> Result<(), ApiError> {
 fn profile_draft_from_model(
     model: intake_profile_drafts::Model,
 ) -> Result<IntakeProfileDraft, ApiError> {
+    let requires_human_confirmation = model.status == "draft";
     Ok(IntakeProfileDraft {
         id: model.id,
         status: model.status,
@@ -1187,7 +1188,7 @@ fn profile_draft_from_model(
         template_version: model.template_version,
         degradation_status: model.degradation_status,
         version: model.version,
-        requires_human_confirmation: true,
+        requires_human_confirmation,
         profile: serde_json::from_str(&model.profile_json).map_err(|_| ApiError::Internal)?,
         field_metadata: serde_json::from_str(&model.field_metadata_json)
             .map_err(|_| ApiError::Internal)?,

--- a/tests/api/authentication_guards.rs
+++ b/tests/api/authentication_guards.rs
@@ -56,6 +56,7 @@ async fn every_protected_endpoint_rejects_missing_and_invalid_bearer_tokens() {
     assert_unauthorized!(app, get, "/api/cases/not-used/map-view");
     assert_unauthorized!(app, get, "/api/cases/not-used/places");
     assert_unauthorized!(app, post, "/api/cases/not-used/places");
+    assert_unauthorized!(app, patch, "/api/cases/not-used/places/not-used/review");
     assert_unauthorized!(app, get, "/api/cases/not-used/resource-configuration");
     assert_unauthorized!(app, post, "/api/cases/not-used/attachments");
     assert_unauthorized!(app, get, "/api/cases/not-used/attachments/not-used");

--- a/tests/api/case_resources_post.rs
+++ b/tests/api/case_resources_post.rs
@@ -79,6 +79,114 @@ async fn post_case_places_requires_family_or_commander_and_returns_pending_revie
 }
 
 #[actix_web::test]
+async fn patch_case_place_review_requires_commander_and_records_audited_transition() {
+    let context = TestContext::new().await;
+    let case_id = context.create_case().await;
+    context
+        .add_member(&case_id, FAMILY, COMMANDER, "commander")
+        .await;
+    let family_token = context.token(FAMILY).await;
+    let commander_token = context.token(COMMANDER).await;
+    let app = crate::init_api_app!(&context);
+
+    let created = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!("/api/cases/{case_id}/places"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {family_token}")))
+            .set_json(json!({
+                "name": "Fictional clinic",
+                "place_type": "medical",
+                "address": "Fictional clinic entrance",
+                "visibility": "confirmed"
+            }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(created.status(), StatusCode::CREATED);
+    let created: serde_json::Value = test::read_body_json(created).await;
+    let place_id = created["id"].as_str().expect("place id");
+    let review_uri = format!("/api/cases/{case_id}/places/{place_id}/review");
+
+    let family_denied = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&review_uri)
+            .insert_header((header::AUTHORIZATION, format!("Bearer {family_token}")))
+            .set_json(json!({
+                "status": "confirmed",
+                "reason": "family cannot review its own submission"
+            }))
+            .to_request(),
+    )
+    .await;
+    assert_error(family_denied, StatusCode::FORBIDDEN, "forbidden").await;
+
+    let invalid = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&review_uri)
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(json!({ "status": "pending_review", "reason": "invalid transition" }))
+            .to_request(),
+    )
+    .await;
+    assert_error(invalid, StatusCode::BAD_REQUEST, "validation_error").await;
+
+    let confirmed = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&review_uri)
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(json!({
+                "status": "confirmed",
+                "reason": "verified against the fictional family report"
+            }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(confirmed.status(), StatusCode::OK);
+    let confirmed: serde_json::Value = test::read_body_json(confirmed).await;
+    assert_eq!(confirmed["review_status"], "confirmed");
+
+    let audit = audit_events::Entity::find()
+        .filter(audit_events::Column::CaseId.eq(&case_id))
+        .filter(audit_events::Column::Action.eq("case.place_reviewed"))
+        .filter(audit_events::Column::EntityId.eq(place_id))
+        .one(&context.database)
+        .await
+        .expect("audit query should succeed")
+        .expect("place review audit should exist");
+    let metadata: serde_json::Value = serde_json::from_str(
+        audit
+            .metadata_json
+            .as_deref()
+            .expect("place review audit should have metadata"),
+    )
+    .expect("place review metadata should be JSON");
+    assert_eq!(metadata["from"], "pending_review");
+    assert_eq!(metadata["to"], "confirmed");
+    assert_eq!(
+        metadata["reason"],
+        "verified against the fictional family report"
+    );
+
+    let repeated = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&review_uri)
+            .insert_header((header::AUTHORIZATION, format!("Bearer {commander_token}")))
+            .set_json(json!({
+                "status": "rejected",
+                "reason": "a completed review cannot be overwritten"
+            }))
+            .to_request(),
+    )
+    .await;
+    assert_error(repeated, StatusCode::CONFLICT, "conflict").await;
+}
+
+#[actix_web::test]
 async fn get_case_places_applies_role_visibility_and_hides_non_members() {
     let context = TestContext::new().await;
     let case_id = context.create_case().await;

--- a/tests/api/intake_session_confirm_post.rs
+++ b/tests/api/intake_session_confirm_post.rs
@@ -47,6 +47,77 @@ async fn ready_session(context: &TestContext) -> String {
 }
 
 #[actix_web::test]
+async fn confirmed_profile_draft_reports_that_version_review_is_complete() {
+    let context = TestContext::new().await;
+    let session_id = ready_session(&context).await;
+    let token = context.token(FAMILY).await;
+    let app = crate::init_api_app!(&context);
+
+    let generated = test::call_service(
+        &app,
+        test::TestRequest::post()
+            .uri(&format!(
+                "/api/intake-sessions/{session_id}/profile-draft/generate"
+            ))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(generated.status(), StatusCode::CREATED);
+    let generated = read_sse_completed_json(generated).await;
+    assert_eq!(generated["status"], "draft");
+    assert_eq!(generated["requires_human_confirmation"], true);
+    let draft_id = generated["id"]
+        .as_str()
+        .expect("generated profile draft should include an id");
+    let review_uri = format!("/api/intake-sessions/{session_id}/profile-draft/{draft_id}/review");
+
+    let confirmed = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&review_uri)
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .set_json(json!({
+                "action": "confirm",
+                "reason": "family confirmed the generated profile version"
+            }))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(confirmed.status(), StatusCode::OK);
+    let confirmed: Value = test::read_body_json(confirmed).await;
+    assert_eq!(confirmed["status"], "confirmed");
+    assert_eq!(confirmed["requires_human_confirmation"], false);
+
+    let refreshed = test::call_service(
+        &app,
+        test::TestRequest::get()
+            .uri(&format!("/api/intake-sessions/{session_id}/profile-draft"))
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .to_request(),
+    )
+    .await;
+    assert_eq!(refreshed.status(), StatusCode::OK);
+    let refreshed: Value = test::read_body_json(refreshed).await;
+    assert_eq!(refreshed["status"], "confirmed");
+    assert_eq!(refreshed["requires_human_confirmation"], false);
+
+    let repeated = test::call_service(
+        &app,
+        test::TestRequest::patch()
+            .uri(&review_uri)
+            .insert_header((header::AUTHORIZATION, format!("Bearer {token}")))
+            .set_json(json!({
+                "action": "confirm",
+                "reason": "a completed version review cannot be repeated"
+            }))
+            .to_request(),
+    )
+    .await;
+    assert_error(repeated, StatusCode::CONFLICT, "conflict").await;
+}
+
+#[actix_web::test]
 async fn post_confirm_rejects_blocking_intake_assessments_without_creating_a_case() {
     let context = TestContext::new().await;
     let family = context.authenticated(FAMILY).await;

--- a/tests/api/openapi_intake_contract.rs
+++ b/tests/api/openapi_intake_contract.rs
@@ -202,6 +202,8 @@ fn intake_openapi_contract_covers_draft_provenance_assessments_and_confirmation(
     assert_schema_contains(
         "IntakeProfileDraft",
         &[
+            "enum: [draft, confirmed, superseded]",
+            "requires_human_confirmation:",
             "field_metadata:",
             "assessments:",
             "confirmation_blocked_reasons:",
@@ -219,6 +221,14 @@ fn intake_openapi_contract_covers_draft_provenance_assessments_and_confirmation(
         ],
     );
     assert_schema_contains("IntakeProfileDraftFields", &["suspicious_motive:"]);
+    assert_schema_contains(
+        "ReviewIntakeProfileDraftRequest",
+        &[
+            "required: [action, reason]",
+            "enum: [confirm, reject]",
+            "maxLength: 1000",
+        ],
+    );
     assert_schema_contains(
         "IntakeDirectionHypothesis",
         &["source_fields:", "uncertainty_notice:", "description:"],
@@ -265,6 +275,19 @@ fn intake_openapi_contract_covers_draft_provenance_assessments_and_confirmation(
         operation("/api/intake-sessions/{session_id}/ai-initial-review/acknowledge")
             .contains("operationId: acknowledgeIntakeAiInitialReview")
     );
+    let profile_review =
+        operation("/api/intake-sessions/{session_id}/profile-draft/{draft_id}/review");
+    for expected in [
+        "operationId: reviewIntakeProfileDraft",
+        "#/components/schemas/ReviewIntakeProfileDraftRequest",
+        "#/components/schemas/IntakeProfileDraft",
+        "requires_human_confirmation false",
+    ] {
+        assert!(
+            profile_review.contains(expected),
+            "profile draft review API must declare {expected:?}"
+        );
+    }
 }
 
 #[test]
@@ -304,10 +327,10 @@ fn clue_timeline_openapi_contract_covers_pagination_and_visibility() {
 
 #[test]
 fn case_places_openapi_contract_covers_role_filtered_reads() {
-    let (_, operation) = OPENAPI
+    let (_, places_path) = OPENAPI
         .split_once("  /api/cases/{case_id}/places:\n")
         .expect("OpenAPI places path must exist");
-    let get_operation = operation
+    let get_operation = places_path
         .split_once("    get:\n")
         .and_then(|(_, after_get)| after_get.split_once("    post:\n").map(|(get, _)| get))
         .expect("OpenAPI places path must declare GET before POST");
@@ -322,6 +345,28 @@ fn case_places_openapi_contract_covers_role_filtered_reads() {
             "OpenAPI places operation must declare {expected:?}"
         );
     }
+
+    let review = operation("/api/cases/{case_id}/places/{place_id}/review:\n");
+    for expected in [
+        "operationId: reviewCasePlace",
+        "x-case-roles: [commander]",
+        "#/components/schemas/ReviewCasePlaceRequest",
+        "#/components/schemas/CasePlace",
+        "\"409\": { $ref: \"#/components/responses/Conflict\" }",
+    ] {
+        assert!(
+            review.contains(expected),
+            "OpenAPI place review operation must declare {expected:?}"
+        );
+    }
+    assert_schema_contains(
+        "ReviewCasePlaceRequest",
+        &[
+            "required: [status, reason]",
+            "enum: [confirmed, rejected]",
+            "maxLength: 1000",
+        ],
+    );
 }
 
 #[test]


### PR DESCRIPTION
## 变更内容

- 指挥端可确认或驳回家属提交的待审核地点，并记录审核理由与审计事件。
- 家属确认 AI 老人画像版本后，页面和字段卡片展示真实的已确认状态。
- OpenAPI、后端 API 与前端组件测试同步覆盖。

## 验证

- 后端地点审核 API 与鉴权测试
- OpenAPI 契约测试
- 家属问询页面组件测试

本 PR 基于 `refactor(frontend)`，不包含未提交的 AI follow-up 工作区改动。