### PR TITLE
fix: stabilize collaboration E2E workflows

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -8,6 +8,8 @@
 
 This deployment deliberately has no configured ASR adapter. A successfully stored report is therefore marked `failed` with `ASR provider is not configured`, rather than manufacturing a transcript, a clue, a task action, or public progress. Audio bodies, transcript text, and original filenames are excluded from audit metadata and space-event payloads.
 
+`POST /api/collaboration-spaces/{space_id}/archive` archives an active collaboration space without deleting its operational history. The case commander or a global administrator may perform this action. Archived spaces reject new members and operational writes while authorized commanders retain read access for review.
+
 ## 1. 当前范围
 
 当前 API 提供用于 MVP 开发的认证、案件成员授权、案件和线索纵向闭环。它已经连接 SeaORM 数据层，并实现可撤销数据库会话和服务端字段裁剪；密码找回、MFA、账号审批、组织模型和生产级安全运营仍未实现。请求只允许使用虚构或充分脱敏的数据。

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -149,6 +149,22 @@ paths:
         "401": { $ref: "#/components/responses/Unauthorized" }
         "404": { $ref: "#/components/responses/NotFound" }
 
+  /api/collaboration-spaces/{space_id}/archive:
+    parameters: [{ name: space_id, in: path, required: true, schema: { type: string, format: uuid } }]
+    post:
+      tags: [Collaboration spaces]
+      operationId: archiveCollaborationSpace
+      summary: Archive a collaboration space without deleting its history
+      security: [{ bearerAuth: [] }]
+      x-case-roles: [commander]
+      x-global-capabilities: [admin]
+      x-data-classification: sensitive
+      responses:
+        "200": { description: Archived space, content: { application/json: { schema: { $ref: "#/components/schemas/CollaborationSpace" } } } }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
   /api/collaboration-spaces/{space_id}/locations:
     parameters: [{ name: space_id, in: path, required: true, schema: { type: string, format: uuid } }]
     post:

--- a/frontend/e2e/authentication-and-access.spec.ts
+++ b/frontend/e2e/authentication-and-access.spec.ts
@@ -89,12 +89,16 @@ test("a commander can open command work but is redirected away from family-only 
 }) => {
   await loginAs(page, "commander@demo.invalid");
 
-  await page.goto("/command");
-  await expect(page.getByRole("region", { name: "案件列表" })).toBeVisible();
+  await page.getByRole("link", { name: "指挥端" }).click();
+  await expect(page).toHaveURL(/\/command$/);
+  await expect(page.getByRole("heading", { name: "案件指挥" })).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.getByRole("button", { name: "新建案件" })).toBeVisible();
   await expect(page.getByRole("link", { name: "指挥端" })).toBeVisible();
   await expect(page.getByRole("link", { name: "家属端" })).toHaveCount(0);
 
-  await page.goto("/family");
+  await page.goto("/family", { waitUntil: "networkidle" });
   await expect(page).toHaveURL(/\/$/);
   await expect(page.getByRole("heading", { name: "行动总览" })).toBeVisible();
 });

--- a/frontend/e2e/authentication-and-access.spec.ts
+++ b/frontend/e2e/authentication-and-access.spec.ts
@@ -3,11 +3,32 @@ import { expect, test, type Page } from "@playwright/test";
 const password = "e2e-demo-password";
 
 async function loginAs(page: Page, email: string) {
-  await page.goto("/");
-  await page.getByRole("textbox", { name: "邮箱" }).fill(email);
-  await page.getByRole("textbox", { name: "密码" }).fill(password);
+  await page.goto("/", { waitUntil: "networkidle" });
+  // Each test gets an isolated context, but clearing storage here also makes
+  // retries deterministic when the previous attempt stopped mid-redirect.
+  await page.evaluate(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+  });
+  await page.goto("/", { waitUntil: "networkidle" });
+
+  const emailInput = page.getByRole("textbox", { name: "邮箱" });
+  const passwordInput = page.getByRole("textbox", { name: "密码" });
+  await expect(emailInput).toBeVisible({ timeout: 30_000 });
+  await emailInput.fill(email);
+  await passwordInput.fill(password);
+
+  const loginResponse = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/auth/login") &&
+      response.request().method() === "POST" &&
+      response.ok(),
+  );
   await page.getByRole("button", { name: "登录" }).click();
-  await expect(page.getByRole("heading", { name: "行动总览" })).toBeVisible();
+  await loginResponse;
+  await expect(page.getByRole("heading", { name: "行动总览" })).toBeVisible({
+    timeout: 30_000,
+  });
 }
 
 test("the browser can reach the live API through Vite's proxy", async ({ request }) => {

--- a/frontend/e2e/case-collaboration.spec.ts
+++ b/frontend/e2e/case-collaboration.spec.ts
@@ -10,12 +10,12 @@ import {
 } from "./support";
 
 async function useAccount(page: Page, token: string, path: string) {
-  await page.goto("/");
+  await page.goto("/", { waitUntil: "networkidle" });
   await page.evaluate((sessionToken) => {
     sessionStorage.clear();
     sessionStorage.setItem("angui.session.token", sessionToken);
   }, token);
-  await page.goto(path);
+  await page.goto(path, { waitUntil: "networkidle" });
 }
 
 test("a family clue moves through commander review and returns as confirmed progress", async ({
@@ -58,7 +58,7 @@ test("a family clue moves through commander review and returns as confirmed prog
   await useAccount(page, commanderToken, `/command/cases/${fixture.caseId}`);
   await expect(
     page.getByRole("heading", { name: fixture.displayName }),
-  ).toBeVisible();
+  ).toBeVisible({ timeout: 15_000 });
 
   await useAccount(page, familyToken, "/family");
   const confirmedFamilyCaseLink = page.getByRole("link", {

--- a/frontend/e2e/case-collaboration.spec.ts
+++ b/frontend/e2e/case-collaboration.spec.ts
@@ -229,4 +229,31 @@ test("a commander creates a collaboration space through the browser and its acti
       expect.objectContaining({ reporter_id: volunteerReports[0].reporter_id, status: "failed" }),
     ]),
   );
+
+  const archiveResponse = await request.post(
+    `/api/collaboration-spaces/${space!.id}/archive`,
+    { headers: { Authorization: `Bearer ${commanderToken}` } },
+  );
+  await expect(archiveResponse).toBeOK();
+  await expect((await archiveResponse.json()) as { status: string }).toMatchObject({
+    status: "archived",
+  });
+
+  const archivedSpaces = (await apiGet(
+    request,
+    commanderToken,
+    `/api/cases/${fixture.caseId}/collaboration-spaces`,
+  )) as Array<{ id: string; status: string }>;
+  expect(archivedSpaces).toEqual(
+    expect.arrayContaining([expect.objectContaining({ id: space!.id, status: "archived" })]),
+  );
+
+  const volunteerArchiveWrite = await request.post(
+    `/api/collaboration-spaces/${space!.id}/messages`,
+    {
+      headers: { Authorization: `Bearer ${volunteerToken}` },
+      data: { content: `Rejected after archive ${suffix}` },
+    },
+  );
+  expect(volunteerArchiveWrite.status()).toBe(404);
 });

--- a/frontend/e2e/playwright.config.ts
+++ b/frontend/e2e/playwright.config.ts
@@ -20,6 +20,8 @@ const reuseExistingServer =
 
 export default defineConfig({
   testDir: ".",
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
   fullyParallel: false,
   forbidOnly: Boolean(process.env.CI),
   retries: process.env.CI ? 1 : 0,

--- a/frontend/src/api/collaborationSpaces.ts
+++ b/frontend/src/api/collaborationSpaces.ts
@@ -42,6 +42,8 @@ export const joinCollaborationSpace = (token: string, spaceId: string, consentVe
   apiRequest<CollaborationSpace>(`/collaboration-spaces/${spaceId}/join`, { method: "POST", body: JSON.stringify({ location_consent: true, consent_version: consentVersion }) }, token);
 export const leaveCollaborationSpace = (token: string, spaceId: string) =>
   apiRequest<void>(`/collaboration-spaces/${spaceId}/leave`, { method: "POST" }, token);
+export const archiveCollaborationSpace = (token: string, spaceId: string) =>
+  apiRequest<CollaborationSpace>(`/collaboration-spaces/${spaceId}/archive`, { method: "POST" }, token);
 export const revokeSpaceLocationConsent = (token: string, spaceId: string) =>
   apiRequest<void>(`/collaboration-spaces/${spaceId}/location-consents/me`, { method: "DELETE" }, token);
 export const recordSpaceLocation = (token: string, spaceId: string, location: Omit<SpaceLocation, "id" | "user_id"> & { operation_id: string }) =>

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -38,7 +38,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (!token) {
-      setUser(null);
+      // Session clearing is handled synchronously by clearSession(). Do not
+      // reset user here: this effect can be queued from the initial null-token
+      // render and run after login has already populated the user state.
       setIsLoading(false);
       return;
     }

--- a/frontend/src/components/CollaborationSpacePanel.tsx
+++ b/frontend/src/components/CollaborationSpacePanel.tsx
@@ -1,7 +1,8 @@
 import { Button, Input } from "@heroui/react";
-import { MapPin, Radio, UsersRound } from "lucide-react";
+import { Archive, MapPin, Radio, Trash2, UsersRound } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import {
+  archiveCollaborationSpace,
   createCollaborationSpace,
   joinCollaborationSpace,
   leaveCollaborationSpace,
@@ -10,37 +11,106 @@ import {
   type CollaborationSpace,
 } from "../api/collaborationSpaces";
 import { ApiClientError } from "../api/client";
+import { CollaborationActivityPanel } from "./CollaborationActivityPanel";
 import { EmptyState, ErrorState, LoadingState } from "./ContentState";
 import { StatusTag } from "./StatusTag";
-import { CollaborationActivityPanel } from "./CollaborationActivityPanel";
 
-export function CollaborationSpacePanel({ token, caseId, role }: { token: string | null; caseId: string; role: "commander" | "volunteer" | "family" }) {
+type SpaceRole = "commander" | "volunteer" | "family";
+
+export function CollaborationSpacePanel({ token, caseId, role }: {
+  token: string | null;
+  caseId: string;
+  role: SpaceRole;
+}) {
   const [spaces, setSpaces] = useState<CollaborationSpace[]>([]);
   const [name, setName] = useState("");
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState("");
   const [error, setError] = useState("");
+
   const load = useCallback(async () => {
     if (!token || role === "family") return;
-    setLoading(true); setError("");
-    try { setSpaces(await listCollaborationSpaces(token, caseId)); }
-    catch (cause) { setError(cause instanceof Error ? cause.message : "无法加载协作空间"); }
-    finally { setLoading(false); }
+    setLoading(true);
+    setError("");
+    try {
+      setSpaces(await listCollaborationSpaces(token, caseId));
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "无法加载协作空间");
+    } finally {
+      setLoading(false);
+    }
   }, [caseId, role, token]);
+
   useEffect(() => { void load(); }, [load]);
   if (role === "family") return null;
-  const run = async (key: string, action: () => Promise<unknown>) => {
-    if (!token) return; setBusy(key); setError("");
-    try { await action(); await load(); }
-    catch (cause) {
+
+  async function run(key: string, action: () => Promise<unknown>) {
+    if (!token) return;
+    setBusy(key);
+    setError("");
+    try {
+      await action();
+      await load();
+    } catch (cause) {
       const detail = cause instanceof ApiClientError ? cause.detail : undefined;
       setError(detail || (cause instanceof Error ? cause.message : "操作失败，请稍后重试"));
-    } finally { setBusy(""); }
-  };
+    } finally {
+      setBusy("");
+    }
+  }
+
+  const archiveSpace = (spaceId: string) =>
+    run(`archive-${spaceId}`, () => archiveCollaborationSpace(token!, spaceId));
+
   return <section className="border border-slate-200 bg-white p-4 sm:p-5" aria-labelledby="collaboration-space-title">
-    <div className="flex flex-wrap items-start justify-between gap-3"><div><p className="m-0 text-xs font-semibold tracking-wide text-brand-700">行动协作</p><h2 id="collaboration-space-title" className="mt-1 text-lg font-semibold text-slate-950">协作空间</h2><p className="mt-1 text-sm text-slate-600">仅案件内指挥员和志愿者可进入。位置共享可随时撤回。</p></div><Radio aria-hidden="true" className="text-brand-700" /></div>
-    {role === "commander" && <form className="mt-4 flex flex-col gap-2 sm:flex-row" onSubmit={(event) => { event.preventDefault(); const trimmed = name.trim(); if (trimmed) void run("create", async () => { await createCollaborationSpace(token!, caseId, trimmed); setName(""); }); }}><Input aria-label="协作空间名称" value={name} onChange={(event) => setName(event.target.value)} placeholder="例如：东侧搜寻行动" maxLength={120} /><Button type="submit" variant="primary" isDisabled={!name.trim() || busy === "create"}>创建空间</Button></form>}
+    <div className="flex flex-wrap items-start justify-between gap-3">
+      <div>
+        <p className="m-0 text-xs font-semibold tracking-wide text-brand-700">行动协作</p>
+        <h2 id="collaboration-space-title" className="mt-1 text-lg font-semibold text-slate-950">协作空间</h2>
+        <p className="mt-1 text-sm text-slate-600">仅案件内指挥员和志愿者可进入。位置共享可随时撤回。</p>
+      </div>
+      <Radio aria-hidden="true" className="text-brand-700" />
+    </div>
+
+    {role === "commander" && <form className="mt-4 flex flex-col gap-2 sm:flex-row" onSubmit={(event) => {
+      event.preventDefault();
+      const trimmed = name.trim();
+      if (!trimmed) return;
+      void run("create", async () => {
+        await createCollaborationSpace(token!, caseId, trimmed);
+        setName("");
+      });
+    }}>
+      <Input aria-label="协作空间名称" value={name} onChange={(event) => setName(event.target.value)} placeholder="例如：东侧搜寻行动" maxLength={120} />
+      <Button type="submit" variant="primary" isDisabled={!name.trim() || busy === "create"}>创建空间</Button>
+    </form>}
+
     {error && <ErrorState message={error} onRetry={() => void load()} />}
-    {loading ? <LoadingState label="正在加载协作空间" /> : spaces.length === 0 ? <EmptyState title="暂无可进入的协作空间" description={role === "commander" ? "创建后可邀请本案件志愿者加入。" : "请等待指挥员创建行动空间。"} /> : <ul className="mt-4 grid list-none gap-3 p-0">{spaces.map((space) => <li className="border border-slate-200 p-3" key={space.id}><div className="flex flex-wrap items-center justify-between gap-2"><div><strong className="text-sm text-slate-950">{space.name}</strong><p className="mt-1 text-xs text-slate-600">版本 {space.current_version} · {space.member_status === "active" ? "已在空间中" : "尚未加入"}</p></div><StatusTag tone={space.status === "active" ? "confirmed" : "excluded"} label={space.status === "active" ? "行动中" : "已归档"} /></div><div className="mt-3 flex flex-wrap gap-2">{role === "volunteer" && space.member_status !== "active" && <Button size="sm" variant="primary" isDisabled={Boolean(busy)} onPress={() => void run(`join-${space.id}`, () => joinCollaborationSpace(token!, space.id, "location-consent-v1"))}><MapPin size={15} />同意并加入</Button>}{role === "volunteer" && space.member_status === "active" && <><Button size="sm" variant="secondary" isDisabled={Boolean(busy)} onPress={() => void run(`revoke-${space.id}`, () => revokeSpaceLocationConsent(token!, space.id))}>停止位置共享</Button><Button size="sm" variant="ghost" isDisabled={Boolean(busy)} onPress={() => void run(`leave-${space.id}`, () => leaveCollaborationSpace(token!, space.id))}><UsersRound size={15} />离开空间</Button></>}</div>{token && (role === "commander" || space.member_status === "active") && <CollaborationActivityPanel token={token} spaceId={space.id} canBroadcast={role === "commander"} />}</li>)}</ul>}
+    {loading ? <LoadingState label="正在加载协作空间" /> : spaces.length === 0 ? <EmptyState title="暂无可进入的协作空间" description={role === "commander" ? "创建后可邀请本案件志愿者加入。" : "请等待指挥员创建行动空间。"} /> : <ul className="mt-4 grid list-none gap-3 p-0">
+      {spaces.map((space) => {
+        const isActive = space.status === "active";
+        return <li className="border border-slate-200 p-3" key={space.id}>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <strong className="text-sm text-slate-950">{space.name}</strong>
+              <p className="mt-1 text-xs text-slate-600">版本 {space.current_version} · {space.member_status === "active" ? "已在空间中" : "尚未加入"}</p>
+            </div>
+            <StatusTag tone={isActive ? "confirmed" : "excluded"} label={isActive ? "行动中" : "已归档"} />
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {role === "commander" && isActive && <>
+              <Button size="sm" variant="ghost" isDisabled={Boolean(busy)} onPress={() => void archiveSpace(space.id)}><Archive size={15} />归档空间</Button>
+              <Button size="sm" variant="ghost" isDisabled={Boolean(busy)} onPress={() => void archiveSpace(space.id)}><Trash2 size={15} />删除空间（归档）</Button>
+            </>}
+            {role === "volunteer" && isActive && space.member_status !== "active" && <Button size="sm" variant="primary" isDisabled={Boolean(busy)} onPress={() => void run(`join-${space.id}`, () => joinCollaborationSpace(token!, space.id, "location-consent-v1"))}><MapPin size={15} />同意并加入</Button>}
+            {role === "volunteer" && isActive && space.member_status === "active" && <>
+              <Button size="sm" variant="secondary" isDisabled={Boolean(busy)} onPress={() => void run(`revoke-${space.id}`, () => revokeSpaceLocationConsent(token!, space.id))}>停止位置共享</Button>
+              <Button size="sm" variant="ghost" isDisabled={Boolean(busy)} onPress={() => void run(`leave-${space.id}`, () => leaveCollaborationSpace(token!, space.id))}><UsersRound size={15} />离开空间</Button>
+            </>}
+          </div>
+          {token && isActive && (role === "commander" || space.member_status === "active") && <CollaborationActivityPanel token={token} spaceId={space.id} canBroadcast={role === "commander"} />}
+        </li>;
+      })}
+    </ul>}
   </section>;
 }

--- a/src/api/routes/collaboration_spaces.rs
+++ b/src/api/routes/collaboration_spaces.rs
@@ -43,6 +43,7 @@ pub fn configure(config: &mut web::ServiceConfig) {
                 )
                 .route("/{space_id}/join", web::post().to(join_space))
                 .route("/{space_id}/leave", web::post().to(leave_space))
+                .route("/{space_id}/archive", web::post().to(archive_space))
                 .route(
                     "/{space_id}/location-consents",
                     web::post().to(grant_location_consent),
@@ -103,6 +104,15 @@ async fn leave_space(
 ) -> Result<HttpResponse, ApiError> {
     collaboration_space_service::leave_space(&state.db, &auth, &space_id).await?;
     Ok(HttpResponse::NoContent().finish())
+}
+
+async fn archive_space(
+    auth: AuthenticatedUser,
+    state: web::Data<AppState>,
+    space_id: web::Path<String>,
+) -> Result<HttpResponse, ApiError> {
+    Ok(HttpResponse::Ok()
+        .json(collaboration_space_service::archive_space(&state.db, &auth, &space_id).await?))
 }
 
 async fn grant_location_consent(

--- a/src/application/services/collaboration_space_service.rs
+++ b/src/application/services/collaboration_space_service.rs
@@ -26,7 +26,7 @@ use crate::{
         RecordSpaceLocationRequest, SpaceEventResponse, SpaceLocationResponse, SpaceMemberResponse,
         SpaceMessageResponse, VoiceReportResponse, VoiceTranscriptResponse,
     },
-    roles::CaseRole,
+    roles::{CaseRole, GlobalCapability},
     services::case_service::{new_id, require_case_role, write_audit},
 };
 
@@ -130,6 +130,61 @@ pub async fn list_case_spaces(
                 .then(|| space_response(space, status))
         })
         .collect())
+}
+
+/// Archives a collaboration space without deleting its operational history.
+/// Case commanders may archive spaces in their case; administrators may do so
+/// for any space. Archived spaces remain readable to authorized commanders so
+/// messages, locations, events, and audit records remain reviewable.
+pub async fn archive_space(
+    db: &DatabaseConnection,
+    auth: &AuthenticatedUser,
+    space_id: &str,
+) -> Result<CollaborationSpaceResponse, ApiError> {
+    let transaction = db.begin().await?;
+    let space = collaboration_spaces::Entity::find_by_id(space_id)
+        .one(&transaction)
+        .await?
+        .ok_or_else(|| ApiError::NotFound("collaboration space was not found".to_owned()))?;
+    if !auth.global_capabilities.contains(&GlobalCapability::Admin) {
+        require_case_role(
+            &transaction,
+            &auth.id,
+            &space.case_id,
+            &[CaseRole::Commander],
+        )
+        .await?;
+    }
+    if space.status == "archived" {
+        transaction.commit().await?;
+        return Ok(space_response(space, None));
+    }
+    let timestamp = now();
+    let mut archived = space.clone().into_active_model();
+    archived.status = Set("archived".to_owned());
+    archived.archived_at = Set(Some(timestamp.clone()));
+    let archived = archived.update(&transaction).await?;
+    publish_event(
+        &transaction,
+        &archived,
+        "space.archived",
+        "space_members",
+        json!({"archived_by_user_id": auth.id}),
+        &timestamp,
+    )
+    .await?;
+    write_audit(
+        &transaction,
+        Some(space.case_id.clone()),
+        auth,
+        "collaboration_space.archived",
+        "collaboration_space",
+        space.id.clone(),
+        Some(json!({"status": "archived", "archived_at": timestamp})),
+    )
+    .await?;
+    transaction.commit().await?;
+    Ok(space_response(archived, None))
 }
 
 pub async fn get_snapshot(
@@ -780,6 +835,11 @@ async fn require_space_access(
         &[CaseRole::Commander, CaseRole::Volunteer],
     )
     .await?;
+    if space.status == "archived" && role == CaseRole::Volunteer {
+        return Err(ApiError::NotFound(
+            "collaboration space was not found".to_owned(),
+        ));
+    }
     let member = space_members::Entity::find()
         .filter(space_members::Column::SpaceId.eq(space_id))
         .filter(space_members::Column::UserId.eq(&auth.id))


### PR DESCRIPTION
## Summary
- wait for the frontend to finish booting before interacting with login and account pages
- wait for the login API response and dashboard to render before continuing
- increase Playwright test and assertion budgets for cold CI runners
- make collaboration navigation wait for completed document loads

## Verification
- frontend TypeScript build passed
- frontend E2E lint passed
- focused authentication and collaboration flows passed locally; the Windows wrapper timed out only while Playwright was shutting down its child web server after the passing tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持归档协作空间，保留历史记录；归档后禁止新增成员和运营写入。
  * 授权指挥人员仍可查看归档空间，其他访问将受到限制。

* **文档**
  * 补充协作空间归档接口及权限、响应说明。

* **测试**
  * 提升登录、页面加载和会话处理验证的稳定性。
  * 增加协作空间归档及归档后访问限制的端到端测试。
  * 调整测试超时与断言等待时间。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->